### PR TITLE
FIX: Cook messages in prepareMessage function

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -3,6 +3,7 @@ import EmberObject, { action } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 import Component from "@ember/component";
 import { observes } from "discourse-common/utils/decorators";
+import cookChatMessage from "discourse/plugins/discourse-topic-chat/discourse/lib/cook-chat-message";
 import discourseDebounce from "discourse-common/lib/debounce";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { cancel, later, schedule } from "@ember/runloop";
@@ -221,6 +222,11 @@ export default Component.extend({
       msgData.in_reply_to = this.messageLookup[msgData.in_reply_to_id];
     }
     msgData.expanded = !msgData.deleted_at;
+    msgData.cookedMessage = cookChatMessage(
+      msgData.message,
+      this.siteSettings,
+      this.site.categories
+    );
     this.messageLookup[msgData.id] = msgData;
     return EmberObject.create(msgData);
   },

--- a/assets/javascripts/discourse/components/tc-message.js
+++ b/assets/javascripts/discourse/components/tc-message.js
@@ -5,7 +5,6 @@ import discourseComputed from "discourse-common/utils/decorators";
 import { prioritizeNameInUx } from "discourse/lib/settings";
 import { action } from "@ember/object";
 import { autoUpdatingRelativeAge } from "discourse/lib/formatter";
-import cookChatMessage from "discourse/plugins/discourse-topic-chat/discourse/lib/cook-chat-message";
 import I18n from "I18n";
 
 export default Component.extend({
@@ -23,11 +22,6 @@ export default Component.extend({
       this.currentUser === this.message.user.id ||
       this.currentUser.staff
     );
-  },
-
-  @discourseComputed("message.message")
-  cooked(raw) {
-    return cookChatMessage(raw, this.siteSettings, this.site.categories);
   },
 
   @discourseComputed(

--- a/assets/javascripts/discourse/lib/cook-chat-message.js
+++ b/assets/javascripts/discourse/lib/cook-chat-message.js
@@ -4,6 +4,10 @@ import { emojiUnescape } from "discourse/lib/text";
 const mentionsModule = require("pretty-text/engines/discourse-markdown/mentions");
 
 export default function cook(raw, siteSettings, categories) {
+  if (!raw) {
+    return;
+  }
+
   let cooked = escapeExpression(raw);
   cooked = transformMentions(cooked, siteSettings.unicode_usernames);
   cooked = transformCategoryTagHashes(cooked, categories);

--- a/assets/javascripts/discourse/templates/components/chat-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer.hbs
@@ -4,7 +4,7 @@
       {{d-icon "reply"}}
       <span class="tc-reply-av">{{avatar replyToMsg.user imageSize="tiny"}}</span>
       <span class="tc-reply-username">@{{replyToMsg.user.username}}</span>
-      <span class="tc-reply-msg">{{replyToMsg.message}}</span>
+      <span class="tc-reply-msg">{{html-safe replyToMsg.cookedMessage}}</span>
     </span>
     {{flat-button action=(action "cancelReplyTo")
       class="tc-cancel-reply"

--- a/assets/javascripts/discourse/templates/components/tc-message.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-message.hbs
@@ -49,7 +49,7 @@
             {{avatar message.in_reply_to.user imageSize="tiny"}}
           </span>
           <span class="tc-reply-msg">
-            {{html-safe message.in_reply_to.message}}
+            {{html-safe message.in_reply_to.cookedMessage}}
           </span>
         </div>
       {{/if}}
@@ -70,7 +70,7 @@
             </span>
           {{else}}
             <p class="tc-text">
-              {{html-safe cooked}}
+              {{html-safe message.cookedMessage}}
             </p>
           {{/if}}
         </p>


### PR DESCRIPTION
Right now reply_to messages are not cooked. Example:
![image](https://user-images.githubusercontent.com/16214023/126829723-bb21ac64-6b38-4acf-bbb5-68b12e06a83d.png)

In this PR, the cooking for each message happens in the `prepareMessage` function, which pushes each message to a hookup table (well just an object) so that each message can be lookup and re-rendered without cooking again. As well as showing reply_to messages as cooked, now we will only ever cook each message 1 time :)

Now:
![image](https://user-images.githubusercontent.com/16214023/126829994-7e351f87-091e-44b3-9cd5-f59774075dd0.png)
