### PR TITLE
FIX: Use new uploadPreProcessors interface to fix uploads

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -336,8 +336,11 @@ export default Component.extend({
         return;
       }
       this.set("stickyScroll", true);
-      this._scrollerEl.scrollTop =
-        this._scrollerEl.scrollHeight - this._scrollerEl.clientHeight;
+
+      if (this._scrollerEl) {
+        this._scrollerEl.scrollTop =
+          this._scrollerEl.scrollHeight - this._scrollerEl.clientHeight;
+      }
     });
   },
 


### PR DESCRIPTION
Since https://github.com/discourse/discourse/commit/9873a942e3d2df367717f119c591492c690d291d
we now need to allow for uploadPreProcessors to be added, because that
is what the ComposerUppyUpload mixin uses. Without this there is an

> TypeError: Cannot read property 'forEach' of undefined

Error in the _setupPreProcessors call in ComposerUppyUpload in core.

Also fixes another error at the same time where we were not checking
for the existence of the _scrollerEl before setting its height, leading
to:

> TypeError: Cannot read property 'scrollHeight' of null