### PR TITLE
FIX: Don't preventDefault on notification click

### DIFF
--- a/assets/javascripts/discourse/widgets/chat-mention-notification-item.js
+++ b/assets/javascripts/discourse/widgets/chat-mention-notification-item.js
@@ -36,7 +36,6 @@ createWidgetFrom(DefaultNotificationItem, "chat-mention-notification-item", {
     const id = this.attrs.id;
     setTransientHeader("Discourse-Clear-Notifications", id);
     cookie("cn", id, { path: getURL("/") });
-    e.preventDefault();
     this.sendWidgetEvent("linkClicked");
     this.chat.openChannelAtMessage(
       this.attrs.data.chat_channel_id,

--- a/assets/javascripts/discourse/widgets/chat-mention-notification-item.js
+++ b/assets/javascripts/discourse/widgets/chat-mention-notification-item.js
@@ -31,7 +31,7 @@ createWidgetFrom(DefaultNotificationItem, "chat-mention-notification-item", {
     return h("a", { attributes: { title } }, contents);
   },
 
-  click(e) {
+  click() {
     this.attrs.set("read", true);
     const id = this.attrs.id;
     setTransientHeader("Discourse-Clear-Notifications", id);


### PR DESCRIPTION
This is a bit of an optimistic fix, as I can't reproduce the issue locally, but on dev if you click a mention notification, the parent widget isn't re-rendering properly and I believe this will fix it
