### PR TITLE
FIX: Apply click selection for messages only on mobile

### DIFF
--- a/assets/javascripts/discourse/components/tc-message.js
+++ b/assets/javascripts/discourse/components/tc-message.js
@@ -27,7 +27,7 @@ export default Component.extend({
   },
 
   click() {
-    if (this.capabilities.touch) {
+    if (this.site.mobileView) {
       this.toggleProperty("isSelected");
     }
   },

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -421,12 +421,12 @@ $float-height: 530px;
     }
   }
 
-  .no-touch & .tc-message:hover,
+  .not-mobile-device & .tc-message:hover,
   .tc-message.tc-message-selected {
     background: var(--primary-very-low);
   }
 
-  .no-touch & .tc-message:hover,
+  .not-mobile-device & .tc-message:hover,
   .tc-message.tc-message-selected,
   .tc-message:focus-within {
     .tc-msgactions-hover {
@@ -435,7 +435,7 @@ $float-height: 530px;
     }
   }
 
-  .no-touch & .user-info-hidden:hover,
+  .not-mobile-device & .user-info-hidden:hover,
   .user-info-hidden.tc-message-selected {
     .tc-meta-data .relative-date {
       visibility: visible;
@@ -815,7 +815,7 @@ $float-height: 530px;
       var(--full-page-border-radius) 0;
   }
 
-  .no-touch & .tc-message:hover,
+  .not-mobile-device & .tc-message:hover,
   .tc-message.tc-message-selected {
     background: var(--primary-low);
   }


### PR DESCRIPTION
Touch unfortunately applies to touch-enabled laptops as well.

Limiting to mobile has its own downsides, i.e. no iPad support.