### PR TITLE
UX: Small CSS tweaks

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -841,6 +841,7 @@ $float-height: 530px;
   }
 
   .tc-replying-indicator {
+    color: var(--primary-medium);
     padding: 0.25em 0.75em;
 
     .replying-text {
@@ -1253,7 +1254,6 @@ $float-height: 530px;
 .full-page-chat {
   font-family: "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-  -moz-osx-font-smoothing: grayscale;
   display: grid;
   grid-template-columns: var(--full-page-sidebar-width) 1fr;
   grid-template-rows: var(--full-page-chat-height);

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -116,9 +116,10 @@
     border-radius: var(--full-page-border-radius);
     overflow: hidden;
     box-shadow: 6px 6px 0px 0px rgba(var(--primary-rgb), 0.125);
+
     .tc-channels {
       background: var(--primary-very-low);
-      border-radius: unset;
+
       .chat-channel-divider {
         padding: 1em 1em 0.5em 1em;
       }
@@ -138,6 +139,7 @@
       background-color: var(--primary-very-low);
     }
   }
+
   @media screen and (max-width: 1366px) {
     #main-outlet {
       padding: 0;
@@ -145,11 +147,16 @@
         max-width: 100%;
       }
     }
+
     .full-page-chat {
-      border-radius: 0px;
+      border-radius: 0;
       border: none;
       box-shadow: none;
       grid-template-columns: 250px 1fr;
+
+      .tc-channels {
+        border-radius: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
* Change typing indicator color to match core
* Remove a macOS-Firefox-specific property
* Fix border radius issues on desktop full-page-chat