### PR TITLE
FIX: Display user card only on actual avatar click

### DIFF
--- a/assets/javascripts/discourse/templates/components/tc-message.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-message.hbs
@@ -95,8 +95,8 @@
           {{#if message.chat_webhook_event.emoji}}
             <div class="tc-avatar">{{replace-emoji message.chat_webhook_event.emoji}}</div>
           {{else}}
-            <div class="tc-avatar" data-user-card={{message.user.username}}>
-              <div class="tc-avatar-container">
+            <div class="tc-avatar">
+              <div class="tc-avatar-container" data-user-card={{message.user.username}}>
                 {{avatar message.user imageSize="medium"}}
                 {{tc-user-presence-flair user=message.user}}
               </div>


### PR DESCRIPTION
Previously all the space below it would also trigger the card.

<img width="163" alt="Screen Shot 2021-12-05 at 11 09 02" src="https://user-images.githubusercontent.com/66961/144743095-9faf760c-7398-497a-8287-bff63e48db7b.png">


