### PR TITLE
FEATURE: Slack-compatible webhooks

### DIFF
--- a/app/controllers/incoming_chat_webhooks_controller.rb
+++ b/app/controllers/incoming_chat_webhooks_controller.rb
@@ -1,33 +1,71 @@
 # frozen_string_literal: true
 
 class DiscourseChat::IncomingChatWebhooksController < ApplicationController
+  WEBHOOK_MAX_MESSAGE_LENGTH = 1000
+  WEBHOOK_MESSAGES_PER_MINUTE_LIMIT = 10
+
   skip_before_action :verify_authenticity_token, :redirect_to_login_if_required
 
+  before_action :validate_payload
+
   def create_message
-    params.require([:key, :body])
+    hijack do
+      process_webhook_payload(text: params[:text], key: params[:key])
+    end
+  end
+
+  ##
+  # See https://api.slack.com/reference/messaging/payload for the
+  # slack message payload format. For now we only support the
+  # text param, which we preprocess lightly to remove the slack-isms
+  # in the formatting.
+  def create_message_slack_compatable
+    text = DiscourseChat::SlackCompatibility.process_text(params[:text])
 
     hijack do
-      if params[:body].length > 1000
-        raise Discourse::InvalidParameters.new("Body cannot be over 1000 characters")
-      end
-
-      webhook = IncomingChatWebhook.includes(:chat_channel).find_by(key: params[:key])
-      raise Discourse::NotFound unless webhook
-
-      # Rate limit to 10 messages per-minute. We can move to a site setting in the future if needed.
-      RateLimiter.new(nil, "incoming_chat_webhook_#{webhook.id}", 10, 1.minute).performed!
-
-      chat_message_creator = DiscourseChat::ChatMessageCreator.create(
-        chat_channel: webhook.chat_channel,
-        user: Discourse.system_user,
-        content: params[:body],
-        incoming_chat_webhook: webhook
-      )
-      if chat_message_creator.failed?
-        render_json_error(chat_message_creator.chat_message)
-      else
-        render json: success_json
-      end
+      process_webhook_payload(text: text, key: params[:key])
     end
+  end
+
+  private
+
+  def process_webhook_payload(text:, key:)
+    validate_message_length(text)
+    webhook = find_and_rate_limit_webhook(key)
+
+    chat_message_creator = DiscourseChat::ChatMessageCreator.create(
+      chat_channel: webhook.chat_channel,
+      user: Discourse.system_user,
+      content: text,
+      incoming_chat_webhook: webhook
+    )
+    if chat_message_creator.failed?
+      render_json_error(chat_message_creator.chat_message)
+    else
+      render json: success_json
+    end
+  end
+
+  def find_and_rate_limit_webhook(key)
+    webhook = IncomingChatWebhook.includes(:chat_channel).find_by(key: key)
+    raise Discourse::NotFound unless webhook
+
+    # Rate limit to 10 messages per-minute. We can move to a site setting in the future if needed.
+    RateLimiter.new(nil, "incoming_chat_webhook_#{webhook.id}", WEBHOOK_MESSAGES_PER_MINUTE_LIMIT, 1.minute).performed!
+    webhook
+  end
+
+  def validate_message_length(message)
+    raise Discourse::InvalidParameters.new("Body cannot be over 1000 characters") if message.length > WEBHOOK_MAX_MESSAGE_LENGTH
+  end
+
+  def validate_payload
+    # TODO (martin) Remove this at 2021-12-15
+    # Backwards compat. We need to replace the body param in our old integrations.
+    if params.key?(:body)
+      params[:text] = params[:body]
+    end
+
+    params.require([:key, :text])
   end
 end

--- a/lib/slack_compatibility.rb
+++ b/lib/slack_compatibility.rb
@@ -1,0 +1,46 @@
+##
+# Processes slack-formatted text messages, as Mattermost does with
+# Slack incoming webhook interopability, for example links in the
+# format <LINK> and <LINK|TEXT>, <!here> and <!all> mentions.
+#
+# See https://api.slack.com/reference/surfaces/formatting for all of
+# the different formatting slack supports with mrkdwn which is mostly
+# identical to Markdown.
+#
+# Mattermost docs for translating the slack format:
+#
+# https://docs.mattermost.com/developer/webhooks-incoming.html?highlight=translate%20slack%20data%20format%20mattermost#translate-slack-s-data-format-to-mattermost
+#
+# We may want to process attachments and blocks from slack in future, and
+# convert user IDs into user mentions.
+class DiscourseChat::SlackCompatibility
+  MRKDWN_LINK_REGEX = Regexp.new(/(<[^\n<\|>]+>|<[^\n<\>]+>)/).freeze
+
+  class << self
+    def process_text(text)
+      text = text.gsub("<!here>", "@here")
+      text = text.gsub("<!all>", "@all")
+
+      text.scan(MRKDWN_LINK_REGEX) do |match|
+        match = match.first
+
+        if match.include?("|")
+          link, title = match.split("|")[0..1]
+        else
+          link = match
+        end
+
+        title = title&.gsub(/<|>/, "")
+        link = link&.gsub(/<|>/, "")
+
+        if title
+          text = text.gsub(match, "[#{title}](#{link})")
+        else
+          text = text.gsub(match, "#{link}")
+        end
+      end
+
+      return text
+    end
+  end
+end

--- a/lib/slack_compatibility.rb
+++ b/lib/slack_compatibility.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # Processes slack-formatted text messages, as Mattermost does with
 # Slack incoming webhook interopability, for example links in the
@@ -40,7 +42,7 @@ class DiscourseChat::SlackCompatibility
         end
       end
 
-      return text
+      text
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -75,6 +75,7 @@ after_initialize do
   load File.expand_path('../lib/guardian_extensions.rb', __FILE__)
   load File.expand_path('../lib/extensions/topic_view_serializer_extension.rb', __FILE__)
   load File.expand_path('../lib/extensions/detailed_tag_serializer_extension.rb', __FILE__)
+  load File.expand_path('../lib/slack_compatibility.rb', __FILE__)
   load File.expand_path('../app/jobs/regular/process_chat_message.rb', __FILE__)
   load File.expand_path('../app/services/chat_publisher.rb', __FILE__)
 
@@ -253,6 +254,9 @@ after_initialize do
 
     # incoming_webhooks_controller routes
     post '/hooks/:key' => 'incoming_chat_webhooks#create_message'
+
+    # incoming_webhooks_controller routes
+    post '/hooks/:key/slack' => 'incoming_chat_webhooks#create_message_slack_compatable'
 
     # move_to_topic_controller routes
     resources :move_to_topic

--- a/spec/lib/slack_compatibility_spec.rb
+++ b/spec/lib/slack_compatibility_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../fabricators/chat_fabricator'
+
+describe DiscourseChat::SlackCompatibility do
+  describe "#process_text" do
+    it "converts mrkdwn links to regular markdown" do
+      text = described_class.process_text("this is some text <https://discourse.org>")
+      expect(text).to eq("this is some text https://discourse.org")
+    end
+
+    it "converts mrkdwn links with titles to regular markdown" do
+      text = described_class.process_text("this is some text <https://discourse.org|Discourse Forums>")
+      expect(text).to eq("this is some text [Discourse Forums](https://discourse.org)")
+    end
+
+    it "handles multiple links" do
+      text = described_class.process_text("this is some text <https://discourse.org|Discourse Forums> with a second link to <https://discourse.org/team>")
+      expect(text).to eq("this is some text [Discourse Forums](https://discourse.org) with a second link to https://discourse.org/team")
+    end
+
+    it "converts <!here> and <!all> to our mention format" do
+      text = described_class.process_text("<!here> this is some important stuff <!all>")
+      expect(text).to eq("@here this is some important stuff @all")
+    end
+  end
+end

--- a/spec/requests/incoming_chat_webhooks_controller_spec.rb
+++ b/spec/requests/incoming_chat_webhooks_controller_spec.rb
@@ -19,11 +19,21 @@ RSpec.describe DiscourseChat::IncomingChatWebhooksController do
     end
 
     it "errors when the body is over 1000 characters" do
-      post "/chat/hooks/#{webhook.key}.json", params: { body: "$" * 1001 }
+      post "/chat/hooks/#{webhook.key}.json", params: { text: "$" * 1001 }
       expect(response.status).to eq(400)
     end
 
     it "creates a new chat message" do
+      expect {
+        post "/chat/hooks/#{webhook.key}.json", params: { text: "A new signup woo!" }
+      }.to change { ChatMessage.where(chat_channel: chat_channel).count }.by(1)
+      expect(response.status).to eq(200)
+      chat_webhook_event = ChatWebhookEvent.last
+      expect(chat_webhook_event.incoming_chat_webhook_id).to eq(webhook.id)
+      expect(chat_webhook_event.chat_message_id).to eq(ChatMessage.last.id)
+    end
+
+    it "creates a new chat message with the old body param for backwards compat" do
       expect {
         post "/chat/hooks/#{webhook.key}.json", params: { body: "A new signup woo!" }
       }.to change { ChatMessage.where(chat_channel: chat_channel).count }.by(1)
@@ -37,12 +47,22 @@ RSpec.describe DiscourseChat::IncomingChatWebhooksController do
       RateLimiter.enable
       RateLimiter.clear_all!
       10.times do
-        post "/chat/hooks/#{webhook.key}.json", params: { body: "A new signup woo!" }
+        post "/chat/hooks/#{webhook.key}.json", params: { text: "A new signup woo!" }
       end
       expect(response.status).to eq(200)
 
-      post "/chat/hooks/#{webhook.key}.json", params: { body: "A new signup woo!" }
+      post "/chat/hooks/#{webhook.key}.json", params: { text: "A new signup woo!" }
       expect(response.status).to eq(429)
+    end
+  end
+
+  describe "#create_message_slack_compatable" do
+    it "processes the text param with SlackCompatibility" do
+      expect {
+        post "/chat/hooks/#{webhook.key}/slack.json", params: { text: "A new signup woo <!here>!" }
+      }.to change { ChatMessage.where(chat_channel: chat_channel).count }.by(1)
+      expect(response.status).to eq(200)
+      expect(ChatMessage.last.message).to eq("A new signup woo @here!")
     end
   end
 end


### PR DESCRIPTION
This commit adds support for slack-compatible webhooks, which
many other integrations already support (including Mattermost,
OpsGenie, etc.)

To use the slack compatible version of the webhook, post to
the webhook URL and append `/slack` at the end, e.g.

https://meta.discourse.org/chat/hooks/ID/slack.json

See https://api.slack.com/reference/messaging/payload for the
slack message payload format. For now we only support the
text param, which we preprocess lightly to remove the slack-isms
in the formatting.

Later on down the track we may want to process blocks, attachments,
and user mentions in the text.