### PR TITLE
UX: Add 'Chat' to document title

### DIFF
--- a/assets/javascripts/discourse/routes/chat.js
+++ b/assets/javascripts/discourse/routes/chat.js
@@ -1,9 +1,14 @@
 import DiscourseRoute from "discourse/routes/discourse";
+import I18n from "I18n";
 import { defaultHomepage } from "discourse/lib/utilities";
 import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
   chat: service(),
+
+  titleToken() {
+    return I18n.t("chat.title_capitalized");
+  },
 
   beforeModel(params) {
     if (!this.currentUser?.can_chat || !this.siteSettings.topic_chat_enabled) {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -34,6 +34,7 @@ en:
       send: "Send Chat Message"
       send_error: "Something went wrong"
       title: "chat"
+      title_capitalized: "Chat"
       unread_count: "(%{count} new)"
       upload: "Attach a file"
       exit: "back"


### PR DESCRIPTION
I know it's weird to have a capitalized translation, but the JS way to capitalize a word is even more ugly. Can't use CSS because this is the document title.

![image](https://user-images.githubusercontent.com/16214023/135289250-d1b30ceb-6e2f-4aad-a6ed-02f2533e3ebe.png)
