### PR TITLE
DEV: Remove requires for fabricators

### DIFF
--- a/spec/components/chat_message_creator_spec.rb
+++ b/spec/components/chat_message_creator_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../fabricators/chat_fabricator'
 
 describe DiscourseChat::ChatMessageCreator do
   fab!(:admin1) { Fabricate(:admin) }

--- a/spec/components/chat_message_updater_spec.rb
+++ b/spec/components/chat_message_updater_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../fabricators/chat_fabricator'
 
 describe DiscourseChat::ChatMessageUpdater do
   fab!(:admin1) { Fabricate(:admin) }

--- a/spec/jobs/process_chat_message_spec.rb
+++ b/spec/jobs/process_chat_message_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../fabricators/chat_fabricator'
 
 describe Jobs::ProcessChatMessage do
   fab!(:chat_message) { Fabricate(:chat_message, message: "https://discourse.org/team") }

--- a/spec/models/chat_channel_spec.rb
+++ b/spec/models/chat_channel_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../fabricators/chat_fabricator'
 
 describe ChatChannel do
   fab!(:user1) { Fabricate(:user) }

--- a/spec/requests/admin/admin_incoming_chat_webhooks_controller_spec.rb
+++ b/spec/requests/admin/admin_incoming_chat_webhooks_controller_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../../fabricators/chat_fabricator'
 
 RSpec.describe DiscourseChat::AdminIncomingChatWebhooksController do
   fab!(:admin) { Fabricate(:admin) }

--- a/spec/requests/chat_channel_controller_spec.rb
+++ b/spec/requests/chat_channel_controller_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../fabricators/chat_fabricator'
 
 RSpec.describe DiscourseChat::ChatChannelsController do
   fab!(:user) { Fabricate(:user) }

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../fabricators/chat_fabricator'
 
 RSpec.describe DiscourseChat::ChatController do
   fab!(:user) { Fabricate(:user) }

--- a/spec/requests/direct_messages_controller_spec.rb
+++ b/spec/requests/direct_messages_controller_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../fabricators/chat_fabricator'
 
 RSpec.describe DiscourseChat::DirectMessagesController do
   fab!(:user) { Fabricate(:user) }

--- a/spec/requests/incoming_chat_webhooks_controller_spec.rb
+++ b/spec/requests/incoming_chat_webhooks_controller_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../fabricators/chat_fabricator'
 
 RSpec.describe DiscourseChat::IncomingChatWebhooksController do
   fab!(:chat_channel) { Fabricate(:chat_channel) }

--- a/spec/requests/move_to_topic_controller_spec.rb
+++ b/spec/requests/move_to_topic_controller_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require_relative '../fabricators/chat_fabricator'
 
 RSpec.describe DiscourseChat::MoveToTopicController do
   describe "#create" do


### PR DESCRIPTION
This is no longer needed as at https://github.com/discourse/discourse/commit/0edacbd8f7f2bf153f11fc8f7579b30ba7f368c6