### PR TITLE
UX: Show actions, timestamp on click for touch devices

### DIFF
--- a/assets/javascripts/discourse/components/tc-message.js
+++ b/assets/javascripts/discourse/components/tc-message.js
@@ -8,7 +8,7 @@ import { autoUpdatingRelativeAge } from "discourse/lib/formatter";
 import I18n from "I18n";
 
 export default Component.extend({
-  tagName: "",
+  tagName: "div",
   lastRead: false,
   isSelected: false,
 
@@ -24,6 +24,12 @@ export default Component.extend({
       this.currentUser === this.message.user.id ||
       this.currentUser.staff
     );
+  },
+
+  click() {
+    if (this.capabilities.touch) {
+      this.toggleProperty("isSelected");
+    }
   },
 
   @discourseComputed("message.hideUserInfo", "message.chat_webhook_event")
@@ -62,13 +68,6 @@ export default Component.extend({
       classNames.push("tc-message-selected");
     }
     return classNames.join(" ");
-  },
-
-  @action
-  clickMessage() {
-    if (this.capabilities.touch) {
-      this.toggleProperty("isSelected");
-    }
   },
 
   @discourseComputed("message.user")

--- a/assets/javascripts/discourse/templates/components/tc-message.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-message.hbs
@@ -8,7 +8,7 @@
       }}
     </div>
   {{else}}
-    <div class={{messageClasses}} onclick={{action "clickMessage"}}>
+    <div class={{messageClasses}}>
       {{#unless message.staged}}
         <div class="tc-msgactions-hover">
           <div class="tc-msgactions">


### PR DESCRIPTION
Hover state gets invoked too often when scrolling on touch devices.
This adds a click event instead, for more explicit selection of each
message on a touch device.