### PR TITLE
FEATURE: Limit personal chat list to last 10

### DIFF
--- a/lib/chat_channel_fetcher.rb
+++ b/lib/chat_channel_fetcher.rb
@@ -55,6 +55,8 @@ module DiscourseChat::ChatChannelFetcher
         .where(direct_message_users: { user_id: user_id })
         .pluck(:id)
             )
+      .order(updated_at: :desc)
+      .limit(10)
   end
 
   def self.can_see_channel?(channel, guardian)


### PR DESCRIPTION
This is way too long. You can already search for personal chats so we can hide old ones. This will become a setting I'm sure at some point.

![image](https://user-images.githubusercontent.com/16214023/131165968-1084b42f-a269-4e6c-84fe-b10dd2459bbe.png)
