### PR TITLE
FIX: Do not duplicate site chat channel in seeds

### DIFF
--- a/db/fixtures/001_chat_channels.rb
+++ b/db/fixtures/001_chat_channels.rb
@@ -1,4 +1,4 @@
-ChatChannel.seed do |chat_channel|
+ChatChannel.seed(:chatable_id, :chatable_type) do |chat_channel|
   chat_channel.chatable_id = DiscourseChat::SITE_CHAT_ID
   chat_channel.chatable_type = DiscourseChat::SITE_CHAT_TYPE
 end


### PR DESCRIPTION
Currently no constraints are passed into `seed`, so another site chat channel is being created every time `db:migrate` is running. Adding these constraints fixes this https://github.com/mbleigh/seed-fu#constraints