### PR TITLE
FIX: dispatchWidgetAppEvent for sidebar header

### DIFF
--- a/assets/javascripts/discourse/initializers/topic-chat-setup.js
+++ b/assets/javascripts/discourse/initializers/topic-chat-setup.js
@@ -88,6 +88,12 @@ export default {
         "chat:rerender-header"
       );
 
+      api.dispatchWidgetAppEvent(
+        "sidebar-header",
+        "header-chat-link",
+        "chat:rerender-header"
+      );
+
       api.modifyClass("component:topic-admin-menu-button", {
         toggleChat() {
           return doToggleChat(this.topic);


### PR DESCRIPTION
@eviltrout I know I could check a site setting or something, but I don't really want more sidebar specific logic in here (what if the setting name changes etc..), and `dispatchWidgetAppEvent` doesn't error if the component doesn't exist so I think this is fine. What do you think?