### PR TITLE
DEV: Switch serialization format to always embed user objects

### DIFF
--- a/app/serializers/topic_chat_base_message_serializer.rb
+++ b/app/serializers/topic_chat_base_message_serializer.rb
@@ -11,8 +11,7 @@ class TopicChatBaseMessageSerializer < ApplicationSerializer
     :deleted_by_id,
     :flag_count
 
-  # handled in subclasses
-  #has_one :user, serializer: BasicUserSerializer, root: :users
+  has_one :user, serializer: BasicUserSerializer, embed: :objects
 
   def include_deleted_at?
     !object.deleted_at.nil?

--- a/app/serializers/topic_chat_history_message_serializer.rb
+++ b/app/serializers/topic_chat_history_message_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
+# Kept for legacy naming reasons only
 class TopicChatHistoryMessageSerializer < TopicChatBaseMessageSerializer
-  has_one :user, serializer: BasicUserSerializer, embed: :objects
 end

--- a/app/serializers/topic_chat_live_message_serializer.rb
+++ b/app/serializers/topic_chat_live_message_serializer.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class TopicChatLiveMessageSerializer < TopicChatBaseMessageSerializer
-  has_one :user, serializer: BasicUserSerializer, root: :users
-end

--- a/app/serializers/topic_chat_view_serializer.rb
+++ b/app/serializers/topic_chat_view_serializer.rb
@@ -7,7 +7,7 @@ class TopicChatViewSerializer < ApplicationSerializer
     :can_delete_self,
     :can_delete_others
 
-  has_many :messages, serializer: TopicChatLiveMessageSerializer, embed: :objects
+  has_many :messages, serializer: TopicChatHistoryMessageSerializer, embed: :objects
 
   def last_id
     object.message_bus_last_id

--- a/app/services/topic_chat_publisher.rb
+++ b/app/services/topic_chat_publisher.rb
@@ -7,7 +7,7 @@ class TopicChatPublisher
   end
 
   def self.publish_new!(topic, msg)
-    content = TopicChatLiveMessageSerializer.new(msg, { scope: anonymous_guardian, root: :topic_chat_message }).as_json
+    content = TopicChatHistoryMessageSerializer.new(msg, { scope: anonymous_guardian, root: :topic_chat_message }).as_json
     content[:typ] = :sent
     MessageBus.publish("/chat/#{topic.id}", content.as_json)
   end

--- a/assets/javascripts/discourse/components/chat-live-pane.js.es6
+++ b/assets/javascripts/discourse/components/chat-live-pane.js.es6
@@ -22,7 +22,6 @@ export default Component.extend({
   replyToMsg: null, // ?Message
   details: null, // Object { topicId, can_chat, ... }
   messages: null, // Array
-  userLookup: null, // Object<Number, User>
   messageLookup: null, // Object<Number, Message>
 
   didInsertElement() {
@@ -42,7 +41,6 @@ export default Component.extend({
     );
 
     this.messages = A();
-    this.userLookup = {};
     this.messageLookup = {};
   },
 
@@ -65,7 +63,6 @@ export default Component.extend({
       if (this.registeredTopicId) {
         this.messageBus.unsubscribe(`/chat/${this.registeredTopicId}`);
         this.messages.clear();
-        this.userLookup = {};
         this.messageLookup = {};
         this.registeredTopicId = null;
       }
@@ -79,7 +76,6 @@ export default Component.extend({
               return;
             }
             const tc = data.topic_chat_view;
-            this.updateUserLookup(data.users);
             this.set(
               "messages",
               A(tc.messages.reverse().map((m) => this.prepareMessage(m)))
@@ -152,18 +148,7 @@ export default Component.extend({
     this.doScrollStick();
   },
 
-  updateUserLookup(usersData) {
-    if (!usersData) {
-      return;
-    }
-    usersData.forEach((v) => {
-      this.userLookup[v.id] = v;
-      v.template = v.avatar_template; // HACK
-    });
-  },
-
   prepareMessage(msgData) {
-    msgData.user = this.userLookup[msgData.user_id];
     if (msgData.in_reply_to_id) {
       msgData.in_reply_to = this.messageLookup[msgData.in_reply_to_id];
     }
@@ -178,7 +163,6 @@ export default Component.extend({
 
   handleMessage(data) {
     if (data.typ === "sent") {
-      this.updateUserLookup(data.users);
       const msg = this.prepareMessage(data.topic_chat_message);
 
       this.messages.pushObject(msg);

--- a/plugin.rb
+++ b/plugin.rb
@@ -29,7 +29,6 @@ after_initialize do
   load File.expand_path('../app/models/topic_chat.rb', __FILE__)
   load File.expand_path('../app/models/topic_chat_message.rb', __FILE__)
   load File.expand_path('../app/serializers/topic_chat_base_message_serializer.rb', __FILE__)
-  load File.expand_path('../app/serializers/topic_chat_live_message_serializer.rb', __FILE__)
   load File.expand_path('../app/serializers/topic_chat_history_message_serializer.rb', __FILE__)
   load File.expand_path('../app/serializers/topic_chat_view_serializer.rb', __FILE__)
   load File.expand_path('../lib/topic_chat_view.rb', __FILE__)


### PR DESCRIPTION
This removes the complication around the `userLookup` map maintenance on the client and should prevent future bugs, until we're actually ready for this to be optimized.