### PR TITLE
FIX: Double render of ID error with chat composer

### DIFF
--- a/assets/javascripts/discourse/components/chat-channel-title.js
+++ b/assets/javascripts/discourse/components/chat-channel-title.js
@@ -4,7 +4,7 @@ import { gt } from "@ember/object/computed";
 
 export default Component.extend({
   tagName: "span",
-  classNameBindings: [":chat-channel-title","unreadCount:has-unread"],
+  classNameBindings: [":chat-channel-title", "unreadCount:has-unread"],
   channel: null,
   multiDm: gt("channel.chatable.users.length", 1),
 

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -31,13 +31,14 @@ export default Component.extend(
   ComposerUploadUppy,
   {
     classNames: ["tc-composer"],
-    value: "",
     emojiStore: service("emoji-store"),
-    mediaOptimizationWorker: service(),
     editingMessage: null,
-    timer: null,
+    fullPage: false,
     inputDisabled: not("canChat"),
+    mediaOptimizationWorker: service(),
     onValueChange: null,
+    timer: null,
+    value: "",
 
     // Composer Uppy values
     ready: true,
@@ -45,7 +46,6 @@ export default Component.extend(
     composerModel: null,
     composerModelContentKey: "value",
     editorInputClass: ".tc-composer-input",
-    fileUploadElementId: "file-uploader",
     showCancelBtn: or("isUploading", "isProcessingUpload"),
     uploadCancelled: false,
     uploadProcessorActions: null,
@@ -53,6 +53,18 @@ export default Component.extend(
     uploadMarkdownResolvers: null,
     uploadType: "chat-composer",
     uppyId: "chat-composer-uppy",
+
+    @discourseComputed("fullPage")
+    fileUploadElementId(fullPage) {
+      return fullPage ? "chat-full-page-uploader" : "chat-widget-uploader";
+    },
+
+    @discourseComputed("fullPage")
+    mobileFileUploaderId(fullPage) {
+      return fullPage
+        ? "chat-full-page-mobile-uploader"
+        : "chat-widget-mobile-uploader";
+    },
 
     init() {
       this._super(...arguments);

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -20,6 +20,7 @@ export default Component.extend({
   classNameBindings: [":tc-live-pane", "sendingloading", "loading"],
   topicId: null, // ?Number
   chatChannel: null,
+  fullPage: false,
   registeredChatChannelId: null, // ?Number
   loading: false,
   loadingMore: false,

--- a/assets/javascripts/discourse/templates/components/chat-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer.hbs
@@ -30,7 +30,7 @@
   {{flat-button
     action=(action "uploadClicked")
     class="upload-btn"
-    id="mobile-file-upload"
+    id=mobileFileUploaderId
     icon="far-image"
     title="chat.upload"
   }}
@@ -51,4 +51,4 @@
   <span class="btn uploading-indicator {{unless isProcessingUpload "hidden"}}">{{i18n "upload_selector.processing"}}</span>
   <span role="button" onClick={{action "cancelUploads"}} class="btn btn-danger cancel-btn {{unless showCancelBtn "hidden"}}">{{i18n "cancel"}}</span>
 </div>
-<input type="file" id="file-uploader" accept={{acceptedFormats}} multiple>
+<input type="file" id={{fileUploadElementId}} accept={{acceptedFormats}} multiple>

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -65,6 +65,7 @@
     onCancelEditing=this.cancelEditing
     onEditLastMessageRequested=this.editLastMessageRequested
     onValueChange=(action "reStickScrollIfNeeded")
+    fullPage=fullPage
   }}
 {{/if}}
 

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -9,7 +9,7 @@ $float-height: 530px;
 }
 
 .tc-composer {
-  #file-uploader {
+  #chat-full-page-uploader, #chat-widget-uploader {
     display: none;
   }
 }


### PR DESCRIPTION
Relies on this core PR being merged https://github.com/discourse/discourse/pull/14324

This avoids a double render of the same ID if the chat widget and full page chat are momentarily both rendered. This is possible if you have the widget open and get a chat desktop notification and click it. For a moment the full page chat is rendered while the widget is being closed. This is the error without this change: 
![image](https://user-images.githubusercontent.com/16214023/133828370-7f867660-d42d-417f-a97b-5e5d639835c5.png)
