### PR TITLE
FIX: Stop double file dialog on mobile preventing uploads

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -113,6 +113,9 @@ export default Component.extend(
       );
     },
 
+    // noop, the upload button is different on mobile here
+    _bindMobileUploadButton() {},
+
     didRender() {
       this._super(...arguments);
       if (this.canChat && this._messageIsEmpty() && !this.site.mobileView) {


### PR DESCRIPTION
There is a separate mobile-file-upload button used for the
composer that is bound with `_bindMobileUploadButton`, which
shows the file selection dialog box when clicked. However this
is leading to a double file dialog on mobile for the chat-composer,
because there is no concept of a mobile upload button there.

This commit just changes `_bindMobileUploadButton` to a noop for
the chat-composer to prevent the issue from happening.