### PR TITLE
FIX: Use `tertiary` color as background for highlighted mentions

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -457,8 +457,8 @@ $float-height: 530px;
         }
       }
       .mention.highlighted {
-        background: var(--highlight);
-        color: var(--primary-high-or-secondary-low);
+        background: var(--tertiary-low);
+        color: var(--primary-very-high);
       }
     }
     .tc-message-edited {


### PR DESCRIPTION
The `highlight` color for the background and `primary-high` for the text color don't fill too well on dark themes. `tertiary` with `primary-very-high` look a lot better:

![image](https://user-images.githubusercontent.com/17474474/145468221-a34d68d6-1636-4662-bdb4-d52aaf9beefc.png)
