### PR TITLE
FIX: Properly highlight chat messages

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -341,192 +341,196 @@ $float-height: 530px;
       }
     }
   }
-
-  .tc-message {
-    align-items: flex-start;
-    position: relative;
-    padding: 0.25em 0.5em 0.25em 0.75em;
-    background-color: var(--secondary);
-    display: flex;
-    min-width: 0;
-
-    &.tc-action {
-      background-color: var(--highlight-medium);
-    }
-    &.deleted {
-      background-color: var(--danger-medium);
-    }
+  .chat-message {
     &.highlighted {
-      background-color: var(--tertiary-low);
-    }
-    &.transition-slow {
-      transition: 2s linear background-color;
-    }
-    &.user-info-hidden {
-      .tc-meta-data {
-        display: inline-block;
-        width: var(--small-message-left-width);
-        padding-right: 0.2em;
-        vertical-align: top;
-
-        .relative-date {
-          visibility: hidden;
-        }
-      }
-
-      .tc-message-container {
-        margin-left: 0;
-      }
-
-      .tc-msgactions-hover {
-        top: -1.75em;
+      .tc-message {
+        background-color: var(--tertiary-low) !important;
       }
     }
-    &.is-reply {
-      display: grid;
-      grid-template-columns: var(--small-message-left-width) 1fr;
-      grid-template-rows: 30px auto;
-      grid-template-areas:
-        "replyto replyto"
-        "avatar message";
-      .tc-reply-display {
-        grid-area: replyto;
-        cursor: pointer;
 
-        .d-icon {
-          color: var(--primary-high);
-        }
-      }
-      .tc-avatar {
-        grid-area: avatar;
-        width: 100%;
-      }
-      .tc-message-container {
-        grid-area: message;
-        width: 100%;
-      }
-    }
-    .tc-message-container {
-      margin-left: 0.5em;
-      flex-grow: 1;
-      word-break: break-word;
-      overflow-wrap: break-word;
-    }
-
-    .tc-avatar-container {
+    .tc-message {
       align-items: flex-start;
+      position: relative;
+      padding: 0.25em 0.5em 0.25em 0.75em;
+      background-color: var(--secondary);
       display: flex;
-      cursor: pointer;
-      justify-content: center;
-      width: var(--small-message-left-width);
-    }
+      min-width: 0;
 
-    .tc-bot-indicator {
-      text-transform: uppercase;
-      padding: 0.25em;
-      background: var(--primary-low);
-      border-radius: 3px;
-      font-size: var(--font-down-2);
-      margin-left: -0.25em;
-    }
-    .tc-text {
-      display: inline-block;
-      margin: 0;
-      img {
-        max-width: 100%;
-        height: unset;
+      &.tc-action {
+        background-color: var(--highlight-medium);
       }
-      code {
+      &.deleted {
+        background-color: var(--danger-medium);
+      }
+      &.transition-slow {
+        transition: 2s linear background-color;
+      }
+      &.user-info-hidden {
+        .tc-meta-data {
+          display: inline-block;
+          width: var(--small-message-left-width);
+          padding-right: 0.2em;
+          vertical-align: top;
+
+          .relative-date {
+            visibility: hidden;
+          }
+        }
+
+        .tc-message-container {
+          margin-left: 0;
+        }
+
+        .tc-msgactions-hover {
+          top: -1.75em;
+        }
+      }
+      &.is-reply {
+        display: grid;
+        grid-template-columns: var(--small-message-left-width) 1fr;
+        grid-template-rows: 30px auto;
+        grid-template-areas:
+          "replyto replyto"
+          "avatar message";
+        .tc-reply-display {
+          grid-area: replyto;
+          cursor: pointer;
+
+          .d-icon {
+            color: var(--primary-high);
+          }
+        }
+        .tc-avatar {
+          grid-area: avatar;
+          width: 100%;
+        }
+        .tc-message-container {
+          grid-area: message;
+          width: 100%;
+        }
+      }
+      .tc-message-container {
+        margin-left: 0.5em;
+        flex-grow: 1;
+        word-break: break-word;
+        overflow-wrap: break-word;
+      }
+
+      .tc-avatar-container {
+        align-items: flex-start;
+        display: flex;
+        cursor: pointer;
+        justify-content: center;
+        width: var(--small-message-left-width);
+      }
+
+      .tc-bot-indicator {
+        text-transform: uppercase;
+        padding: 0.25em;
+        background: var(--primary-low);
+        border-radius: 3px;
+        font-size: var(--font-down-2);
+        margin-left: -0.25em;
+      }
+      .tc-text {
+        display: inline-block;
+        margin: 0;
+        img {
+          max-width: 100%;
+          height: unset;
+        }
+        code {
+          font-size: var(--font-down-1);
+        }
+        > p {
+          margin: 0.5em 0 0.5em;
+        }
+        > p:first-of-type {
+          margin: 0.1em 0;
+        }
+        > p:last-of-type {
+          margin: 0.1em 0 0.1em;
+        }
+        .tc-uploads {
+          margin-top: 1em;
+
+          .chat-img-upload,
+          .chat-other-upload {
+            margin-bottom: 1em;
+          }
+        }
+      }
+      .tc-message-edited {
+        display: inline-block;
+        color: var(--primary-medium);
         font-size: var(--font-down-1);
       }
-      > p {
-        margin: 0.5em 0 0.5em;
-      }
-      > p:first-of-type {
-        margin: 0.1em 0;
-      }
-      > p:last-of-type {
-        margin: 0.1em 0 0.1em;
-      }
-      .tc-uploads {
-        margin-top: 1em;
+      .chat-message-reaction-list {
+        position: relative;
+        margin-top: 0.25em;
+        display: flex;
+        flex-wrap: wrap;
 
-        .chat-img-upload,
-        .chat-other-upload {
-          margin-bottom: 1em;
+        .reaction-users-list {
+          position: absolute;
+          top: -2px;
+          transform: translateY(-100%);
+          border: 1px solid var(--primary-low);
+          border-radius: 6px;
+          padding: 0.5em;
+          background: var(--primary-very-low);
+          max-width: 300px;
+          z-index: 3;
         }
-      }
-    }
-    .tc-message-edited {
-      display: inline-block;
-      color: var(--primary-medium);
-      font-size: var(--font-down-1);
-    }
-    .chat-message-reaction-list {
-      position: relative;
-      margin-top: 0.25em;
-      display: flex;
-      flex-wrap: wrap;
 
-      .reaction-users-list {
-        position: absolute;
-        top: -2px;
-        transform: translateY(-100%);
-        border: 1px solid var(--primary-low);
-        border-radius: 6px;
-        padding: 0.5em;
-        background: var(--primary-very-low);
-        max-width: 300px;
-        z-index: 3;
-      }
+        .chat-message-reaction {
+          display: inline-flex;
+          padding: 0.3em 0.6em;
+          margin: 1px 0.25em 1px 0;
+          font-size: var(--font-down-2);
+          border-radius: 4px;
+          border: 1px solid var(--primary-low);
+          background: transparent;
+          cursor: pointer;
+          user-select: none;
+          transition: background 0.2s;
 
-      .chat-message-reaction {
-        display: inline-flex;
-        padding: 0.3em 0.6em;
-        margin: 1px 0.25em 1px 0;
-        font-size: var(--font-down-2);
-        border-radius: 4px;
-        border: 1px solid var(--primary-low);
-        background: transparent;
-        cursor: pointer;
-        user-select: none;
-        transition: background 0.2s;
+          &:not(.reacted) {
+            &:hover {
+              background: var(--primary-low);
+            }
+          }
+          &:not(.show) {
+            display: none;
+          }
+          &.reacted {
+            border-color: var(--tertiary);
+            background: rgba(var(--tertiary-rgb), 0.2);
+          }
 
-        &:not(.reacted) {
+          .emoji {
+            height: 15px;
+            margin-right: 4px;
+            width: auto;
+          }
+        }
+        .chat-message-react-btn {
+          vertical-align: top;
+          padding: 0em 0.25em;
+          background: none;
+          border: none;
+
           &:hover {
-            background: var(--primary-low);
-          }
-        }
-        &:not(.show) {
-          display: none;
-        }
-        &.reacted {
-          border-color: var(--tertiary);
-          background: rgba(var(--tertiary-rgb), 0.2);
-        }
-
-        .emoji {
-          height: 15px;
-          margin-right: 4px;
-          width: auto;
-        }
-      }
-      .chat-message-react-btn {
-        vertical-align: top;
-        padding: 0em 0.25em;
-        background: none;
-        border: none;
-
-        &:hover {
-          .d-icon {
-            color: var(--primary);
+            .d-icon {
+              color: var(--primary);
+            }
           }
         }
       }
-    }
-    .tc-send-error {
-      text-align: center;
-      color: var(--danger-medium);
+      .tc-send-error {
+        text-align: center;
+        color: var(--danger-medium);
+      }
     }
   }
 
@@ -1307,9 +1311,6 @@ $float-height: 530px;
   .tc-messages-scroll,
   .tc-message {
     background: var(--primary-very-low);
-    &.highlighted {
-      background-color: var(--tertiary-low);
-    }
   }
   .tc-live-pane {
     box-sizing: border-box;


### PR DESCRIPTION
I know important is bad, but it's IMPORTANT! We have the background color set to various things (in widget or in full-screen), and then we have hover background color, but we waant to always ignore all of that and show the highlight when it should be there.