### PR TITLE
FIX: Implement emoji picker

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -270,6 +270,7 @@ export default Component.extend(
           template: findRawTemplate("user-selector-autocomplete"),
           key: "@",
           width: "100%",
+          treatAsTextarea: true,
           autoSelectFirstSuggestion: true,
           transformComplete: (v) => v.username || v.name,
           dataSource: (term) => userSearch({ term, includeGroups: false }),
@@ -283,6 +284,7 @@ export default Component.extend(
       $textarea.autocomplete({
         template: findRawTemplate("category-tag-autocomplete"),
         key: "#",
+        treatAsTextarea: true,
         afterComplete: (value) => {
           this.set("value", value);
           return this._focusTextArea();
@@ -314,6 +316,7 @@ export default Component.extend(
           this.set("value", text);
           this._focusTextArea();
         },
+        treatAsTextarea: true,
 
         onKeyUp: (text, cp) => {
           const matches = /(?:^|[\s.\?,@\/#!%&*;:\[\]{}=\-_()])(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi.exec(

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -447,6 +447,12 @@ export default Component.extend(
       this._addText(selected, text);
     },
 
+    @action
+    onEmojiSelected(code) {
+      this.emojiSelected(code);
+      this.set("emojiPickerIsActive", false);
+    },
+
     @discourseComputed("previewing")
     placeholder(previewing) {
       return I18n.t(

--- a/assets/javascripts/discourse/templates/components/chat-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer.hbs
@@ -49,6 +49,13 @@
     icon=(if showToolbar "minus" "plus")
   }}
 
+  {{emoji-picker
+    isActive=emojiPickerIsActive
+    isEditorFocused=isEditorFocused
+    emojiSelected=(action "onEmojiSelected")
+    onEmojiPickerClose=(action (mut emojiPickerIsActive) false)
+  }}
+
   {{#if site.mobileView}}
     {{flat-button
       action=(action "sendClicked")
@@ -59,13 +66,6 @@
     }}
   {{/if}}
 </div>
-
-{{emoji-picker
-  isActive=emojiPickerIsActive
-  isEditorFocused=isEditorFocused
-  emojiSelected=(action "onEmojiSelected")
-  onEmojiPickerClose=(action (mut emojiPickerIsActive) false)
-}}
 
 <div class="tc-composer-uploads-container">
   <span class="btn uploading-indicator {{unless isUploading "hidden"}}">{{i18n "upload_selector.uploading"}} {{uploadProgress}}%</span>

--- a/assets/javascripts/discourse/templates/components/chat-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer.hbs
@@ -42,6 +42,13 @@
     rows=1
   }}
 
+  {{emoji-picker
+    isActive=emojiPickerIsActive
+    isEditorFocused=isEditorFocused
+    emojiSelected=(action "onEmojiSelected")
+    onEmojiPickerClose=(action (mut emojiPickerIsActive) false)
+  }}
+
   {{flat-button
     action=(action "toggleToolbar")
     class="open-toolbar-btn"

--- a/assets/javascripts/discourse/templates/components/chat-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer.hbs
@@ -42,13 +42,6 @@
     rows=1
   }}
 
-  {{emoji-picker
-    isActive=emojiPickerIsActive
-    isEditorFocused=isEditorFocused
-    emojiSelected=(action "onEmojiSelected")
-    onEmojiPickerClose=(action (mut emojiPickerIsActive) false)
-  }}
-
   {{flat-button
     action=(action "toggleToolbar")
     class="open-toolbar-btn"
@@ -66,6 +59,13 @@
     }}
   {{/if}}
 </div>
+
+{{emoji-picker
+  isActive=emojiPickerIsActive
+  isEditorFocused=isEditorFocused
+  emojiSelected=(action "onEmojiSelected")
+  onEmojiPickerClose=(action (mut emojiPickerIsActive) false)
+}}
 
 <div class="tc-composer-uploads-container">
   <span class="btn uploading-indicator {{unless isUploading "hidden"}}">{{i18n "upload_selector.uploading"}} {{uploadProgress}}%</span>

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -65,6 +65,11 @@
   }
 }
 
+.tc-composer-row .emoji-picker.opened {
+  position: absolute;
+  bottom: 40px;
+}
+
 .tc-message:not(.user-info-hidden) {
   padding: 0.15em 1em;
   margin-top: 0.5em;

--- a/assets/stylesheets/mobile/mobile.scss
+++ b/assets/stylesheets/mobile/mobile.scss
@@ -30,10 +30,6 @@
   .tc-composer-input {
     padding-right: 75px;
   }
-  .autocomplete {
-    bottom: 40px;
-    top: unset !important;
-  }
   .open-toolbar-btn {
     right: 50px;
   }

--- a/assets/stylesheets/mobile/mobile.scss
+++ b/assets/stylesheets/mobile/mobile.scss
@@ -30,6 +30,10 @@
   .tc-composer-input {
     padding-right: 75px;
   }
+  .autocomplete {
+    bottom: 40px;
+    top: unset !important;
+  }
   .open-toolbar-btn {
     right: 50px;
   }


### PR DESCRIPTION
Dependent on this PR being merged first - https://github.com/discourse/discourse/pull/14976

Also I could not get `autocomplete` popup to go up on mobile - currently its cut off going down. Setting bottom value seems to work well! I didn't see any cases where it _doesn't_ work.

<img width="910" alt="Screen Shot 2021-11-16 at 1 13 47 PM" src="https://user-images.githubusercontent.com/16214023/142050453-8fd13297-daf7-4412-94f5-9bf99794719b.png">

<img width="414" alt="Screen Shot 2021-11-16 at 1 14 20 PM" src="https://user-images.githubusercontent.com/16214023/142050499-998f7890-dc3f-451d-8c33-603b4f9d4e02.png">

