### PR TITLE
FIX: Reply-to line rendering

### DIFF
--- a/app/serializers/chat_base_message_serializer.rb
+++ b/app/serializers/chat_base_message_serializer.rb
@@ -7,7 +7,6 @@ class ChatBaseMessageSerializer < ApplicationSerializer
     :action_code,
     :created_at,
     :excerpt,
-    :in_reply_to_id,
     :deleted_at,
     :deleted_by_id,
     :flag_count,
@@ -56,7 +55,7 @@ class ChatBaseMessageSerializer < ApplicationSerializer
     !object.deleted_at.nil?
   end
 
-  def include_in_reply_to_id?
+  def include_in_reply_to?
     object.in_reply_to_id.presence
   end
 

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -210,6 +210,14 @@ acceptance("Discourse Chat - without unread", function (needs) {
     assert.ok(messages[2].querySelector("img.chat-img-upload"));
   });
 
+  test("Reply-to line is present", async function (assert) {
+    await visit("/chat/channel/9/Site");
+    const messages = queryAll(".chat-message");
+    const replyTo = messages[2].querySelector(".tc-reply-msg");
+    assert.ok(replyTo);
+    assert.equal(replyTo.innerText.trim(), messageContents[1]);
+  });
+
   test("Message controls are present and correct for permissions", async function (assert) {
     await visit("/chat/channel/9/Site");
     const messages = queryAll(".tc-message");

--- a/test/javascripts/chat-fixtures.js
+++ b/test/javascripts/chat-fixtures.js
@@ -108,62 +108,66 @@ export function allChannels() {
   return channels.public_channels;
 }
 
+const messages = [
+  {
+    id: 174,
+    message: messageContents[0],
+    cooked: messageContents[0],
+    excerpt: messageContents[0],
+    action_code: null,
+    created_at: "2021-07-20T08:14:16.950Z",
+    flag_count: 0,
+    user: {
+      id: 1,
+      username: "markvanlan",
+      name: null,
+      avatar_template: "/letter_avatar_proxy/v4/letter/m/48db29/{size}.png",
+    },
+  },
+  {
+    id: 175,
+    message: messageContents[1],
+    cooked: messageContents[1],
+    excerpt: messageContents[1],
+    action_code: null,
+    created_at: "2021-07-20T08:14:22.043Z",
+    flag_count: 0,
+    user: {
+      id: 2,
+      username: "hawk",
+      name: null,
+      avatar_template: "/letter_avatar_proxy/v4/letter/m/48db29/{size}.png",
+    },
+    uploads: [
+      {
+        extension: "pdf",
+        filesize: 861550,
+        height: null,
+        human_filesize: "841 KB",
+        id: 38,
+        original_filename: "Chat message PDF!",
+        retain_hours: null,
+        short_path: "/uploads/short-url/vYozObYao54I6G3x8wvOf73epfX.pdf",
+        short_url: "upload://vYozObYao54I6G3x8wvOf73epfX.pdf",
+        thumbnail_height: null,
+        thumbnail_width: null,
+        url:
+          "//localhost:3000/uploads/default/original/1X/e0172973d7eff927b875995eb86b162da961b9e1.pdf",
+        width: null,
+      },
+    ],
+  },
+];
+
 export const chatView = {
-  chat_messages: [
-    {
-      id: 174,
-      message: messageContents[0],
-      cooked: messageContents[0],
-      action_code: null,
-      created_at: "2021-07-20T08:14:16.950Z",
-      flag_count: 0,
-      user: {
-        id: 1,
-        username: "markvanlan",
-        name: null,
-        avatar_template: "/letter_avatar_proxy/v4/letter/m/48db29/{size}.png",
-      },
-    },
-    {
-      id: 175,
-      message: messageContents[1],
-      cooked: messageContents[1],
-      action_code: null,
-      created_at: "2021-07-20T08:14:22.043Z",
-      in_reply_to_id: 174,
-      flag_count: 0,
-      user: {
-        id: 2,
-        username: "hawk",
-        name: null,
-        avatar_template: "/letter_avatar_proxy/v4/letter/m/48db29/{size}.png",
-      },
-      uploads: [
-        {
-          extension: "pdf",
-          filesize: 861550,
-          height: null,
-          human_filesize: "841 KB",
-          id: 38,
-          original_filename: "Chat message PDF!",
-          retain_hours: null,
-          short_path: "/uploads/short-url/vYozObYao54I6G3x8wvOf73epfX.pdf",
-          short_url: "upload://vYozObYao54I6G3x8wvOf73epfX.pdf",
-          thumbnail_height: null,
-          thumbnail_width: null,
-          url:
-            "//localhost:3000/uploads/default/original/1X/e0172973d7eff927b875995eb86b162da961b9e1.pdf",
-          width: null,
-        },
-      ],
-    },
+  chat_messages: messages.concat([
     {
       id: 176,
       message: messageContents[2],
       cooked: messageContents[2],
+      excerpt: messageContents[2],
       action_code: null,
       created_at: "2021-07-20T08:14:25.043Z",
-      in_reply_to_id: 174,
       flag_count: 0,
       user: {
         id: 2,
@@ -171,6 +175,7 @@ export const chatView = {
         name: null,
         avatar_template: "/letter_avatar_proxy/v4/letter/m/48db29/{size}.png",
       },
+      in_reply_to: messages[1],
       uploads: [
         {
           extension: "png",
@@ -207,5 +212,5 @@ export const chatView = {
         },
       },
     },
-  ],
+  ]),
 };


### PR DESCRIPTION
Branch name is whack, sorry.

`in_reply_to` was being thrown out by the ember store because `in_reply_to_id` was serialized (unnecessarily). Removed and the reply-to line is rendered again.