### PR TITLE
DEV: Remove staff-only chat and seed staff category channel

### DIFF
--- a/app/controllers/chat_base_controller.rb
+++ b/app/controllers/chat_base_controller.rb
@@ -12,14 +12,10 @@ class DiscourseChat::ChatBaseController < ::ApplicationController
   end
 
   def set_channel_and_chatable
-    @chat_channel = ChatChannel.find_by(id: params[:chat_channel_id])
+    @chat_channel = ChatChannel.includes(:chatable).find_by(id: params[:chat_channel_id])
     raise Discourse::NotFound unless @chat_channel
 
-    @chatable = nil
-    if !@chat_channel.site_channel?
-      @chatable = @chat_channel.chatable
-    end
-
+    @chatable = @chat_channel.chatable
     guardian.ensure_can_see_chat_channel!(@chat_channel)
   end
 end

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -18,9 +18,7 @@ class ChatChannel < ActiveRecord::Base
   def chatable_url
     return nil if direct_message_channel?
 
-    site_channel? ?
-      Discourse.base_url :
-      chatable.url
+    chatable.url
   end
 
   def tag_channel?
@@ -39,10 +37,6 @@ class ChatChannel < ActiveRecord::Base
     chatable_type == "DirectMessageChannel"
   end
 
-  def site_channel?
-    chatable_type == DiscourseChat::SITE_CHAT_TYPE
-  end
-
   def chatable_has_custom_fields?
     topic_channel? || category_channel?
   end
@@ -54,9 +48,7 @@ class ChatChannel < ActiveRecord::Base
   end
 
   def allowed_group_ids
-    if site_channel?
-      [Group::AUTO_GROUPS[:staff]]
-    elsif category_channel?
+    if category_channel?
       chatable.secure_group_ids
     elsif topic_channel? && chatable.category
       chatable.category.secure_group_ids
@@ -73,19 +65,13 @@ class ChatChannel < ActiveRecord::Base
       chatable.name
     when "Tag"
       chatable.name
-    when "Site"
-      I18n.t("chat.site_chat_name")
     when "DirectMessageChannel"
       chatable.chat_channel_title_for_user(self, user)
     end
   end
 
   def self.public_channels
-    where(chatable_type: ["Topic", "Category", DiscourseChat::SITE_CHAT_TYPE])
-  end
-
-  def self.site_channel
-    find_by(chatable_id: DiscourseChat::SITE_CHAT_ID)
+    where(chatable_type: ["Topic", "Category", "Tag"])
   end
 
   def self.is_enabled?(t)

--- a/app/serializers/chat_base_message_serializer.rb
+++ b/app/serializers/chat_base_message_serializer.rb
@@ -41,7 +41,6 @@ class ChatBaseMessageSerializer < ApplicationSerializer
   end
 
   def include_flag_count?
-    object.chat_channel.site_channel? ||
-      scope.can_see_flags?(object.chat_channel.chatable) && (false && object.flag_count > 0)
+    scope.can_see_flags?(object.chat_channel.chatable) && (false && object.flag_count > 0)
   end
 end

--- a/app/serializers/chat_view_serializer.rb
+++ b/app/serializers/chat_view_serializer.rb
@@ -16,8 +16,7 @@ class ChatViewSerializer < ApplicationSerializer
   end
 
   def include_can_delete_self?
-    object.chat_channel.site_channel? ||
-      scope.can_delete_own_chats?(object.chatable)
+    scope.can_delete_own_chats?(object.chatable)
   end
 
   def can_delete_self
@@ -25,8 +24,7 @@ class ChatViewSerializer < ApplicationSerializer
   end
 
   def include_can_delete_others?
-    object.chat_channel.site_channel? ||
-      scope.can_delete_other_chats?(object.chatable)
+    scope.can_delete_other_chats?(object.chatable)
   end
 
   def can_delete_others

--- a/assets/javascripts/discourse/components/channel-list.js
+++ b/assets/javascripts/discourse/components/channel-list.js
@@ -4,6 +4,7 @@ import showModal from "discourse/lib/show-modal";
 import { action, computed } from "@ember/object";
 import { schedule } from "@ember/runloop";
 import { inject as service } from "@ember/service";
+import { empty } from "@ember/object/computed";
 
 export default Component.extend({
   classNames: "tc-channels",
@@ -12,6 +13,7 @@ export default Component.extend({
   creatingDmChannel: false,
   inSidebar: false,
   toggleSection: null,
+  publicChannelsEmpty: empty("publicChannels"),
   chat: service(),
 
   didInsertElement() {

--- a/assets/javascripts/discourse/templates/components/channel-list.hbs
+++ b/assets/javascripts/discourse/templates/components/channel-list.hbs
@@ -25,9 +25,18 @@
     }}
   </div>
   <div id="public-channels" class={{publicChannelClasses}}>
-    {{#each publicChannels as |channel|}}
-      {{chat-channel-row channel=channel switchChannel=onSelect}}
-    {{/each}}
+    {{#if publicChannelsEmpty}}
+      <div class="public-channel-empty-message">
+        {{i18n "chat.no_public_channels"}}
+        <a href {{action "openChannelSettingsModal"}}>
+          {{i18n "chat.click_to_join"}}
+        </a>
+      </div>
+    {{else}}
+      {{#each publicChannels as |channel|}}
+        {{chat-channel-row channel=channel switchChannel=onSelect}}
+      {{/each}}
+    {{/if}}
   </div>
 
   <div class="chat-channel-divider">

--- a/assets/javascripts/discourse/templates/components/chat-channel-settings-row.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-settings-row.hbs
@@ -86,5 +86,5 @@
 </div>
 
 {{#each channel.chat_channels as |nestedChannel|}}
-  {{chat-channel-settings-row channel=nestedChannel}}
+  {{chat-channel-settings-row channel=nestedChannel onFollowChannel=onFollowChannel}}
 {{/each}}

--- a/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
@@ -37,7 +37,4 @@
     <span class="topic-chat-icon">{{d-icon "far-comments"}}</span>
   </span>
   <p class="topic-chat-name">{{replace-emoji channel.chatable.fancy_title}}</p>
-{{else}}
-  {{d-icon "lock"}}
-  <p class="chat-name">{{i18n "chat.channels.staff"}}</p>
 {{/if}}

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -133,23 +133,6 @@ $float-height: 530px;
   align-self: flex-end;
 }
 
-.tc-channels {
-  .chat-unread-urgent-indicator,
-  .chat-unread-indicator {
-    width: 10px;
-    height: 10px;
-    opacity: 0.4;
-    margin-left: 0.5em;
-    border-radius: 10px;
-    border: 0;
-    right: 7px;
-    top: calc(50% - 5px);
-    .chat-unread-urgent-indicator-number-wrap {
-      display: none;
-    }
-  }
-}
-
 .topic-chat-container {
   background: var(--secondary);
   border: 1px solid var(--primary-low-mid);
@@ -269,6 +252,24 @@ $float-height: 530px;
   overflow-y: auto;
   height: 100%;
 
+  .chat-unread-urgent-indicator,
+  .chat-unread-indicator {
+    width: 10px;
+    height: 10px;
+    opacity: 0.4;
+    margin-left: 0.5em;
+    border-radius: 10px;
+    border: 0;
+    right: 7px;
+    top: calc(50% - 5px);
+    .chat-unread-urgent-indicator-number-wrap {
+      display: none;
+    }
+  }
+
+  .public-channel-empty-message {
+    margin: 0 0.5em 0.5em 0.5em;
+  }
   .chat-channel-divider {
     font-weight: bold;
     padding: 0.5em;
@@ -967,6 +968,11 @@ $float-height: 530px;
         position: absolute;
         top: 0;
       }
+    }
+
+    .public-channel-empty-message {
+      margin: 0;
+      padding: 0em 2em 0.5em;
     }
 
     .category-chat-private {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -90,9 +90,6 @@ en:
         new: "New personal chat"
         create: "Go"
 
-      channels:
-        staff: "Staff-only"
-
       incoming_webhooks:
         back: "Back"
         channel: "Channel"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -12,6 +12,7 @@ en:
       category_chat_enabled: "Chat enabled for category"
       chat_channels: "Channels"
       chat_channels_with_count: "Channels (%{count} online)"
+      click_to_join: "Click here to view available channels."
       close: "Close"
       collapse: "Collapse Chat Drawer"
       deleted: "A message was deleted. [view]"
@@ -40,6 +41,7 @@ en:
       minimal_view:
         title: "Minimal chat view"
         description: "Hides all non-chat related sidebar items when on the chat page. Applies only to the current browser."
+      no_public_channels: "You have not joined any channels."
       only_chat_push_notifications:
         title: "Only send chat push notifications"
         description: "Block all non-chat push notifications from being sent"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -9,7 +9,6 @@ en:
       content: "Chat separation post for %{date}."
     enabled_chat: "Enabled chat"
     disabled_chat: "Disabled chat"
-    site_chat_name: "Staff-only"
     notifications:
       mention: "@%{username} mentioned you in chat"
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,3 +9,6 @@ plugins:
     default: "3" # 3 is staff group id
     allow_any: false
     refresh: true
+  needs_chat_seeded:
+    default: true
+    hidden: true

--- a/db/fixtures/001_chat_channels.rb
+++ b/db/fixtures/001_chat_channels.rb
@@ -1,5 +1,3 @@
 # frozen_string_literal: true
-ChatChannel.seed(:chatable_id, :chatable_type) do |chat_channel|
-  chat_channel.chatable_id = DiscourseChat::SITE_CHAT_ID
-  chat_channel.chatable_type = DiscourseChat::SITE_CHAT_TYPE
-end
+
+ChatSeeder.new.execute if !Rails.env.test?

--- a/lib/chat_seeder.rb
+++ b/lib/chat_seeder.rb
@@ -6,7 +6,8 @@ class ChatSeeder
 
     begin
       staff_category = Category.find_by(id: SiteSetting.staff_category_id)
-      create_staff_chat_channel(staff_category)
+      chat_channel = create_staff_chat_channel(staff_category)
+      auto_join_users(chat_channel)
     rescue => error
       Rails.logger.warn("Error seeding chat staff category - #{error.inspect}")
     ensure
@@ -17,8 +18,17 @@ class ChatSeeder
   def create_staff_chat_channel(staff_category)
     return unless staff_category
 
-    ChatChannel.create(chatable: staff_category)
+    chat_channel = ChatChannel.create(chatable: staff_category)
     staff_category.custom_fields[DiscourseChat::HAS_CHAT_ENABLED] = true
     staff_category.save!
+    chat_channel
+  end
+
+  def auto_join_users(chat_channel)
+    group_ids = chat_channel.allowed_group_ids
+    users = User.not_suspended.joins(:group_users).where(group_users: { group_id:  group_ids }).uniq
+    users.each do |user|
+      UserChatChannelMembership.create!(user: user, chat_channel: chat_channel, following: true)
+    end
   end
 end

--- a/lib/chat_seeder.rb
+++ b/lib/chat_seeder.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ChatSeeder
+  def execute(args = {})
+    return unless SiteSetting.needs_chat_seeded
+
+    begin
+      staff_category = Category.find_by(id: SiteSetting.staff_category_id)
+      create_staff_chat_channel(staff_category)
+    rescue => error
+      Rails.logger.warn("Error seeding chat staff category - #{error.inspect}")
+    ensure
+      SiteSetting.needs_chat_seeded = false
+    end
+  end
+
+  def create_staff_chat_channel(staff_category)
+    return unless staff_category
+
+    ChatChannel.create(chatable: staff_category)
+    staff_category.custom_fields[DiscourseChat::HAS_CHAT_ENABLED] = true
+    staff_category.save!
+  end
+end

--- a/lib/guardian_extensions.rb
+++ b/lib/guardian_extensions.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 module DiscourseChat::GuardianExtensions
-  def can_access_site_chat?
-    @user.staff?
-  end
-
   def can_moderate_chat?(chatable)
     chatable.class.name == "Topic" ?
       can_perform_action_available_to_group_moderators?(chatable) :
@@ -33,8 +29,6 @@ module DiscourseChat::GuardianExtensions
       return false unless chat_channel.chatable
 
       can_see_category?(chat_channel.chatable)
-    elsif chat_channel.site_channel?
-      can_access_site_chat?
     else
       true
     end

--- a/plugin.rb
+++ b/plugin.rb
@@ -27,9 +27,6 @@ after_initialize do
     PLUGIN_NAME = "discourse-chat"
     HAS_CHAT_ENABLED = "has_chat_enabled"
 
-    SITE_CHAT_ID = -1
-    SITE_CHAT_TYPE = "Site"
-
     class Engine < ::Rails::Engine
       engine_name PLUGIN_NAME
       isolate_namespace DiscourseChat
@@ -71,6 +68,7 @@ after_initialize do
   load File.expand_path('../lib/chat_channel_fetcher.rb', __FILE__)
   load File.expand_path('../lib/chat_message_creator.rb', __FILE__)
   load File.expand_path('../lib/chat_message_updater.rb', __FILE__)
+  load File.expand_path('../lib/chat_seeder.rb', __FILE__)
   load File.expand_path('../lib/chat_view.rb', __FILE__)
   load File.expand_path('../lib/direct_message_channel_creator.rb', __FILE__)
   load File.expand_path('../lib/guardian_extensions.rb', __FILE__)

--- a/spec/components/chat_message_creator_spec.rb
+++ b/spec/components/chat_message_creator_spec.rb
@@ -10,7 +10,6 @@ describe DiscourseChat::ChatMessageCreator do
   fab!(:user2) { Fabricate(:user) }
   fab!(:user3) { Fabricate(:user) }
   fab!(:user_without_memberships) { Fabricate(:user) }
-  fab!(:site_chat_channel) { Fabricate(:site_chat_channel) }
   fab!(:public_chat_channel) { Fabricate(:chat_channel, chatable: Fabricate(:topic)) }
   fab!(:direct_message_channel) { Fabricate(:chat_channel, chatable: Fabricate(:direct_message_channel, users: [user1, user2])) }
 
@@ -19,9 +18,6 @@ describe DiscourseChat::ChatMessageCreator do
     SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
 
     # Create channel memberships
-    [admin1, admin2].each do |user|
-      Fabricate(:user_chat_channel_membership, chat_channel: site_chat_channel, user: user)
-    end
     [admin1, admin2, user1, user2, user3].each do |user|
       Fabricate(:user_chat_channel_membership, chat_channel: public_chat_channel, user: user)
     end
@@ -141,16 +137,6 @@ describe DiscourseChat::ChatMessageCreator do
         content: "hi @#{user2.username}"
       )
     }.to change { Notification.count }.by(0)
-  end
-
-  it "created mention notifications only for staff in site channel" do
-    expect {
-      DiscourseChat::ChatMessageCreator.create(
-        chat_channel: site_chat_channel,
-        user: admin1,
-        content: "Hey @#{admin2.username}, @#{user2.username} and @#{user3.username}"
-      )
-    }.to change { Notification.count }.by(1)
   end
 
   it "creates only mention notifications for users with access in private chat " do

--- a/spec/components/chat_seeder_spec.rb
+++ b/spec/components/chat_seeder_spec.rb
@@ -25,7 +25,7 @@ describe ChatSeeder do
   end
 
   it "does nothing when 'SiteSetting.needs_chat_seeded' is false" do
-    SiteSetting.needs_chat_seeded = false;
+    SiteSetting.needs_chat_seeded = false
     expect {
       ChatSeeder.new.execute
     }.to change {

--- a/spec/components/chat_seeder_spec.rb
+++ b/spec/components/chat_seeder_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ChatSeeder do
+  fab!(:category) { Fabricate(:category) }
+
+  before do
+    SiteSetting.staff_category_id = category.id
+  end
+  it "creates a chat channel for staff category" do
+    expect {
+      ChatSeeder.new.execute
+    }.to change {
+      ChatChannel.where(chatable: category).count
+    }.by(1)
+
+    expect(category.custom_fields[DiscourseChat::HAS_CHAT_ENABLED]).to eq(true)
+    expect(SiteSetting.needs_chat_seeded).to eq(false)
+  end
+
+  it "does nothing when 'SiteSetting.needs_chat_seeded' is false" do
+    SiteSetting.needs_chat_seeded = false;
+    expect {
+      ChatSeeder.new.execute
+    }.to change {
+      ChatChannel.where(chatable: category).count
+    }.by(0)
+  end
+end

--- a/spec/components/chat_seeder_spec.rb
+++ b/spec/components/chat_seeder_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 describe ChatSeeder do
-  fab!(:category) { Fabricate(:category) }
+  fab!(:category) { Fabricate(:private_category, group: Group[:staff]) }
+  fab!(:staff_user1) { Fabricate(:user, groups: [Group[:staff]]) }
+  fab!(:staff_user2) { Fabricate(:user, groups: [Group[:staff]]) }
 
   before do
     SiteSetting.staff_category_id = category.id
@@ -14,6 +16,9 @@ describe ChatSeeder do
     }.to change {
       ChatChannel.where(chatable: category).count
     }.by(1)
+      .and change {
+        UserChatChannelMembership.where(following: true).count
+      }.by(2)
 
     expect(category.custom_fields[DiscourseChat::HAS_CHAT_ENABLED]).to eq(true)
     expect(SiteSetting.needs_chat_seeded).to eq(false)

--- a/spec/fabricators/chat_fabricator.rb
+++ b/spec/fabricators/chat_fabricator.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
 Fabricator(:chat_channel) do
-  chatable nil
-end
-
-Fabricator(:site_chat_channel, from: :chat_channel) do
-  chatable_id DiscourseChat::SITE_CHAT_ID
-  chatable_type DiscourseChat::SITE_CHAT_TYPE
+  chatable { Fabricate(:topic) }
 end
 
 Fabricator(:chat_message) do
@@ -22,7 +17,7 @@ end
 Fabricator(:incoming_chat_webhook) do
   name { sequence(:name) { |i| "#{i + 1}" } }
   key { sequence(:key) { |i| "#{i + 1}" } }
-  chat_channel { Fabricate(:site_chat_channel) }
+  chat_channel { Fabricate(:chat_channel, chatable: Fabricate(:topic)) }
 end
 
 Fabricator(:user_chat_channel_membership) do

--- a/spec/models/chat_channel_spec.rb
+++ b/spec/models/chat_channel_spec.rb
@@ -7,7 +7,6 @@ describe ChatChannel do
   fab!(:user1) { Fabricate(:user) }
   fab!(:user2) { Fabricate(:user) }
   fab!(:group) { Fabricate(:group) }
-  fab!(:site_channel) { Fabricate(:site_chat_channel) }
   fab!(:public_topic_channel) { Fabricate(:chat_channel, chatable: Fabricate(:topic)) }
   fab!(:private_category) { Fabricate(:private_category, group: group) }
   fab!(:private_category_channel) { Fabricate(:chat_channel, chatable: private_category) }
@@ -16,7 +15,6 @@ describe ChatChannel do
 
   describe "#allowed_user_ids" do
     it "is correct for each channel type" do
-      expect(site_channel.allowed_user_ids).to eq(nil)
       expect(private_category_channel.allowed_user_ids).to eq(nil)
       expect(private_topic_channel.allowed_user_ids).to eq(nil)
       expect(public_topic_channel.allowed_user_ids).to eq(nil)
@@ -26,7 +24,6 @@ describe ChatChannel do
 
   describe "#allowed_group_ids" do
     it "is correct for each channel type" do
-      expect(site_channel.allowed_group_ids).to eq([Group::AUTO_GROUPS[:staff]])
       expect(private_category_channel.allowed_group_ids).to eq([group.id])
       expect(private_topic_channel.allowed_group_ids).to eq([group.id])
       expect(public_topic_channel.allowed_group_ids).to eq(nil)

--- a/spec/requests/admin/admin_incoming_chat_webhooks_controller_spec.rb
+++ b/spec/requests/admin/admin_incoming_chat_webhooks_controller_spec.rb
@@ -6,7 +6,7 @@ require_relative '../../fabricators/chat_fabricator'
 RSpec.describe DiscourseChat::AdminIncomingChatWebhooksController do
   fab!(:admin) { Fabricate(:admin) }
   fab!(:user) { Fabricate(:user) }
-  fab!(:chat_channel1) { Fabricate(:site_chat_channel) }
+  fab!(:chat_channel1) { Fabricate(:chat_channel, chatable: Fabricate(:topic)) }
   fab!(:chat_channel2) { Fabricate(:chat_channel, chatable: Fabricate(:topic)) }
 
   before do

--- a/spec/requests/chat_channel_controller_spec.rb
+++ b/spec/requests/chat_channel_controller_spec.rb
@@ -93,14 +93,13 @@ RSpec.describe DiscourseChat::ChatChannelsController do
         expect(response.parsed_body["public_channels"].detect { |channel| channel["id"] == private_category_cc.id }["chat_channels"].first["chatable_id"]).to eq(private_topic_cc.chatable_id)
       end
 
-      it "returns all channels for admin, including site chat" do
+      it "returns all channels for admin" do
         sign_in(admin)
         get "/chat/chat_channels.json"
 
         expect(response.status).to eq(200)
         expect(response.parsed_body["public_channels"].map { |channel| channel["chatable_id"] })
           .to match_array([
-            DiscourseChat::SITE_CHAT_ID,
             public_category_cc.chatable_id,
             private_category_cc.chatable_id,
             one_off_cc.chatable_id,

--- a/spec/requests/incoming_chat_webhooks_controller_spec.rb
+++ b/spec/requests/incoming_chat_webhooks_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require_relative '../fabricators/chat_fabricator'
 
 RSpec.describe DiscourseChat::IncomingChatWebhooksController do
-  fab!(:chat_channel) { Fabricate(:site_chat_channel) }
+  fab!(:chat_channel) { Fabricate(:chat_channel) }
   fab!(:webhook) { Fabricate(:incoming_chat_webhook, chat_channel: chat_channel) }
 
   describe "#create_message" do


### PR DESCRIPTION
This removes the one-off `staff-only` chat channel in favor of an auto-seeded staff category chat channel.

Also adds nice text and prompt for the channel list has no channels:

In sidebar

![Screen Shot 2021-11-17 at 3 06 24 PM](https://user-images.githubusercontent.com/16214023/142285991-716968eb-ef06-4963-9b9b-23a9438d250e.png)

In float

![Screen Shot 2021-11-17 at 3 06 29 PM](https://user-images.githubusercontent.com/16214023/142286020-e8156468-d1c2-41c3-9b3a-fd9cb4c46e2d.png)


