### PR TITLE
FIX: All sorts of scroll improvements

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -276,8 +276,8 @@ export default Component.extend({
   _markLastReadMessage(opts = { reRender: false }) {
     if (opts.reRender) {
       this.messages.forEach((m) => {
-        if (m.lastRead) {
-          m.set("lastRead", false);
+        if (m.newestMessage) {
+          m.set("newestMessage", false);
         }
       });
     }
@@ -289,13 +289,18 @@ export default Component.extend({
     }
 
     this.set("lastSendReadMessageId", lastReadId);
-    let message = this.messageLookup[lastReadId] || this.messages[0];
-    if (message && message !== this.messages[this.messages.length - 1]) {
-      message.set("lastRead", true);
-      this.scrollToMessage(message.id);
-    } else {
-      this._stickScrollToBottom();
+    // let message = this.messageLookup[lastReadId] || this.messages[0];
+    const indexOfLastReadyMessage =
+      this.messages.findIndex((m) => m.id === lastReadId) || 0;
+    const newestUnreadMessage = this.messages[indexOfLastReadyMessage + 1];
+
+    if (newestUnreadMessage) {
+      newestUnreadMessage.set("newestMessage", true);
+      // We have the last read message from lookup, but now we need the index of the message,
+      // so that we can scroll to the message directly after it.
+      return this.scrollToMessage(newestUnreadMessage.id);
     }
+    this._stickScrollToBottom();
   },
 
   highlightOrFetchMessage(_, messageId) {
@@ -318,7 +323,7 @@ export default Component.extend({
     }
 
     const messageEl = this._scrollerEl.querySelector(
-      `.tc-message-${messageId}`
+      `.chat-message-${messageId}`
     );
     if (messageEl) {
       next(() => {
@@ -833,6 +838,7 @@ export default Component.extend({
     this._reportReplyingPresence(composerValue);
   },
 
+  @action
   reStickScrollIfNeeded() {
     if (this.stickyScroll) {
       this._stickScrollToBottom();

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -289,7 +289,6 @@ export default Component.extend({
     }
 
     this.set("lastSendReadMessageId", lastReadId);
-    // let message = this.messageLookup[lastReadId] || this.messages[0];
     const indexOfLastReadyMessage =
       this.messages.findIndex((m) => m.id === lastReadId) || 0;
     const newestUnreadMessage = this.messages[indexOfLastReadyMessage + 1];

--- a/assets/javascripts/discourse/components/tc-message.js
+++ b/assets/javascripts/discourse/components/tc-message.js
@@ -13,7 +13,6 @@ export default Component.extend({
   REMOVE_REACTION: "remove",
   SHOW_LEFT: "showLeft",
   SHOW_RIGHT: "showRight",
-  lastRead: false,
   isHovered: false,
   emojiPickerIsActive: false,
 
@@ -78,20 +77,26 @@ export default Component.extend({
     return hide && !webhookEvent;
   },
 
+  @discourseComputed("selectingMessages", "message.id")
+  messageContainerClasses(selecting, id) {
+    return `chat-message chat-message-${id} ${
+      selecting ? "selecting-messages" : ""
+    }`.trim();
+  },
+
   @discourseComputed(
-    "message.id",
     "message.staged",
     "message.deleted_at",
     "message.in_reply_to",
     "message.action_code",
     "isHovered"
   )
-  messageClasses(id, staged, deletedAt, inReplyTo, actionCode, isHovered) {
+  innerMessageClasses(staged, deletedAt, inReplyTo, actionCode, isHovered) {
     let classNames = ["tc-message"];
-    classNames.push(
-      staged ? "tc-message-staged" : `tc-message-${this.message.id}`
-    );
 
+    if (staged) {
+      classNames.push("tc-message-staged");
+    }
     if (actionCode) {
       classNames.push("tc-action");
       classNames.push(`tc-action-${actionCode}`);
@@ -313,6 +318,7 @@ export default Component.extend({
     }
 
     this._updateReactionsList(busData.emoji, busData.action, busData.user);
+    this.afterReactionAdded();
   },
 
   @action
@@ -324,6 +330,7 @@ export default Component.extend({
     this._loadingReactions.push(emoji);
     this._updateReactionsList(emoji, reactAction, this.currentUser);
     this._publishReaction(emoji, reactAction);
+    this.afterReactionAdded();
   },
 
   _updateReactionsList(emoji, reactAction, user) {

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -43,6 +43,7 @@
         onSelectMessage=onSelectMessage
         bulkSelectMessages=bulkSelectMessages
         fullPage=fullPage
+        afterReactionAdded=(action "reStickScrollIfNeeded")
       }}
     {{/each}}
   {{/conditional-loading-spinner}}

--- a/assets/javascripts/discourse/templates/components/tc-message.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-message.hbs
@@ -1,4 +1,13 @@
-<div class="chat-message {{if selectingMessages "selecting-messages"}}">
+<div class={{messageContainerClasses}}>
+  {{#if message.newestMessage}}
+    <div class="tc-new-messages">
+      <div class="new-message-separator"></div>
+      <span class="new-message-indicator">
+        {{i18n "chat.new_messages"}}
+      </span>
+    </div>
+  {{/if}}
+
   {{emoji-picker
     isActive=emojiPickerIsActive
     isEditorFocused=true
@@ -23,7 +32,7 @@
         }}
       </div>
     {{else}}
-      <div class={{messageClasses}}>
+      <div class={{innerMessageClasses}}>
         {{#unless message.staged}}
           <div class="tc-msgactions-hover">
             <div class="tc-msgactions">
@@ -180,14 +189,6 @@
           {{/if}}
         </div>
       </div>
-      {{#if message.lastRead}}
-        <div class="tc-new-messages">
-          <div class="new-message-separator"></div>
-          <span class="new-message-indicator">
-            {{i18n "chat.new_messages"}}
-          </span>
-        </div>
-      {{/if}}
     {{/if}}
   {{/if}}
 </div>

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -550,6 +550,7 @@ $float-height: 530px;
     background-color: var(--secondary);
     border: 1px solid var(--primary-low);
     border-radius: 0.25em;
+    z-index: 2;
 
     button {
       padding: 0.4em 0.5em;

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -342,7 +342,11 @@ acceptance("Discourse Chat - without unread", function (needs) {
     const done = assert.async();
     next(async () => {
       // Wait for DOM to rerender. Message should be un-staged
-      assert.ok(lastMessage.classList.contains("tc-message-202"));
+      assert.ok(
+        lastMessage
+          .closest(".chat-message")
+          .classList.contains("chat-message-202")
+      );
       assert.notOk(lastMessage.classList.contains("tc-message-staged"));
 
       const nextMessageContent = "What up what up!";
@@ -384,7 +388,7 @@ acceptance("Discourse Chat - without unread", function (needs) {
 
     const done = assert.async();
     next(async () => {
-      assert.ok(query(".tc-message-175 .tc-text").innerHTML.includes(cooked));
+      assert.ok(query(".chat-message-175 .tc-text").innerHTML.includes(cooked));
       done();
     });
   });


### PR DESCRIPTION
First I was tackling sticking to the bottom when new reactions come in that could force chat up. Then I started to think more about the last read message scrolling as it's a bit janky.

I realized a much better way is to add a boolean to the newest message with the indicator at the top, so that it's always scrolled perfectly, with the "New messages" line right at the top. It works much better this way.