### PR TITLE
UX: Align title elements

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
@@ -4,7 +4,6 @@
       {{channel.chatable.users.length}}
     </span>
     <span class="dm-usernames">{{usernames}}</span>
-
   {{else}}
     <div class="dm-single-user">
       <div class="tc-avatar-container">
@@ -13,7 +12,6 @@
       </div>
       <span class="dm-usernames">{{channel.chatable.users.firstObject.username}}</span>
     </div>
-
   {{/if}}
 {{else if (eq channel.chatable_type "Tag")}}
   <span class="tag-chat-badge">

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1204,8 +1204,11 @@ $float-height: 530px;
     position: relative;
   }
 
+  .tag-chat-badge,
   .category-chat-badge,
   .topic-chat-badge {
+    display: flex;
+
     .d-icon {
       height: 1.125em;
       width: 1.125em;


### PR DESCRIPTION
Before / After
<img width="120" alt="Screen Shot 2021-11-18 at 02 33 53" src="https://user-images.githubusercontent.com/66961/142335051-33512035-459b-4475-876b-3eb44de1e072.png"> <img width="120" alt="Screen Shot 2021-11-18 at 02 34 15" src="https://user-images.githubusercontent.com/66961/142335057-238115d2-9385-4b81-9e52-dce2354e9a02.png">

