### PR TITLE
Ensure space is reserved for the 'replying...' indicator

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -568,4 +568,9 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   removeUpload(upload) {
     this.uploads.removeObject(upload);
   },
+
+  @discourseComputed("uploads.[]", "inProgressUploads.[]")
+  showUploadsContainer() {
+    return this.uploads?.length > 0 || this.inProgressUploads?.length > 0;
+  },
 });

--- a/assets/javascripts/discourse/templates/components/chat-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer.hbs
@@ -67,22 +67,24 @@
   {{/if}}
 </div>
 
-<div class="chat-composer-uploads-container">
-  {{#each uploads as |upload|}}
-    {{chat-composer-upload
-      upload=upload
-      done=true
-      cancel=(action "removeUpload" upload)
-      fileName=upload.original_filename
-    }}
-  {{/each}}
+{{#if showUploadsContainer}}
+  <div class="chat-composer-uploads-container">
+    {{#each uploads as |upload|}}
+      {{chat-composer-upload
+        upload=upload
+        done=true
+        cancel=(action "removeUpload" upload)
+        fileName=upload.original_filename
+      }}
+    {{/each}}
 
-  {{#each inProgressUploads as |upload|}}
-    {{chat-composer-upload
-      upload=upload
-      cancel=(action "cancelUploading" upload)
-      fileName=upload.fileName
-    }}
-  {{/each}}
-</div>
+    {{#each inProgressUploads as |upload|}}
+      {{chat-composer-upload
+        upload=upload
+        cancel=(action "cancelUploading" upload)
+        fileName=upload.fileName
+      }}
+    {{/each}}
+  </div>
+{{/if}}
 <input type="file" id={{fileUploadElementId}} accept={{acceptedFormats}} multiple>

--- a/assets/javascripts/discourse/templates/components/chat-replying-indicator.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-replying-indicator.hbs
@@ -1,5 +1,5 @@
-{{#if shouldDisplay}}
-  <span class="replying-text">
+<span class="replying-text">
+  {{#if shouldDisplay}}
     {{text}}<span class="wave"><span class="dot">.</span><span class="dot">.</span><span class="dot">.</span></span>
-  </span>
-{{/if}}
+  {{/if}}
+</span>

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -838,7 +838,7 @@ $float-height: 530px;
   }
 
   .tc-replying-indicator {
-    padding: 0 0.75em 0.25em 0.75em;
+    padding: 0.25em 0.75em;
 
     .replying-text {
       font-size: var(--font-down-2);
@@ -1113,7 +1113,7 @@ $float-height: 530px;
 
 .chat-composer-uploads-container {
   display: flex;
-  padding: 0.5em 0.75em;
+  padding: 0.5em 0.5em 0 0.5em;
   white-space: nowrap;
   overflow-x: auto;
 


### PR DESCRIPTION
Otherwise, the UI will jump around when people start/stop replying

Partial revert of ab5117dcd645ebe2144512e224da8d6c32160a34.

To reduce the unused space, this PR hides the uploads-container div when it's empty.

<img width="431" alt="Screenshot 2021-12-06 at 17 30 57" src="https://user-images.githubusercontent.com/6270921/144893755-a127c52d-6a9f-4e2b-ad9c-f35eba130e3e.png">
<img width="422" alt="Screenshot 2021-12-06 at 17 31 09" src="https://user-images.githubusercontent.com/6270921/144893757-0fe12930-1b74-442f-9ccb-aca11fa73c1a.png">
