### PR TITLE
FIX: Escape while editing message calls correct func

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -209,7 +209,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
       } else if (this.editingMessage) {
         event.preventDefault();
         this.set("replyToMsg", null);
-        this.reset();
+        this.cancelEditing();
       } else {
         this._textarea.blur();
       }

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -202,7 +202,8 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
       this.onEditLastMessageRequested();
     }
 
-    if (event.code === "Escape") {
+    if (event.keyCode === 27) {
+      // keyCode for 'Escape'
       if (this.replyToMsg) {
         event.preventDefault();
         this.set("replyToMsg", null);

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -488,13 +488,12 @@ acceptance("Discourse Chat - without unread", function (needs) {
 
   test("Pressing escape cancels editing", async function (assert) {
     await visit("/chat/channel/9/Site");
-    const chatMessage = query(".chat-message");
-    await click(chatMessage.querySelector(".edit-btn"));
-    assert.ok(query(".tc-composer .tc-composer-message-details"));
+    await click(".chat-message .edit-btn");
+    assert.ok(exists(".tc-composer .tc-composer-message-details"));
     await triggerKeyEvent(".tc-composer", "keydown", 27); // 27 is escape
 
     // tc-composer-message-details will be gone as no message is being edited
-    assert.notOk(query(".tc-composer .tc-composer-message-details"));
+    assert.notOk(exists(".tc-composer .tc-composer-message-details"));
   });
 
   test("Unread indicator increments for public channels when messages come in", async function (assert) {

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -486,6 +486,17 @@ acceptance("Discourse Chat - without unread", function (needs) {
     assert.equal(query(".tc-composer-input").value.trim(), "");
   });
 
+  test("Pressing escape cancels editing", async function (assert) {
+    await visit("/chat/channel/9/Site");
+    const chatMessage = query(".chat-message");
+    await click(chatMessage.querySelector(".edit-btn"));
+    assert.ok(query(".tc-composer .tc-composer-message-details"));
+    await triggerKeyEvent(".tc-composer", "keydown", 27); // 27 is escape
+
+    // tc-composer-message-details will be gone as no message is being edited
+    assert.notOk(query(".tc-composer .tc-composer-message-details"));
+  });
+
   test("Unread indicator increments for public channels when messages come in", async function (assert) {
     await visit("/t/internationalization-localization/280");
     assert.notOk(


### PR DESCRIPTION
I changed the behavior of reset and forgot to switch this usage of `reset` to the new function `cancelEditing`