### PR TITLE
FEATURE: Handle attachments for Slack webhooks

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,3 +12,6 @@ plugins:
   needs_chat_seeded:
     default: true
     hidden: true
+  chat_debug_webhook_payloads:
+    default: false
+    hidden: true

--- a/lib/slack_compatibility.rb
+++ b/lib/slack_compatibility.rb
@@ -44,5 +44,17 @@ class DiscourseChat::SlackCompatibility
 
       text
     end
+
+    # TODO: This is quite hacky and is only here to support a single
+    # attachment for our OpsGenie integration. In future we would
+    # want to iterate through this attachments array and extract
+    # things properly.
+    #
+    # See https://api.slack.com/reference/messaging/attachments for
+    # more details on what fields are here.
+    def process_legacy_attachments(attachments)
+      text = CGI.unescape(attachments[0][:fallback])
+      process_text(text)
+    end
   end
 end


### PR DESCRIPTION
Very minimal handling of the attachments part of the
slack webhook payload, to handle our OpsGenie integration,
which does not use the top-level `text` field.

This is quite barebones and needs to be expanded upon in
future. We are just using the `fallback` field for now because
it contains all the text we need from the other attachment
fields. See https://api.slack.com/reference/messaging/attachments
for more details.

Also added a SiteSetting.chat_debug_webhook_payloads setting
to drop the webhook payloads into the Rails logger when
enabled, so we can look at them in a nicer way.