### PR TITLE
FIX: Drop --full-page-chat-height to fix app height issue

### DIFF
--- a/assets/javascripts/discourse/components/full-page-chat.js
+++ b/assets/javascripts/discourse/components/full-page-chat.js
@@ -2,7 +2,6 @@ import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
-import { next } from "@ember/runloop";
 
 export default Component.extend({
   tagName: "",

--- a/assets/javascripts/discourse/components/full-page-chat.js
+++ b/assets/javascripts/discourse/components/full-page-chat.js
@@ -41,16 +41,13 @@ export default Component.extend({
     this._super(...arguments);
 
     this._scrollSidebarToBotton();
-    window.addEventListener("resize", this._calculateHeight, false);
     document.body.classList.add("has-full-page-chat");
     this.chat.setFullScreenChatOpenStatus(true);
-    next(this._calculateHeight);
   },
 
   willDestroyElement() {
     this._super(...arguments);
     this.appEvents.off("chat:refresh-channels", this, "refreshModel");
-    window.removeEventListener("resize", this._calculateHeight, false);
     document.body.classList.remove("has-full-page-chat");
     this.chat.setFullScreenChatOpenStatus(false);
   },
@@ -71,20 +68,6 @@ export default Component.extend({
     if (sidebarScroll) {
       sidebarScroll.scrollTop = sidebarScroll.scrollHeight;
     }
-  },
-
-  _calculateHeight() {
-    const main = document.getElementById("main-outlet"),
-      padBottom = window
-        .getComputedStyle(main, null)
-        .getPropertyValue("padding-bottom"),
-      chatContainerCoords = document
-        .querySelector(".full-page-chat")
-        .getBoundingClientRect();
-
-    const elHeight =
-      window.innerHeight - chatContainerCoords.y - parseInt(padBottom, 10) - 10;
-    document.body.style.setProperty("--full-page-chat-height", `${elHeight}px`);
   },
 
   @action

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1244,13 +1244,20 @@ $float-height: 530px;
   }
 }
 
+body.has-full-page-chat #main-outlet {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - var(--header-offset));
+}
+
 .full-page-chat {
   font-family: "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   -moz-osx-font-smoothing: grayscale;
   display: grid;
+  flex-grow: 1;
   grid-template-columns: var(--full-page-sidebar-width) 1fr;
-  grid-template-rows: var(--full-page-chat-height);
 
   .tc-channels {
     background: var(--primary-very-low);

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1245,9 +1245,11 @@ $float-height: 530px;
 }
 
 body.has-full-page-chat #main-outlet {
+  align-self: stretch;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
   height: calc(100vh - var(--header-offset));
 }
 
@@ -1258,6 +1260,7 @@ body.has-full-page-chat #main-outlet {
   display: grid;
   flex-grow: 1;
   grid-template-columns: var(--full-page-sidebar-width) 1fr;
+  min-height: 0;
 
   .tc-channels {
     background: var(--primary-very-low);

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -150,7 +150,6 @@
       border: none;
       box-shadow: none;
       grid-template-columns: 250px 1fr;
-      grid-template-rows: calc(var(--full-page-chat-height) + 10px);
     }
   }
 }


### PR DESCRIPTION
No more listening to "resize" event or manual height var calculation. The issue in the Desktop app was that the content was taller than the app window (when you had a lot of channels/personal messages)