### PR TITLE
Workaround for Safari scrollbar position

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -139,7 +139,7 @@ export default Component.extend({
           }
           this.setMessageProps(data.chat_view);
           this.decorateMessages();
-          this.onScroll();
+          this._stickScrollToBottom();
         })
         .catch((err) => {
           throw err;
@@ -349,7 +349,7 @@ export default Component.extend({
       if (this._scrollerEl) {
         // Set scrollTop to 0 isn't always enough for some reason. 10 makes sure
         // that the scroll is at the bottom. (it's reversed because flex-direction: column-reverse)
-        this._scrollerEl.scrollTop = 10;
+        this._scrollerEl.scrollTop = -1;
       }
     });
   },
@@ -358,6 +358,7 @@ export default Component.extend({
     if (this._selfDeleted()) {
       return;
     }
+
     resetIdle();
 
     const atTop =

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -347,9 +347,13 @@ export default Component.extend({
       this.set("stickyScroll", true);
 
       if (this._scrollerEl) {
-        // Set scrollTop to 0 isn't always enough for some reason. 10 makes sure
-        // that the scroll is at the bottom. (it's reversed because flex-direction: column-reverse)
+        // Trigger a tiny scrollTop change so Safari scrollbar is placed at bottom.
+        // Setting to just 0 doesn't work (it's at 0 by default, so there is no change)
+        // Very hacky, but no way to get around this Safari bug
         this._scrollerEl.scrollTop = -1;
+        later(() => {
+          this._scrollerEl.scrollTop = 0;
+        }, 40);
       }
     });
   },
@@ -358,7 +362,6 @@ export default Component.extend({
     if (this._selfDeleted()) {
       return;
     }
-
     resetIdle();
 
     const atTop =
@@ -805,7 +808,6 @@ export default Component.extend({
 
   @action
   composerValueChanged(composerValue) {
-    this.reStickScrollIfNeeded();
     this._reportReplyingPresence(composerValue);
   },
 


### PR DESCRIPTION
Safari/Webkit appears to have a bug with `flex-direction: column-reverse`, on first load, it doesn't update the location of the scrollbar. The scrollbar is stuck at the top of the element, even though the element contents is scrolled to the bottom. 

This workaround triggers a 1-pixel scroll, to force recalculating the position of the scrollbar. 