### PR TITLE
FEATURE: Client-side per-channel drafts

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -456,20 +456,23 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
     );
   },
 
-  @discourseComputed("loading", "previewing")
-  inputDisabled(loading, previewing) {
-    return loading || previewing;
-  },
-
   @discourseComputed(
     "value",
-    "inputDisabled",
+    "loading",
+    "previewing",
     "uploads.@each",
     "uploading",
     "processingUpload"
   )
-  sendDisabled(value, inputDisabled, uploads, uploading, processingUpload) {
-    if (inputDisabled || uploading || processingUpload) {
+  sendDisabled(
+    value,
+    loading,
+    previewing,
+    uploads,
+    uploading,
+    processingUpload
+  ) {
+    if (loading || previewing || uploading || processingUpload) {
       return true;
     }
 

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -32,6 +32,8 @@ export function addChatToolbarButton(toolbarButton) {
 }
 
 export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
+  chat: service(),
+  chatChannel: null,
   classNames: ["tc-composer"],
   emojiStore: service("emoji-store"),
   editingMessage: null,
@@ -164,6 +166,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
 
   _insertUpload(_, upload) {
     this.uploads.pushObject(upload);
+    this.onValueChange(this.value, this.uploads);
   },
 
   keyDown(event) {
@@ -216,6 +219,13 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
 
   didReceiveAttrs() {
     this._super(...arguments);
+    if (!this.editingMessage && !this.replyToMsg) {
+      const draft = this.draft?.value || this.draft?.uploads?.length ?
+        this.draft : { value: "", uploads: [] }
+      console.log(draft)
+      this.setProperties(draft);
+    }
+
 
     if (this.editingMessage) {
       this.setProperties({
@@ -239,7 +249,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
       () => {
         this._resizeTextArea();
         this._applyUserAutocomplete();
-        this.onValueChange(value);
+        this.onValueChange(value, this.uploads);
       },
       THROTTLE_MS
     );
@@ -542,11 +552,6 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   },
 
   @action
-  cancelUploads() {
-    this.set("uploadCancelled", true);
-  },
-
-  @action
   toggleToolbar() {
     this.set("showToolbar", !this.showToolbar);
     if (this.showToolbar) {
@@ -562,6 +567,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
     this.appEvents.trigger(`${this.eventPrefix}:cancel-upload`, {
       fileId: upload.id,
     });
+    this.onValueChange(this.value, this.uploads);
   },
 
   @action

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -219,10 +219,10 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
 
   didReceiveAttrs() {
     this._super(...arguments);
+
     if (!this.editingMessage && !this.replyToMsg && this.draft) {
       this.setProperties(this.draft);
     }
-
 
     if (this.editingMessage) {
       this.setProperties({
@@ -457,14 +457,20 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
     );
   },
 
-  @discourseComputed("isUploading", "isProcessingUpload", "previewing")
-  inputDisabled(uploading, processingUpload, previewing) {
-    return uploading || processingUpload || previewing;
+  @discourseComputed("loading", "previewing")
+  inputDisabled(loading, previewing) {
+    return loading || previewing;
   },
 
-  @discourseComputed("value", "loading")
-  sendDisabled(value, loading) {
-    if (this.inputDisabled || loading) {
+  @discourseComputed(
+    "value",
+    "inputDisabled",
+    "uploads.@each",
+    "uploading",
+    "processingUpload"
+  )
+  sendDisabled(value, inputDisabled, uploads, uploading, processingUpload) {
+    if (inputDisabled || uploading || processingUpload) {
       return true;
     }
 
@@ -514,13 +520,18 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   reset() {
     this.set("value", "");
     this.set("uploads", []);
-    this.onCancelEditing();
     this._focusTextArea({ ensureAtEnd: true, resizeTextArea: true });
   },
 
   @action
   cancelReplyTo() {
     this.set("replyToMsg", null);
+  },
+
+  @action
+  cancelEditing() {
+    this.onCancelEditing();
+    this._focusTextArea({ ensureAtEnd: true, resizeTextArea: true });
   },
 
   @discourseComputed()

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -219,11 +219,8 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
 
   didReceiveAttrs() {
     this._super(...arguments);
-    if (!this.editingMessage && !this.replyToMsg) {
-      const draft = this.draft?.value || this.draft?.uploads?.length ?
-        this.draft : { value: "", uploads: [] }
-      console.log(draft)
-      this.setProperties(draft);
+    if (!this.editingMessage && !this.replyToMsg && this.draft) {
+      this.setProperties(this.draft);
     }
 
 

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -33,7 +33,6 @@ export function addChatToolbarButton(toolbarButton) {
 
 export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   chat: service(),
-  chatChannel: null,
   classNames: ["tc-composer"],
   emojiStore: service("emoji-store"),
   editingMessage: null,

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -121,6 +121,7 @@ export default Component.extend({
 
       if (this.chatChannel.id != null) {
         this.fetchMessages();
+        this.getDraftForChannel()
       }
     }
   },
@@ -160,6 +161,10 @@ export default Component.extend({
           this.set("loading", false);
         });
     });
+  },
+
+  getDraftForChannel() {
+    this.set('draft', this.chat.getDraftForChannel(this.chatChannel.id) || { value: "", uploads: [] })
   },
 
   _fetchMorePastMessages() {
@@ -634,6 +639,9 @@ export default Component.extend({
       return;
     }
     this.set("sendingloading", true);
+    this.chat.setDraftForChannel(this.chatChannel.id, null);
+    this.set("draft", null)
+
     this.set("_nextStagedMessageId", this._nextStagedMessageId + 1);
     const cooked = this.cook(message);
     const stagedId = this._nextStagedMessageId;
@@ -839,8 +847,9 @@ export default Component.extend({
   },
 
   @action
-  composerValueChanged(composerValue) {
-    this._reportReplyingPresence(composerValue);
+  composerValueChanged(value, uploads) {
+    this.chat.setDraftForChannel(this.chatChannel.id, { value, uploads });
+    this._reportReplyingPresence(value);
   },
 
   @action

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -165,13 +165,7 @@ export default Component.extend({
   },
 
   loadDraftForChannel() {
-    this.set(
-      "draft",
-      this.chat.getDraftForChannel(this.chatChannel.id) || {
-        value: "",
-        uploads: [],
-      }
-    );
+    this.set("draft", this.chat.getDraftForChannel(this.chatChannel.id));
   },
 
   _fetchMorePastMessages() {

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -121,7 +121,7 @@ export default Component.extend({
 
       if (this.chatChannel.id != null) {
         this.fetchMessages();
-        this.getDraftForChannel()
+        this.loadDraftForChannel();
       }
     }
   },
@@ -164,8 +164,14 @@ export default Component.extend({
     });
   },
 
-  getDraftForChannel() {
-    this.set('draft', this.chat.getDraftForChannel(this.chatChannel.id) || { value: "", uploads: [] })
+  loadDraftForChannel() {
+    this.set(
+      "draft",
+      this.chat.getDraftForChannel(this.chatChannel.id) || {
+        value: "",
+        uploads: [],
+      }
+    );
   },
 
   _fetchMorePastMessages() {
@@ -640,8 +646,7 @@ export default Component.extend({
       return;
     }
     this.set("sendingloading", true);
-    this.chat.setDraftForChannel(this.chatChannel.id, null);
-    this.set("draft", null)
+    this._setDraftForChannel(null);
 
     this.set("_nextStagedMessageId", this._nextStagedMessageId + 1);
     const cooked = this.cook(message);
@@ -841,15 +846,20 @@ export default Component.extend({
 
   @action
   cancelEditing() {
-    this.setProperties({
-      editingMessage: null,
-      value: "",
-    });
+    this.set("editingMessage", null);
+  },
+
+  @action
+  _setDraftForChannel(draft) {
+    this.chat.setDraftForChannel(this.chatChannel.id, draft);
+    this.set("draft", draft);
   },
 
   @action
   composerValueChanged(value, uploads) {
-    this.chat.setDraftForChannel(this.chatChannel.id, { value, uploads });
+    if (!this.editingMessage) {
+      this._setDraftForChannel({ value, uploads });
+    }
     this._reportReplyingPresence(value);
   },
 

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -24,6 +24,7 @@ export default Service.extend({
   chatOpen: false,
   chatNotificationManager: service(),
   cook: null,
+  drafts: null,
   directMessageChannels: null,
   hasFetchedChannels: false,
   hasUnreadPublicMessages: false,
@@ -43,7 +44,10 @@ export default Service.extend({
     this._super(...arguments);
 
     if (this.currentUser?.has_chat_enabled) {
-      this.set("allChannels", []);
+      this.setProperties({
+        allChannels: [],
+        drafts: {},
+      });
       this._subscribeToNewDmChannelUpdates();
       this._subscribeToUserTrackingChannel();
       this.presenceChannel = this.presence.getChannel("/chat/online");
@@ -55,7 +59,10 @@ export default Service.extend({
   willDestroy() {
     this._super(...arguments);
     if (this.currentUser?.has_chat_enabled) {
-      this.set("allChannels", null);
+      this.setProperties({
+        allChannels: null,
+        drafts: null,
+      });
       this._unsubscribeFromNewDmChannelUpdates();
       this._unsubscribeFromUserTrackingChannel();
       this._unsubscribeFromAllChatChannels();
@@ -577,6 +584,14 @@ export default Service.extend({
       chatable_type: channel.chatable_type,
       chat_message_id: channel.last_read_message_id,
     };
+  },
+
+  setDraftForChannel(channelId, draft) {
+    this.drafts[channelId] = draft
+  },
+
+  getDraftForChannel(channelId) {
+    return this.drafts[channelId];
   },
 
   addToolbarButton(toolbarButton) {

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -45,7 +45,8 @@ export default Service.extend({
     this._super(...arguments);
 
     if (this.currentUser?.has_chat_enabled) {
-      this.set("allChannels", []), this._subscribeToNewDmChannelUpdates();
+      this.set("allChannels", []);
+      this._subscribeToNewDmChannelUpdates();
       this._subscribeToUserTrackingChannel();
       this.appEvents.on("page:changed", this, "_storeLastNonChatRouteInfo");
       this.appEvents.on("modal:closed", this, "_onSettingsModalClosed");
@@ -57,7 +58,8 @@ export default Service.extend({
   willDestroy() {
     this._super(...arguments);
     if (this.currentUser?.has_chat_enabled) {
-      this.set("allChannels", null), this._unsubscribeFromNewDmChannelUpdates();
+      this.set("allChannels", null);
+      this._unsubscribeFromNewDmChannelUpdates();
       this._unsubscribeFromUserTrackingChannel();
       this._unsubscribeFromAllChatChannels();
       this.appEvents.off("page:changed", this, "_storeLastNonChatRouteInfo");

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -587,7 +587,7 @@ export default Service.extend({
   },
 
   setDraftForChannel(channelId, draft) {
-    this.drafts[channelId] = draft
+    this.drafts[channelId] = draft;
   },
 
   getDraftForChannel(channelId) {

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -1,4 +1,5 @@
 import EmberObject from "@ember/object";
+import KeyValueStore from "discourse/lib/key-value-store";
 import Service, { inject as service } from "@ember/service";
 import Site from "discourse/models/site";
 import { addChatToolbarButton } from "discourse/plugins/discourse-chat/discourse/components/chat-composer";
@@ -13,6 +14,7 @@ import simpleCategoryHashMentionTransform from "discourse/plugins/discourse-chat
 export const LIST_VIEW = "list_view";
 export const CHAT_VIEW = "chat_view";
 
+const DRAFT_STORE_NAMESPACE = "discourse_chat_drafts_";
 const CHAT_ONLINE_OPTIONS = {
   userUnseenTime: 60000, // 60 seconds with no interaction
   browserHiddenTime: 60000, // Or the browser has been in the background for 60 seconds
@@ -24,7 +26,6 @@ export default Service.extend({
   chatOpen: false,
   chatNotificationManager: service(),
   cook: null,
-  drafts: null,
   directMessageChannels: null,
   hasFetchedChannels: false,
   hasUnreadPublicMessages: false,
@@ -44,26 +45,19 @@ export default Service.extend({
     this._super(...arguments);
 
     if (this.currentUser?.has_chat_enabled) {
-      this.setProperties({
-        allChannels: [],
-        drafts: {},
-      });
-      this._subscribeToNewDmChannelUpdates();
+      this.set("allChannels", []), this._subscribeToNewDmChannelUpdates();
       this._subscribeToUserTrackingChannel();
-      this.presenceChannel = this.presence.getChannel("/chat/online");
       this.appEvents.on("page:changed", this, "_storeLastNonChatRouteInfo");
       this.appEvents.on("modal:closed", this, "_onSettingsModalClosed");
+      this.presenceChannel = this.presence.getChannel("/chat/online");
+      this._draftStore = new KeyValueStore(DRAFT_STORE_NAMESPACE);
     }
   },
 
   willDestroy() {
     this._super(...arguments);
     if (this.currentUser?.has_chat_enabled) {
-      this.setProperties({
-        allChannels: null,
-        drafts: null,
-      });
-      this._unsubscribeFromNewDmChannelUpdates();
+      this.set("allChannels", null), this._unsubscribeFromNewDmChannelUpdates();
       this._unsubscribeFromUserTrackingChannel();
       this._unsubscribeFromAllChatChannels();
       this.appEvents.off("page:changed", this, "_storeLastNonChatRouteInfo");
@@ -587,11 +581,11 @@ export default Service.extend({
   },
 
   setDraftForChannel(channelId, draft) {
-    this.drafts[channelId] = draft;
+    this._draftStore.setObject({ key: channelId, value: draft });
   },
 
   getDraftForChannel(channelId) {
-    return this.drafts[channelId];
+    return this._draftStore.getObject(channelId) || { value: "", uploads: [] };
   },
 
   addToolbarButton(toolbarButton) {

--- a/assets/javascripts/discourse/templates/components/chat-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer.hbs
@@ -35,7 +35,7 @@
     input=(action "onTextareaInput" value="target.value")
     type="text"
     class="tc-composer-input"
-    disabled=inputDisabled
+    disabled=previewing
     autocorrect="on"
     autocapitalize="off"
     placeholder=placeholder

--- a/assets/javascripts/discourse/templates/components/chat-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer.hbs
@@ -10,7 +10,7 @@
   {{chat-composer-message-details
     message=editingMessage
     icon="pencil-alt"
-    action=(action "reset")
+    action=(action "cancelEditing")
     title="chat.reply_edit"
   }}
 {{/if}}

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -83,6 +83,7 @@
     </div>
   {{else}}
     {{chat-composer
+      draft=draft
       sendMessage=(action "sendMessage")
       editMessage=(action "editMessage")
       setReplyTo=(action "setReplyTo")

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -458,6 +458,34 @@ acceptance("Discourse Chat - without unread", function (needs) {
     );
   });
 
+  test("Drafts are saved and reloaded", async function (assert) {
+    await visit("/chat/channel/9/Site");
+    await fillIn(".tc-composer-input", "Hi people");
+
+    await visit("/chat/channel/75/@hawk");
+    assert.equal(query(".tc-composer-input").value.trim(), "");
+    await fillIn(".tc-composer-input", "What up what up");
+
+    await visit("/chat/channel/9/Site");
+    assert.equal(query(".tc-composer-input").value.trim(), "Hi people");
+    await fillIn(".tc-composer-input", "");
+
+    await visit("/chat/channel/75/@hawk");
+    assert.equal(query(".tc-composer-input").value.trim(), "What up what up");
+
+    // Send a message
+    const composerTextarea = query(".tc-composer-input");
+    await focus(composerTextarea);
+    await triggerKeyEvent(composerTextarea, "keydown", 13); // 13 is enter keycode
+
+    assert.equal(query(".tc-composer-input").value.trim(), "");
+
+    // Navigate away and back to make sure input didn't re-fill
+    await visit("/chat/channel/9/Site");
+    await visit("/chat/channel/75/@hawk");
+    assert.equal(query(".tc-composer-input").value.trim(), "");
+  });
+
   test("Unread indicator increments for public channels when messages come in", async function (assert) {
     await visit("/t/internationalization-localization/280");
     assert.notOk(


### PR DESCRIPTION
Very simple implementation: store text/uploads in a `drafts` object in the chat service, with the channel ID as the key. When a new chat channel is opened, load the draft into the composer, and keep it updated while the user inputs text/uploads/sends messages.

Coolest thing about this is if you are typing in the widget and expand into full page, your uploads/text will still be there :)

Oh also, this make the composer textarea **not-** disabled when uploads are processing. That was old logic when the uploads went into markdown