### PR TITLE
UX: Remove collapse functionality in channel selector

### DIFF
--- a/assets/javascripts/discourse/components/chat-channel-row.js
+++ b/assets/javascripts/discourse/components/chat-channel-row.js
@@ -1,19 +1,12 @@
 import Component from "@ember/component";
-import { action } from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
 
 export default Component.extend({
   channel: null,
   switchChannel: null,
-  expanded: true,
   nested: false,
 
   click() {
     this.switchChannel(this.channel);
-  },
-
-  @action
-  toggleExpand() {
-    this.set("expanded", !this.expanded);
   },
 });

--- a/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
@@ -1,14 +1,7 @@
 <div class={{if nested "chat-channel-row nested" "chat-channel-row"}}>
-  {{#if (and (eq channel.chatable_type "Category") channel.chat_channels)}}
-    <span class="chat-channel-toggle-expand" onclick={{action "toggleExpand"}}>
-      {{d-icon (if expanded "chevron-up" "chevron-right")}}
-    </span>
-  {{/if}}
   {{chat-channel-title channel=channel}}
 </div>
 
-{{#if expanded}}
-  {{#each channel.chat_channels as |nested_channel|}}
-    {{chat-channel-row channel=nested_channel switchChannel=switchChannel nested=true}}
-  {{/each}}
-{{/if}}
+{{#each channel.chat_channels as |nested_channel|}}
+  {{chat-channel-row channel=nested_channel switchChannel=switchChannel nested=true}}
+{{/each}}

--- a/assets/stylesheets/drawer.scss
+++ b/assets/stylesheets/drawer.scss
@@ -351,19 +351,6 @@ $header-height: 2.5rem;
     padding-left: 2.5em;
   }
 
-  .chat-channel-row-type {
-    margin-left: 0.5em;
-    font-size: var(--font-down-2);
-  }
-
-  .d-icon {
-    padding: 0.25em 0.75em 0.25em 0.5em;
-
-    &:hover {
-      background: var(--primary-med-low);
-    }
-  }
-
   .badge-wrapper {
     align-items: center;
     margin-right: 0;


### PR DESCRIPTION
I was wrong on what I did before.. This is so much cleaner

![image](https://user-images.githubusercontent.com/16214023/126501095-9587173c-44fd-44aa-96c3-680062d6242c.png)

Than this

![image](https://user-images.githubusercontent.com/16214023/126501147-ecd9632a-4ec6-4be0-88e9-a49270a59bda.png)
