### PR TITLE
FIX: Attempt to fix the sporadic defocusing problem

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -127,6 +127,10 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
     this._applyEmojiAutocomplete(this._$textarea);
     this._bindUploadTarget();
 
+    if (!this.site.mobileView) {
+      this._focusTextArea();
+    }
+
     this.appEvents.on(
       `${this.eventPrefix}:upload-success`,
       this,
@@ -154,13 +158,6 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
       this,
       "_insertUpload"
     );
-  },
-
-  didRender() {
-    this._super(...arguments);
-    if (this._messageIsEmpty() && !this.site.mobileView) {
-      this._focusTextArea();
-    }
   },
 
   _insertUpload(_, upload) {
@@ -432,7 +429,6 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
         return;
       }
 
-      this._textarea.blur();
       this._textarea.focus();
 
       if (opts.resizeTextArea) {


### PR DESCRIPTION
- Remove the `.blur()` immediately before `.focus()`
- Move the `_focusTextArea()` call from `didRender` to `didInsertElement`
- Remove the `_messageIsEmpty` check from this call. IMO we still want to focus, even if there's a draft message in the textarea.