### PR TITLE
UX: Render emojis in reply-to and bot emoji

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-composer-message-details.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer-message-details.hbs
@@ -3,7 +3,7 @@
     {{d-icon icon}}
     <span class="tc-reply-av">{{avatar message.user imageSize="tiny"}}</span>
     <span class="tc-reply-username">{{message.user.username}}</span>
-    <span class="tc-reply-msg">{{html-safe message.excerpt}}</span>
+    <span class="tc-reply-msg">{{replace-emoji message.excerpt}}</span>
   </div>
 
   {{flat-button

--- a/assets/javascripts/discourse/templates/components/tc-message.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-message.hbs
@@ -104,10 +104,14 @@
           <div role="button" onclick={{action "viewReply"}} class="tc-reply-display">
             {{d-icon "share" title="chat.in_reply_to"}}
             <span class="tc-reply-av">
-              {{avatar message.in_reply_to.user imageSize="tiny"}}
+              {{#if message.in_reply_to.chat_webhook_event.emoji}}
+                {{replace-emoji message.in_reply_to.chat_webhook_event.emoji}}
+              {{else}}
+                {{avatar message.in_reply_to.user imageSize="tiny"}}
+              {{/if}}
             </span>
             <span class="tc-reply-msg">
-              {{html-safe message.in_reply_to.excerpt}}
+              {{replace-emoji message.in_reply_to.excerpt}}
             </span>
           </div>
         {{/if}}


### PR DESCRIPTION
Currently chat bot emojis are not rendered in the reply-to line, and the system icon is rendered. This fixes that, as well as rendering emojis in reply-to line, as well as composer edit/reply line.