### PR TITLE
FIX: on mobile the user card is at 1000+ do not change it

### DIFF
--- a/assets/stylesheets/drawer.scss
+++ b/assets/stylesheets/drawer.scss
@@ -419,15 +419,16 @@ $header-height: 2.5rem;
   }
 }
 
-.user-card, .group-card {
-  z-index: 201;
-}
-
 :root:not(.mobile-view) {
   .tc-drawer {
     width: 400px;
     margin-right: 20px;
     max-width: calc(100vw - 20px);
+  }
+
+  .user-card,
+  .group-card {
+    z-index: 201;
   }
 }
 :root.mobile-view {


### PR DESCRIPTION
Before this fix, display a user card would make it appear under cloak and as a result wouldn't be clickable.