### PR TITLE
FIX: Make PresenceChannel 'public' for unsecured categories/topics

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -215,6 +215,9 @@ after_initialize do
       config = PresenceChannel::Config.new
       config.allowed_group_ids = chat_channel.allowed_group_ids
       config.allowed_user_ids = chat_channel.allowed_user_ids
+      if config.allowed_group_ids.nil? && config.allowed_user_ids.nil?
+        config.public = true
+      end
       config
     end
   rescue ActiveRecord::RecordNotFound


### PR DESCRIPTION
Otherwise, a `nil` value for `allowed_group_ids` and `allowed_user_ids` will mean nobody is allowed access