### PR TITLE
Capitalize chat title.

### DIFF
--- a/assets/javascripts/discourse/templates/components/category-chat-settings.hbs
+++ b/assets/javascripts/discourse/templates/components/category-chat-settings.hbs
@@ -1,5 +1,5 @@
 {{#if siteSettings.chat_enabled}}
-  <h3>{{i18n "chat.title"}}</h3>
+  <h3>{{i18n "chat.title_capitalized"}}</h3>
   <section class="field">
     <label class="checkbox-label">
       {{input


### PR DESCRIPTION
https://dev.discourse.org/t/incorrect-capitalization-in-chat-category-extension/57436