### PR TITLE
REFACTOR: drops usage of one observer

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -114,8 +114,10 @@ export default Component.extend({
     this._focusTextArea({ ensureAtEnd: true, resizeTextArea: true });
   },
 
-  @observes("value")
-  _watchChanges() {
+  @action
+  onTextareaInput(value) {
+    this.set("value", value);
+
     // throttle, not debounce, because we do eventually want to react during the typing
     this.timer = throttle(
       this,

--- a/assets/javascripts/discourse/templates/components/chat-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer.hbs
@@ -16,7 +16,8 @@
 {{/if}}
 <div class="tc-composer-row">
   {{d-textarea
-    value=value
+    value=(readonly value)
+    input=(action "onTextareaInput" value="target.value")
     type="text"
     class="tc-composer-input"
     disabled=inputDisabled


### PR DESCRIPTION
This also keeps value mutations inside chat-composer component and not in children of it.