### PR TITLE
FIX: Image uploading due to core change

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -73,7 +73,7 @@ export default Component.extend(
         : "chat-widget-mobile-uploader";
     },
 
-    _findMatchingUploadHandler(_) {
+    _findMatchingUploadHandler() {
       return;
     },
 


### PR DESCRIPTION
There was [a change](https://github.com/discourse/discourse/commit/f6528afa019ded81012947efdf2835324488183b) to core recently that added a method that the chat-composer did not have. We don't have custom upload handlers for the chat composer, so we can safely return `null` here.