### PR TITLE
UX: Position chat float in line with composer right side

### DIFF
--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -76,6 +76,7 @@ export default Component.extend({
     this._subscribeToUpdateChannels();
     this._subscribeToUserTrackingChannel();
     this._setHasUnreadMessages();
+    this._checkSize();
     this.appEvents.on("chat:toggle-open", this, "toggleChat");
     this.appEvents.on("chat:open-channel", this, "openChannelFor");
     this.appEvents.on("chat:open-message", this, "openChannelAtMessage");
@@ -233,6 +234,10 @@ export default Component.extend({
     this.element.style.setProperty(
       "--composer-height",
       composer.offsetHeight + "px"
+    );
+    this.element.style.setProperty(
+      "--composer-right",
+      composer.offsetLeft + "px"
     );
   },
 

--- a/assets/javascripts/discourse/templates/components/chat-composer-message-details.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer-message-details.hbs
@@ -1,10 +1,10 @@
 <div class="tc-composer-message-details">
-  <span class="width-limited">
+  <div class="tc-reply-display">
     {{d-icon icon}}
     <span class="tc-reply-av">{{avatar message.user imageSize="tiny"}}</span>
     <span class="tc-reply-username">{{message.user.username}}</span>
     <span class="tc-reply-msg">{{html-safe message.cookedMessage}}</span>
-  </span>
+  </div>
 
   {{flat-button
     action=action

--- a/assets/stylesheets/drawer.scss
+++ b/assets/stylesheets/drawer.scss
@@ -36,7 +36,7 @@ $header-height: 2.5rem;
 .topic-chat-float-container {
   z-index: 200; // higher than timeline, lower than composer, lower than user card
   position: fixed;
-  right: 0;
+  right: var(--composer-right, 20px);
   left: 0;
   margin: 0;
   padding: 0;
@@ -53,8 +53,8 @@ $header-height: 2.5rem;
 
   box-sizing: border-box;
   max-height: 90vh;
-  padding-bottom: var(--composer-height, 0px);
-  transition: padding-bottom 250ms ease;
+  padding-bottom: var(--composer-height, 0);
+  transition: padding-bottom 100ms ease-in;
 }
 .tc-drawer {
   align-self: flex-end;
@@ -218,16 +218,6 @@ $header-height: 2.5rem;
       color: var(--primary-medium);
       font-size: var(--font-down-1);
     }
-    .tc-reply-display {
-      display: inline-block;
-      text-overflow: ellipsis;
-      overflow-x: hidden;
-      white-space: nowrap;
-      width: 94%;
-      font-size: 0.8em;
-      line-height: 0.8em;
-      margin-bottom: -0.5em;
-    }
   }
   .tc-action-text {
     font-style: italic;
@@ -274,6 +264,36 @@ $header-height: 2.5rem;
       &.first {
         font-weight: bold;
       }
+    }
+  }
+}
+
+.tc-reply-display {
+  display: inline-flex;
+  height: 2em;
+  align-items: center;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  font-size: var(--font-down-1);
+  margin-bottom: -0.5em;
+
+  .tc-reply-av {
+    padding: 0 0.5em 0 0.3em;
+  }
+
+  .tc-reply-username {
+    padding: 0 0.5em 0 0;
+  }
+  .tc-reply-msg {
+    align-self: baseline;
+    color: var(--primary-high);
+    > * {
+      margin-top: 0;
+      display: inline-block;
+    }
+    > p {
+      margin-top: 0.35em;
     }
   }
 }
@@ -406,19 +426,12 @@ $header-height: 2.5rem;
     .tc-composer-message-details {
       position: relative;
       width: 100%;
-      flex-direction: row;
+      max-height: calc(2em - 5px);
       padding: 6px 4px;
-      height: 1.6em;
       border-top: 1px solid var(--primary-low);
 
-      .width-limited {
-        display: inline-block;
-        width: calc(100% - 28px);
-        height: 1.5em;
-        text-overflow: ellipsis;
-        overflow: hidden;
-        white-space: nowrap;
-        flex-grow: 1;
+      .tc-reply-display {
+        width: calc(100% - 2em);
       }
     }
     .cancel-message-action {
@@ -512,8 +525,7 @@ $header-height: 2.5rem;
 :root:not(.mobile-view) {
   .tc-drawer {
     width: 400px;
-    margin-right: 20px;
-    max-width: calc(100vw - 20px);
+    max-width: 100vw;
   }
 
   .user-card,


### PR DESCRIPTION
The chat float is now always on the right side of the composer. Also this gets us to a spot with reply styling that is... not terrible.

![image](https://user-images.githubusercontent.com/16214023/128730644-c74432cd-d8cb-4ac8-aa4b-e9d796e83a3e.png)
