### PR TITLE
FIX: Chat mention notifications error on click

### DIFF
--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -117,9 +117,9 @@ export default Component.extend({
     }
   },
 
-  openChannelAtMessage(activeChannel, messageId) {
+  openChannelAtMessage(chat_channel_id, messageId) {
     this.chatService.setMessageId(messageId);
-    ajax(`/chat/${activeChannel.id}.json`).then((response) => {
+    ajax(`/chat/${chat_channel_id}.json`).then((response) => {
       this.switchChannel(response.chat_channel);
     });
   },


### PR DESCRIPTION
This happened because I did a big find/replace of `chat_channel_id` to `activeChannel.id` and I replaced this instance, where it is needed. JS tests coming next week.