### PR TITLE
UX: Restrict image height/width

### DIFF
--- a/assets/javascripts/discourse/components/chat-upload.js
+++ b/assets/javascripts/discourse/components/chat-upload.js
@@ -14,7 +14,7 @@ export default Component.extend({
 
   @discourseComputed("upload.width", "upload.height")
   size(width, height) {
-    var ratio = Math.min(
+    const ratio = Math.min(
       this.siteSettings.max_image_width / width,
       this.siteSettings.max_image_height / height
     );

--- a/assets/javascripts/discourse/components/chat-upload.js
+++ b/assets/javascripts/discourse/components/chat-upload.js
@@ -11,4 +11,13 @@ export default Component.extend({
       return this.IMAGE_TYPE;
     }
   },
+
+  @discourseComputed("upload.width", "upload.height")
+  size(width, height) {
+    var ratio = Math.min(
+      this.siteSettings.max_image_width / width,
+      this.siteSettings.max_image_height / height
+    );
+    return { width: width * ratio, height: height * ratio };
+  },
 });

--- a/assets/javascripts/discourse/templates/components/chat-upload.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-upload.hbs
@@ -1,5 +1,5 @@
 {{#if (eq type IMAGE_TYPE)}}
-  <img class="chat-img-upload" data-orig-src={{upload.short_url}} height={{upload.height}} width={{upload.width}}>
+  <img class="chat-img-upload" data-orig-src={{upload.short_url}} height={{size.height}} width={{size.width}}>
 {{else}}
   <a class="chat-other-upload" data-orig-href={{upload.short_url}}>{{upload.original_filename}}</a>
 {{/if}}


### PR DESCRIPTION
This restricts image height/width to the proper site settings. For posts this is done in `PostCookedProcessor` because the images are in the `cooked` content. Since uploads are rendered differently here, we can super easily fix the dimensions on the client.