### PR TITLE
FIX: Remove JS scrolling that isn't needed

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -339,7 +339,7 @@ export default Component.extend({
 
       if (this._scrollerEl) {
         // Set scrollTop to 0 isn't always enough for some reason. 10 makes sure
-        // that the scroll is at the bottom. (it's reversed because flex-direction: column-reverse
+        // that the scroll is at the bottom. (it's reversed because flex-direction: column-reverse)
         this._scrollerEl.scrollTop = 10;
       }
     });


### PR DESCRIPTION
Since I reversed the scroll direction of the chat container, we shouldn't need a lot of the logic. I believe this fixes a bug where the chat doesn't scroll when new messages come in.