### PR TITLE
FIX: Remove links around chat channel title

### DIFF
--- a/assets/javascripts/discourse/components/chat-channel-title.js
+++ b/assets/javascripts/discourse/components/chat-channel-title.js
@@ -14,8 +14,6 @@ export default Component.extend({
   },
 
   click() {
-    if (this.onClick) {
-      return this.onClick();
-    }
+    return this.onClick?.();
   },
 });

--- a/assets/javascripts/discourse/components/chat-channel-title.js
+++ b/assets/javascripts/discourse/components/chat-channel-title.js
@@ -12,4 +12,10 @@ export default Component.extend({
   usernames(users) {
     return users.map((user) => user.username).join(", ");
   },
+
+  click() {
+    if (this.onClick) {
+      return this.onClick();
+    }
+  },
 });

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -804,6 +804,11 @@ export default Component.extend({
   },
 
   @action
+  onChannelTitleClick() {
+    return this.router.transitionTo(this.chatChannel.chatable_url);
+  },
+
+  @action
   moveMessagesToTopic() {
     showModal("move-chat-to-topic").setProperties({
       chatMessageIds: this.messages

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -805,7 +805,9 @@ export default Component.extend({
 
   @action
   onChannelTitleClick() {
-    return this.router.transitionTo(this.chatChannel.chatable_url);
+    if (this.chatChannel.chatable_url) {
+      return this.router.transitionTo(this.chatChannel.chatable_url);
+    }
   },
 
   @action

--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -264,7 +264,7 @@ export default Component.extend({
 
   @action
   onChannelTitleClick() {
-    if (this.expanded) {
+    if (this.expanded && this.activeChannel.chatable_url) {
       this.router.transitionTo(this.activeChannel.chatable_url);
     } else {
       this.set("expanded", true);

--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -263,6 +263,15 @@ export default Component.extend({
   },
 
   @action
+  onChannelTitleClick() {
+    if (this.expanded) {
+      this.router.transitionTo(this.activeChannel.chatable_url);
+    } else {
+      this.set("expanded", true);
+    }
+  },
+
+  @action
   toggleExpand() {
     this.set("expanded", !this.expanded);
     this.appEvents.trigger("chat:toggle-expand", this.expanded);
@@ -348,6 +357,7 @@ export default Component.extend({
       expanded: this.expectPageChange ? true : this.expanded,
       loading: false,
       hidden: false,
+      expanded: true,
       expectPageChange: false,
       view: CHAT_VIEW,
     };

--- a/assets/javascripts/discourse/templates/components/chat-channel-settings-row.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-settings-row.hbs
@@ -1,5 +1,5 @@
 <div class="chat-channel-settings-row">
-  {{chat-channel-title channel=channel}}
+  {{chat-channel-title channel=channel onClick=(action "previewChannel")}}
 
   <div class="btn-container">
     {{#if channel.following}}

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -7,9 +7,9 @@
         action=onBackClick
       }}
     {{/if}}
-    <a href={{chatChannel.chatable_url}}>
-      {{chat-channel-title channel=chatChannel}}
-    </a>
+
+    {{chat-channel-title onClick=(action "onChannelTitleClick") channel=chatChannel}}
+
     {{#if previewing}}
       {{d-button
         class="btn-primary join-channel-btn"

--- a/assets/javascripts/discourse/templates/components/topic-chat-float.hbs
+++ b/assets/javascripts/discourse/templates/components/topic-chat-float.hbs
@@ -10,18 +10,15 @@
             title="chat.return_to_list"
           }}
         {{/if}}
-        <a href={{activeChannel.chatable_url}} class="tc-title-seg">
-          {{#if activeChannel}}
-            {{chat-channel-title channel=activeChannel}}
-            {{#if (and (not expanded) unreadCount)}}
-              <span class="tc-unread-count">{{unreadCount}}</span>
-            {{/if}}
+
+        {{#if activeChannel}}
+          {{chat-channel-title channel=activeChannel onClick=(action "onChannelTitleClick")}}
+          {{#if (and (not expanded) unreadCount)}}
+            <span class="tc-unread-count">{{unreadCount}}</span>
           {{/if}}
-        </a>
+        {{/if}}
       {{else}}
-        <div class="tc-title-seg">
-          <span class="tc-branding">{{i18n "chat.heading"}}</span>
-        </div>
+        <span class="no-channel-title">{{i18n "chat.heading"}}</span>
       {{/if}}
 
       <button

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -101,7 +101,8 @@ $float-height: 530px;
     pointer-events: auto;
   }
   bottom: 0;
-  .tc-branding {
+
+  .no-channel-title {
     font-weight: 900;
   }
   &.composer-draft-collapsed {
@@ -171,40 +172,31 @@ $float-height: 530px;
   justify-content: space-between;
   align-items: center;
 
-  button {
+  .btn {
     height: 100%;
   }
-  .tc-title-seg {
-    padding: 0 0.25em;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    color: var(--primary);
-    display: flex;
-    align-items: center;
-    width: 100%;
-    .chat-channel-title {
-      width: calc(95% - 0.5em);
-      margin-right: 0.5em;
-      .chat-name,
-      .topic-chat-name,
-      .category-chat-name {
-        color: var(--primary);
-      }
-      .badge-wrapper.bullet {
-        margin-right: 0px;
-      }
-      .dm-usernames {
-        max-width: 100%;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-      .d-icon:not(.d-icon-hashtag) {
-        color: var(--primary-high);
-      }
-      .category-hashtag {
-        padding: 2px 4px;
-      }
+
+  .chat-channel-title {
+    width: calc(95% - 0.5em);
+    margin-right: 0.5em;
+    .chat-name,
+    .topic-chat-name,
+    .category-chat-name {
+      color: var(--primary);
+    }
+    .badge-wrapper.bullet {
+      margin-right: 0px;
+    }
+    .dm-usernames {
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .d-icon:not(.d-icon-hashtag) {
+      color: var(--primary-high);
+    }
+    .category-hashtag {
+      padding: 2px 4px;
     }
   }
   .tc-unread-count {
@@ -982,12 +974,27 @@ $float-height: 530px;
 }
 
 .chat-channel-title {
+  position: relative;
   display: grid;
   grid-template-columns: 20px 1fr;
   grid-column-gap: 0.5em;
   align-items: center;
   font-weight: 500;
   max-width: calc(100% - 10px - 0.5em);
+  cursor: pointer;
+
+  .category-chat-private .d-icon {
+    background-color: var(--secondary);
+    position: absolute;
+    border-radius: 5px;
+    padding: 2px 2px 3px;
+    color: var(--primary-high);
+    height: 0.5em;
+    width: 0.5em;
+    left: 8px;
+    top: -1px;
+  }
+
   .category-chat-name,
   .topic-chat-name,
   .tag-chat-name,
@@ -1176,6 +1183,8 @@ $float-height: 530px;
 }
 
 .chat-settings-modal {
+  max-height: 600px;
+
   .chat-channel-settings-row {
     display: flex;
     flex-wrap: wrap;
@@ -1311,51 +1320,17 @@ $float-height: 530px;
   }
 }
 
-.topic-chat-drawer-header {
-  .chat-channel-title {
-    position: relative;
-    max-width: 100%;
-  }
-  .category-chat-private .d-icon {
-    background-color: var(--secondary);
-    position: absolute;
-    border-radius: 5px;
-    padding: 2px 2px 3px;
-    color: var(--primary-high);
-    height: 0.5em;
-    width: 0.5em;
-    left: 8px;
-    top: -1px;
-  }
-}
-
 .tc-full-page-header {
   .chat-channel-title {
-    position: relative;
     max-width: 100%;
     .dm-usernames {
       overflow: hidden;
       text-overflow: ellipsis;
     }
   }
-  .category-chat-private .d-icon {
-    background-color: var(--secondary);
-    position: absolute;
-    border-radius: 5px;
-    padding: 2px 2px 3px;
-    color: var(--primary-high);
-    height: 0.5em;
-    width: 0.5em;
-    left: 8px;
-    top: -1px;
-  }
 }
 
 .tc-channels {
-  .chat-channel-title {
-    position: relative;
-  }
-
   .tag-chat-badge,
   .category-chat-badge,
   .topic-chat-badge {


### PR DESCRIPTION
This does a few things:
* Sets max-height on chat channel settings modal
* Removes links around chat-channel-title in favor of passed in action
  *  Huge benefit of this is that we can make the title expand the widget when it is hidden on click.
* Expands widget when it was collapsed and sidebar link is clicked on
* Cleans up a ton of css