### PR TITLE
FIX: Correctly place autocomplete in production

### DIFF
--- a/assets/stylesheets/drawer.scss
+++ b/assets/stylesheets/drawer.scss
@@ -298,10 +298,6 @@ $header-height: 2.5rem;
       display: flex;
       flex-direction: row;
       align-items: stretch;
-
-      .autocomplete {
-        transform: translateY(-100%);
-      }
     }
     .tc-composer-input {
       margin-bottom: 0;


### PR DESCRIPTION
Locally, the `tranform: translateY(-100%)` positions it properly, but in production, that makes the box 100% too high... I am still trying to figure this out, but for now lets have it look OK in production rather than locally for me. 