### PR TITLE
UX: Fix composer scroll & scroll to bottom on open new channel

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -24,6 +24,7 @@ export default Component.extend({
   editingMessage: null,
   timer: null,
   inputDisabled: not("canChat"),
+  onValueChange: null,
 
   didInsertElement() {
     this._super(...arguments);
@@ -121,6 +122,7 @@ export default Component.extend({
       () => {
         this._resizeTextArea();
         this._applyUserAutocomplete();
+        this.onValueChange();
       },
       THROTTLE_MS
     );

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -208,6 +208,9 @@ export default Component.extend({
         message.set("lastRead", true);
       }
       this.scrollToMessage(message.id);
+    } else {
+      // This is the user's first visit to the channel. Scroll them to the bottom
+      this.stickScrollToBottom();
     }
   },
 
@@ -282,16 +285,15 @@ export default Component.extend({
     }
 
     // Stick to bottom if scroll is at the bottom
-    const current =
+    const shouldStick =
       this._scrollerEl.scrollHeight -
         this._scrollerEl.scrollTop -
         this._scrollerEl.clientHeight <=
       STICKY_SCROLL_LENIENCE;
-    if (current !== this.stickyScroll) {
-      this.set("stickyScroll", current);
-      if (current) {
-        this._scrollerEl.scrollTop =
-          this._scrollerEl.scrollHeight - this._scrollerEl.clientHeight;
+    if (shouldStick !== this.stickyScroll) {
+      this.set("stickyScroll", shouldStick);
+      if (shouldStick) {
+        this.stickScrollToBottom();
       }
     }
   },
@@ -482,6 +484,13 @@ export default Component.extend({
 
   _stopLastReadRunner() {
     cancel(this._updateReadTimer);
+  },
+
+  @action
+  onComposerValueChange() {
+    // When the composer value changes and sticky scroll is set, make sure to stay
+    // stuck to the bottom. Composer height changes force content up.
+    this.stickScrollToBottom();
   },
 
   @action

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -36,6 +36,7 @@
     editingMessage=this.editingMessage
     onCancelEditing=this.cancelEditing
     onEditLastMessageRequested=this.editLastMessageRequested
+    onValueChange=(action "onComposerValueChange")
   }}
 {{/if}}
 


### PR DESCRIPTION
Fix this issue where typing multiple lines causes the bottom messages to be hidden behind composer due to scroll. If stickyscroll is active, keep scrolled to the bottom.
![image](https://user-images.githubusercontent.com/16214023/128411931-ca223567-7315-4aa5-be09-e31da6a67da1.png)

This also makes it so that when you enter a channel for the first time, you open it to the bottom, not the top.