### PR TITLE
Fix restick scroll

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -793,11 +793,11 @@ export default Component.extend({
 
   @action
   composerValueChanged(composerValue) {
-    this._reStickScrollIfNeeded();
+    this.reStickScrollIfNeeded();
     this._reportReplyingPresence(composerValue);
   },
 
-  _reStickScrollIfNeeded() {
+  reStickScrollIfNeeded() {
     if (this.stickyScroll) {
       this._stickScrollToBottom();
     }


### PR DESCRIPTION
I renamed this method in 4d0f577, without realising that is called from many places. This reverts the rename.