### PR TITLE
FEATURE: hold back on emoji autocomplete

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -341,7 +341,16 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
           const full = `:${term}`;
           term = term.toLowerCase();
 
-          if (term.length < this.siteSettings.emoji_autocomplete_min_chars) {
+          // We need to avoid quick emoji autocomplete cause it can interfere with quick
+          // typing, set minimal length to 2
+          let minLength = Math.max(this.siteSettings.emoji_autocomplete_min_chars, 2);
+
+          if (term.length < minLength) {
+            return resolve(SKIP);
+          }
+
+          // bypass :-p and other common typed smileys
+          if (!term.match(/[^-\{\}\[\]\(\)\*_\<\>\\\/].*[^-\{\}\[\]\(\)\*_\<\>\\\/]/)) {
             return resolve(SKIP);
           }
 

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -343,14 +343,21 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
 
           // We need to avoid quick emoji autocomplete cause it can interfere with quick
           // typing, set minimal length to 2
-          let minLength = Math.max(this.siteSettings.emoji_autocomplete_min_chars, 2);
+          let minLength = Math.max(
+            this.siteSettings.emoji_autocomplete_min_chars,
+            2
+          );
 
           if (term.length < minLength) {
             return resolve(SKIP);
           }
 
           // bypass :-p and other common typed smileys
-          if (!term.match(/[^-\{\}\[\]\(\)\*_\<\>\\\/].*[^-\{\}\[\]\(\)\*_\<\>\\\/]/)) {
+          if (
+            !term.match(
+              /[^-\{\}\[\]\(\)\*_\<\>\\\/].*[^-\{\}\[\]\(\)\*_\<\>\\\/]/
+            )
+          ) {
             return resolve(SKIP);
           }
 


### PR DESCRIPTION
In chat since "ENTER" submits a message we need to be a bit more protective
of autocomplete dialog.

Hold off for at least 2 chars and avoid autocomplete unless there are 2 non
symbol letters, this catches most commonly typed word emojis
