### PR TITLE
UX: do not wait for channels to be loaded to show chat

### DIFF
--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -242,6 +242,7 @@ export default Component.extend({
   @action
   toggleChat() {
     if (this.hidden) {
+      this.set("hidden", false);
       this.fetchChannels();
     } else {
       this.set("hidden", true);
@@ -254,7 +255,6 @@ export default Component.extend({
       this.setProperties({
         channels: channels,
         activeChannel: null,
-        hidden: false,
         expanded: true,
         view: LIST_VIEW,
       });


### PR DESCRIPTION
This is a very minor change and should probably be improve in the future to maybe have some loading state but I think we should aim to show chat panel as fast as possible.