### PR TITLE
FIX: Resync user tracking state when messages are lost

### DIFF
--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -23,6 +23,7 @@ export default Service.extend({
   hasUnreadPublicMessages: false,
   idToTitleMap: null,
   lastNonChatRoute: null,
+  lastUserTrackingMessageId: null,
   messageId: null,
   presence: service(),
   presenceChannel: null,
@@ -405,7 +406,16 @@ export default Service.extend({
   _subscribeToUserTrackingChannel() {
     this.messageBus.subscribe(
       `/chat/user-tracking-state/${this.currentUser.id}`,
-      (busData) => {
+      (busData, _, messageId) => {
+        if (
+          this.lastUserTrackingMessageId &&
+          messageId !== this.lastUserTrackingMessageId + 1
+        ) {
+          return this.forceRefreshChannels();
+        } else {
+          this.lastUserTrackingMessageId = messageId;
+        }
+
         const trackingState = this.currentUser.chat_channel_tracking_state[
           busData.chat_channel_id
         ];


### PR DESCRIPTION
I have been relying on message_bus message to never be lost for user chat tracking state. Messages _are_ lost, so we need to be tolerant of lost messages. Here we refresh the user's chat tracking state when we can tell a message has been lost.

Based on David's work here https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/services/presence.js#L181-L195