### PR TITLE
FIX: Never return to "/" from chat back button

### DIFF
--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -59,7 +59,9 @@ export default Service.extend({
   },
 
   getLastNonChatRoute() {
-    return this.lastNonChatRoute || `discovery.${defaultHomepage()}`;
+    return this.lastNonChatRoute && this.lastNonChatRoute !== "/"
+      ? this.lastNonChatRoute
+      : `discovery.${defaultHomepage()}`;
   },
 
   loadCookFunction(categories) {


### PR DESCRIPTION
I created this diff yesterday and it didn't take into account "/" route anymore. 
![image](https://user-images.githubusercontent.com/16214023/131877080-3f8858ab-3023-48fb-bfb7-e7b0c071ae43.png)
