### PR TITLE
FEATURE: Convert link text to <a> tags

### DIFF
--- a/assets/javascripts/discourse/lib/cook-chat-message.js
+++ b/assets/javascripts/discourse/lib/cook-chat-message.js
@@ -49,6 +49,8 @@ function convertNewlines(raw) {
   return raw.replace(/\n/g, "<br>");
 }
 
+// Regex's are from stack overflow
+// https://stackoverflow.com/questions/49634850/javascript-convert-plain-text-links-to-clickable-links
 const LINK_HTTP_REGEX = /(\b(https?|ftp):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gim;
 const LINK_WWW_REGEX = /(^|[^\/])(www\.[\S]+(\b|$))/gim;
 const LINK_MAILTO_REGEX = /(([a-zA-Z0-9\-\_\.])+@[a-zA-Z\_]+?(\.[a-zA-Z]{2,6})+)/gim;


### PR DESCRIPTION
I stack-overflowed _hard_ here. Seems to work well though https://stackoverflow.com/questions/49634850/javascript-convert-plain-text-links-to-clickable-links

Some examples 
![image](https://user-images.githubusercontent.com/16214023/128047398-019b5be2-dc6d-4f7e-ba72-a38447c42505.png)
