### PR TITLE
UX: Don't do the ugly text bounce on edit

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -493,16 +493,12 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
 
   @action
   internalSendMessage() {
-    if (this._messageIsValid()) {
-      return this.sendMessage(this.value, this.uploads).then(() =>
-        this.reset()
-      );
-    }
+    return this.sendMessage(this.value, this.uploads).then(this.reset);
   },
 
   @action
   internalEditMessage() {
-    this.editMessage(this.editingMessage, this.value, this.uploads).then(
+    return this.editMessage(this.editingMessage, this.value, this.uploads).then(
       this.reset
     );
   },

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -224,7 +224,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
       this.setProperties(this.draft);
     }
 
-    if (this.editingMessage) {
+    if (this.editingMessage && !this.loading) {
       this.setProperties({
         replyToMsg: null,
         value: this.editingMessage.message,
@@ -502,13 +502,9 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
 
   @action
   internalEditMessage() {
-    if (this._messageIsValid()) {
-      return this.editMessage(
-        this.editingMessage,
-        this.value,
-        this.uploads
-      ).then(() => this.reset());
-    }
+    this.editMessage(this.editingMessage, this.value, this.uploads).then(
+      this.reset
+    );
   },
 
   _messageIsValid() {


### PR DESCRIPTION
There was also a double check for if the `messageIsValid` for both `internalEditMessage` and `internalSendMessage` (they're both called after the verifications)