### PR TITLE
FIX: Ensure the user remains 'present' in notification-routing channels

### DIFF
--- a/assets/javascripts/discourse/services/chat-notification-manager.js
+++ b/assets/javascripts/discourse/services/chat-notification-manager.js
@@ -61,11 +61,11 @@ export default Service.extend({
   _pageChanged(path) {
     this.set("_inChat", path.startsWith("/chat/channel/"));
     if (this._inChat) {
-      this._chatPresenceChannel.enter();
+      this._chatPresenceChannel.enter({ onlyWhileActive: false });
       this._corePresenceChannel.leave();
     } else {
       this._chatPresenceChannel.leave();
-      this._corePresenceChannel.enter();
+      this._corePresenceChannel.enter({ onlyWhileActive: false });
     }
   },
 


### PR DESCRIPTION
Following core change in https://github.com/discourse/discourse/commit/af4b8d0e21f823463a1f8a613aedf9bc845a62e1