### PR TITLE
FEATURE: Wait 5 seconds to send notifications, to make sure user hasn't read

### DIFF
--- a/app/jobs/regular/send_chat_notifications.rb
+++ b/app/jobs/regular/send_chat_notifications.rb
@@ -8,8 +8,7 @@ module Jobs
       return unless [:new, :edit].include?(args[:type])
 
       @chat_message = ChatMessage.includes(:user, chat_channel: :chatable).find_by(id: args[:chat_message_id])
-      return if @chat_message.nil?
-      return if @chat_message.revisions.where("created_at > ?", args[:timestamp]).any?
+      return if @chat_message.nil? || @chat_message.revisions.where("created_at > ?", args[:timestamp]).any?
 
       @chat_channel = @chat_message.chat_channel
       @user = @chat_message.user

--- a/app/jobs/regular/send_chat_notifications.rb
+++ b/app/jobs/regular/send_chat_notifications.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+module Jobs
+  class SendChatNotifications < ::Jobs::Base
+    MENTION_REGEX = /\@\w+/
+
+    def execute(args = {})
+      return unless validate_args(args)
+
+      @chat_message = ChatMessage.includes(:user, chat_channel: :chatable).find_by(id: args[:chat_message_id])
+      return if @chat_message.nil?
+
+      @chat_channel = @chat_message.chat_channel
+      @user = @chat_message.user
+
+      if args[:type] == :new
+        mentioned_user_ids = create_mention_notifications
+        notify_watching_users(except: [@user.id] + mentioned_user_ids)
+      elsif args[:type] == :edit
+        update_mention_notifications
+      end
+
+    end
+
+    private
+
+    def validate_args(args)
+      return false unless [:new, :edit].include?(args[:type])
+
+      true
+    end
+
+    def update_mention_notifications
+      existing_notifications = Notification
+        .where(notification_type: Notification.types[:chat_mention])
+        .where("data LIKE ?", "%\"chat_message_id\":#{@chat_message.id}%")
+
+      already_notified_user_ids = existing_notifications.map(&:user_id)
+      mentioned_user_ids = mentioned_users.map(&:id)
+
+      needs_deletion = already_notified_user_ids - mentioned_user_ids
+      needs_deletion.each do |user_id|
+        notification = existing_notifications.detect { |n| n.user_id == user_id }
+        notification.destroy!
+      end
+
+      needs_notification_ids = mentioned_user_ids - already_notified_user_ids
+      return unless needs_notification_ids.present?
+
+      needs_notification = User
+        .includes(:do_not_disturb_timings, :user_chat_channel_memberships)
+        .where(id: needs_notification_ids)
+      needs_notification.each { |target_user|
+        guardian = Guardian.new(target_user)
+        if guardian.can_chat?(target_user) && guardian.can_see_chat_channel?(@chat_channel)
+          create_mention_notification_for_user(target_user)
+        end
+      }
+    end
+
+    def create_mention_notifications
+      mentioned_user_ids = []
+      mentioned_users.each do |target_user|
+        create_mention_notification_for_user(target_user)
+        mentioned_user_ids.push(target_user.id)
+        ChatPublisher.publish_new_mention(target_user, @chat_channel.id, @chat_message.id)
+      end
+      mentioned_user_ids
+    end
+
+    def mentioned_users
+      @mentioned_users ||= begin
+        mention_matches = @chat_message.message.scan(MENTION_REGEX)
+        if mention_matches.include?("@all")
+          users = users_for_channel(exclude: @user.username)
+        else
+          users = mention_matches.include?("@here") ?
+            users_here(mention_matches) :
+            users_for_channel(
+              exclude: @user.username,
+              usernames: mention_matches.map { |match| match[1..-1] }
+            )
+        end
+        filter_users_who_can_chat(users)
+      end
+    end
+
+    def users_here(mention_matches)
+      users = users_for_channel(exclude: @user.username).where("last_seen_at > ?", 5.minutes.ago)
+      usernames = users.map(&:username)
+      other_mentioned_usernames = mention_matches
+        .map { |match| match[1..-1] }
+        .reject { |username| username == "here" || usernames.include?(username) }
+      if other_mentioned_usernames.any?
+        users = users.or(
+          users_for_channel(
+            exclude: @user.username,
+            usernames: other_mentioned_usernames
+          )
+        )
+      end
+
+      users
+    end
+
+    def users_for_channel(exclude:, usernames: nil)
+      users = User
+        .includes(:do_not_disturb_timings, :push_subscriptions, :groups)
+        .joins(:user_chat_channel_memberships)
+        .joins(:user_option)
+        .not_suspended
+        .where(user_options: { chat_enabled: true })
+        .where(user_chat_channel_memberships: { following: true, chat_channel_id: @chat_channel.id })
+        .where.not(username_lower: exclude.downcase)
+      users = users.where(username_lower: usernames.map(&:downcase)) if usernames
+      users
+    end
+
+    def filter_users_who_can_chat(users)
+      users.select do |user|
+        guardian = Guardian.new(user)
+        guardian.can_chat?(user) && guardian.can_see_chat_channel?(@chat_channel)
+      end
+    end
+
+    def create_mention_notification_for_user(mentioned_user)
+      return if mentioned_user.do_not_disturb?
+
+      Notification.create!(
+        notification_type: Notification.types[:chat_mention],
+        user_id: mentioned_user.id,
+        high_priority: true,
+        data: {
+          message: 'chat.mention_notification',
+          chat_message_id: @chat_message.id,
+          chat_channel_id: @chat_channel.id,
+          chat_channel_title: @chat_channel.title(mentioned_user),
+          mentioned_by_username: @user.username,
+        }.to_json
+      )
+      send_mentioned_os_notifications(mentioned_user)
+    end
+
+    def send_mentioned_os_notifications(mentioned_user)
+      payload = {
+        notification_type: Notification.types[:chat_mention],
+        username: @user.username,
+        translated_title: I18n.t("discourse_push_notifications.popup.chat_mention",
+                                 username: @user.username
+                                ),
+        tag: push_notification_tag(:mention),
+        excerpt: @chat_message.excerpt,
+        post_url: "/chat/channel/#{@chat_channel.id}/#{@chat_channel.title(mentioned_user)}?messageId=#{@chat_message.id}"
+      }
+      membership = mentioned_user.user_chat_channel_memberships.detect { |m| m.chat_channel_id == @chat_channel.id }
+      return if !membership || membership.muted
+
+      unless membership.desktop_notifications_never?
+        MessageBus.publish("/chat/notification-alert/#{mentioned_user.id}", payload, user_ids: [mentioned_user.id])
+      end
+
+      unless membership.mobile_notifications_never?
+        PostAlerter.push_notification(mentioned_user, payload)
+      end
+    end
+
+    def notify_watching_users(except: [])
+      always_notification_level = UserChatChannelMembership::NOTIFICATION_LEVELS[:always]
+      UserChatChannelMembership
+        .includes(user: :groups)
+        .joins(user: :user_option)
+        .where(user_option: { chat_enabled: true })
+        .where.not(user_id: except)
+        .where(chat_channel_id: @chat_channel.id)
+        .where(following: true)
+        .where("desktop_notification_level = ? OR mobile_notification_level = ?",
+               always_notification_level, always_notification_level)
+        .merge(User.not_suspended)
+        .each do |membership|
+          user = membership.user
+          guardian = Guardian.new(user)
+          next unless guardian.can_chat?(user) && guardian.can_see_chat_channel?(@chat_channel)
+
+          payload = {
+            username: @user.username,
+            notification_type: Notification.types[:chat_message],
+            post_url: "/chat/channel/#{@chat_channel.id}/#{@chat_channel.title(user)}",
+            translated_title: I18n.t("discourse_push_notifications.popup.chat_message",
+                                     chat_channel_title: @chat_channel.title(membership.user)
+                                    ),
+            tag: push_notification_tag(:message),
+            excerpt: @chat_message.excerpt
+          }
+          if membership.desktop_notifications_always?
+            MessageBus.publish("/chat/notification-alert/#{user.id}", payload, user_ids: [user.id])
+          end
+
+          if membership.mobile_notifications_always? && !online_user_ids.include?(user.id)
+            PostAlerter.push_notification(user, payload)
+          end
+        end
+    end
+
+    def online_user_ids
+      @online_user_ids ||= PresenceChannel.new("/chat/online").user_ids
+    end
+
+    def push_notification_tag(type)
+      "#{Discourse.current_hostname}-chat-#{type}-#{@chat_channel.id}"
+    end
+  end
+end

--- a/app/jobs/regular/send_chat_notifications.rb
+++ b/app/jobs/regular/send_chat_notifications.rb
@@ -203,11 +203,11 @@ module Jobs
     end
 
     def user_has_seen_message(user)
-      membership = user.user_chat_channel_memberships.detect do |membership|
+      channel_membership = user.user_chat_channel_memberships.detect do |membership|
         membership.chat_channel_id == @chat_channel.id
       end
 
-      (membership.last_read_message_id || 0) >= @chat_message.id
+      (channel_membership.last_read_message_id || 0) >= @chat_message.id
     end
 
     def online_user_ids

--- a/lib/chat_message_creator.rb
+++ b/lib/chat_message_creator.rb
@@ -40,7 +40,7 @@ class DiscourseChat::ChatMessageCreator
       attach_uploads
       ChatPublisher.publish_new!(@chat_channel, @chat_message, @staged_id)
       Jobs.enqueue(:process_chat_message, { chat_message_id: @chat_message.id })
-      Jobs.enqueue(:send_chat_notifications, { type: :new, chat_message_id: @chat_message.id })
+      Jobs.enqueue_in(5.seconds, :send_chat_notifications, { type: :new, chat_message_id: @chat_message.id })
     rescue => error
       @error = error
       if Rails.env.test?

--- a/lib/chat_message_creator.rb
+++ b/lib/chat_message_creator.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 class DiscourseChat::ChatMessageCreator
-  MENTION_REGEX = /\@\w+/
-  attr_reader :error
-  attr_reader :chat_message
+  attr_reader :error, :chat_message
 
   def self.create(opts)
     instance = new(**opts)
@@ -40,10 +38,9 @@ class DiscourseChat::ChatMessageCreator
       @chat_message.cook
       @chat_message.save!
       attach_uploads
-      mentioned_user_ids = create_mention_notifications
-      notify_watching_users(except: [@user.id] + mentioned_user_ids)
       ChatPublisher.publish_new!(@chat_channel, @chat_message, @staged_id)
       Jobs.enqueue(:process_chat_message, { chat_message_id: @chat_message.id })
+      Jobs.enqueue(:send_chat_notifications, { type: :new, chat_message_id: @chat_message.id })
     rescue => error
       @error = error
       if Rails.env.test?
@@ -66,166 +63,6 @@ class DiscourseChat::ChatMessageCreator
 
     uploads = Upload.where(id: @upload_ids, user_id: @user.id)
     self.class.attach_uploads(@chat_message.id, uploads)
-  end
-
-  def notify_watching_users(except: [])
-    always_notification_level = UserChatChannelMembership::NOTIFICATION_LEVELS[:always]
-    UserChatChannelMembership
-      .includes(user: :groups)
-      .joins(user: :user_option)
-      .where(user_option: { chat_enabled: true })
-      .where.not(user_id: except)
-      .where(chat_channel_id: @chat_channel.id)
-      .where(following: true)
-      .where("desktop_notification_level = ? OR mobile_notification_level = ?",
-             always_notification_level, always_notification_level)
-      .merge(User.not_suspended)
-      .each do |membership|
-        user = membership.user
-        next unless Guardian.new.can_chat?(user)
-        payload = {
-          username: @user.username,
-          notification_type: Notification.types[:chat_message],
-          post_url: "/chat/channel/#{@chat_channel.id}/#{@chat_channel.title(user)}",
-          translated_title: I18n.t("discourse_push_notifications.popup.chat_message",
-                                   chat_channel_title: @chat_channel.title(membership.user)
-                                  ),
-          tag: self.class.push_notification_tag(:message, @chat_channel),
-          excerpt: chat_message.message[0..399]
-        }
-        if membership.desktop_notifications_always?
-          MessageBus.publish("/chat/notification-alert/#{user.id}", payload, user_ids: [user.id])
-        end
-
-        if membership.mobile_notifications_always? && !online_user_ids.include?(user.id)
-          PostAlerter.push_notification(user, payload)
-        end
-      end
-  end
-
-  def online_user_ids
-    @online_user_ids ||= PresenceChannel.new("/chat/online").user_ids
-  end
-
-  def create_mention_notifications
-    mentioned_user_ids = []
-    self.class.mentioned_users(chat_message: @chat_message, creator: @user)
-      .each do |target_user|
-      if Guardian.new(target_user).can_see_chat_channel?(@chat_channel)
-        self.class.create_mention_notification(
-          creator_username: @user.username,
-          mentioned_user: target_user,
-          chat_channel: @chat_channel,
-          chat_message: @chat_message,
-        )
-        mentioned_user_ids.push(target_user.id)
-        ChatPublisher.publish_new_mention(target_user, @chat_channel.id, @chat_message.id)
-      end
-    end
-    mentioned_user_ids
-  end
-
-  def self.mentioned_users(chat_message:, creator:)
-    mention_matches = chat_message.message.scan(MENTION_REGEX)
-    if mention_matches.include?("@all")
-      users = users_for_channel(chat_message.chat_channel_id, exclude: creator.username)
-    else
-      users = mention_matches.include?("@here") ?
-        users_here(chat_message.chat_channel_id, creator.username, mention_matches) :
-        users_for_channel(
-          chat_message.chat_channel_id,
-          exclude: creator.username,
-          usernames: mention_matches.map { |match| match[1..-1] }
-        )
-    end
-    filter_users_who_can_chat(users)
-  end
-
-  def self.users_here(chat_channel_id, creator_username, mention_matches)
-    users = users_for_channel(chat_channel_id, exclude: creator_username).where("last_seen_at > ?", 5.minutes.ago)
-    usernames = users.map(&:username)
-    other_mentioned_usernames = mention_matches
-      .map { |match| match[1..-1] }
-      .reject { |username| username == "here" || usernames.include?(username) }
-    if other_mentioned_usernames.any?
-      users = users.or(
-        users_for_channel(
-          chat_channel_id,
-          exclude: creator_username,
-          usernames: other_mentioned_usernames
-        )
-      )
-    end
-
-    filter_users_who_can_chat(users)
-  end
-
-  def self.users_for_channel(chat_channel_id, exclude:, usernames: nil)
-    users = User
-      .includes(:do_not_disturb_timings, :push_subscriptions, :groups)
-      .joins(:user_chat_channel_memberships)
-      .joins(:user_option)
-      .not_suspended
-      .where(user_options: { chat_enabled: true })
-      .where(user_chat_channel_memberships: { following: true, chat_channel_id: chat_channel_id })
-      .where.not(username: exclude)
-    users = users.where(username_lower: usernames.map(&:downcase)) if usernames
-    users
-  end
-
-  def self.filter_users_who_can_chat(users)
-    guardian = Guardian.new
-    users.select { |user| guardian.can_chat?(user) }
-  end
-
-  def self.create_mention_notification(creator_username:, mentioned_user:, chat_channel:, chat_message:)
-    return if mentioned_user.do_not_disturb?
-
-    Notification.create!(
-      notification_type: Notification.types[:chat_mention],
-      user_id: mentioned_user.id,
-      high_priority: true,
-      data: {
-        message: 'chat.mention_notification',
-        chat_message_id: chat_message.id,
-        chat_channel_id: chat_channel.id,
-        chat_channel_title: chat_channel.title(mentioned_user),
-        mentioned_by_username: creator_username,
-      }.to_json
-    )
-    send_mentioned_os_notifications(
-      chat_channel: chat_channel,
-      chat_message: chat_message,
-      mentioned: mentioned_user,
-      mentioner_username: creator_username
-    )
-  end
-
-  def self.send_mentioned_os_notifications(chat_channel:, chat_message:, mentioned:, mentioner_username:)
-    payload = {
-      notification_type: Notification.types[:chat_mention],
-      username: mentioner_username,
-      translated_title: I18n.t("discourse_push_notifications.popup.chat_mention",
-                               username: mentioner_username
-                              ),
-      tag: push_notification_tag(:mention, chat_channel),
-      excerpt: chat_message.message[0..399],
-      post_url: "/chat/channel/#{chat_channel.id}/#{chat_channel.title(mentioned)}?messageId=#{chat_message.id}"
-    }
-    membership = mentioned.user_chat_channel_memberships.detect { |m| m.chat_channel_id == chat_channel.id }
-    return if !membership || membership.muted
-
-    unless membership.desktop_notifications_never?
-      MessageBus.publish("/chat/notification-alert/#{mentioned.id}", payload, user_ids: [mentioned.id])
-    end
-
-    unless membership.mobile_notifications_never?
-      PostAlerter.push_notification(mentioned, payload)
-    end
-  end
-
-  def self.push_notification_tag(type, chat_channel)
-    "#{Discourse.current_hostname}-chat-#{type}-#{chat_channel.id}"
   end
 
   def self.attach_uploads(chat_message_id, uploads)

--- a/lib/chat_message_creator.rb
+++ b/lib/chat_message_creator.rb
@@ -40,7 +40,7 @@ class DiscourseChat::ChatMessageCreator
       attach_uploads
       ChatPublisher.publish_new!(@chat_channel, @chat_message, @staged_id)
       Jobs.enqueue(:process_chat_message, { chat_message_id: @chat_message.id })
-      Jobs.enqueue_in(5.seconds, :send_chat_notifications, { type: :new, chat_message_id: @chat_message.id })
+      Jobs.enqueue_in(5.seconds, :send_chat_notifications, { type: :new, chat_message_id: @chat_message.id, timestamp: @chat_message.created_at })
     rescue => error
       @error = error
       if Rails.env.test?

--- a/lib/chat_message_updater.rb
+++ b/lib/chat_message_updater.rb
@@ -23,11 +23,11 @@ class DiscourseChat::ChatMessageUpdater
       @chat_message.message = @new_content
       @chat_message.cook
       @chat_message.save!
-      save_revision!
+      revision = save_revision!
       update_uploads!
       ChatPublisher.publish_edit!(@chat_channel, @chat_message)
       Jobs.enqueue(:process_chat_message, { chat_message_id: @chat_message.id })
-      Jobs.enqueue_in(5.seconds, :send_chat_notifications, { type: :edit, chat_message_id: @chat_message.id })
+      Jobs.enqueue_in(5.seconds, :send_chat_notifications, { type: :edit, chat_message_id: @chat_message.id, timestamp: revision.created_at })
     rescue => error
       puts error.inspect
       @error = error

--- a/lib/chat_message_updater.rb
+++ b/lib/chat_message_updater.rb
@@ -27,7 +27,7 @@ class DiscourseChat::ChatMessageUpdater
       update_uploads!
       ChatPublisher.publish_edit!(@chat_channel, @chat_message)
       Jobs.enqueue(:process_chat_message, { chat_message_id: @chat_message.id })
-      Jobs.enqueue(:send_chat_notifications, { type: :edit, chat_message_id: @chat_message.id })
+      Jobs.enqueue_in(5.seconds, :send_chat_notifications, { type: :edit, chat_message_id: @chat_message.id })
     rescue => error
       puts error.inspect
       @error = error

--- a/lib/chat_notifier.rb
+++ b/lib/chat_notifier.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class DiscourseChat::ChatNotifier
-
-end

--- a/lib/chat_notifier.rb
+++ b/lib/chat_notifier.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class DiscourseChat::ChatNotifier
+
+end

--- a/lib/guardian_extensions.rb
+++ b/lib/guardian_extensions.rb
@@ -28,7 +28,7 @@ module DiscourseChat::GuardianExtensions
         !chat_channel.chatable.archived &&
         can_see_topic?(chat_channel.chatable)
     elsif chat_channel.direct_message_channel?
-      chat_channel.chatable.user_can_access?(user)
+      chat_channel.chatable.user_can_access?(@user)
     elsif chat_channel.category_channel?
 
       can_see_category?(chat_channel.chatable)

--- a/plugin.rb
+++ b/plugin.rb
@@ -70,7 +70,6 @@ after_initialize do
   load File.expand_path('../lib/chat_message_creator.rb', __FILE__)
   load File.expand_path('../lib/chat_message_processor.rb', __FILE__)
   load File.expand_path('../lib/chat_message_updater.rb', __FILE__)
-  load File.expand_path('../lib/chat_notifier.rb', __FILE__)
   load File.expand_path('../lib/chat_seeder.rb', __FILE__)
   load File.expand_path('../lib/direct_message_channel_creator.rb', __FILE__)
   load File.expand_path('../lib/guardian_extensions.rb', __FILE__)
@@ -78,6 +77,7 @@ after_initialize do
   load File.expand_path('../lib/extensions/detailed_tag_serializer_extension.rb', __FILE__)
   load File.expand_path('../lib/slack_compatibility.rb', __FILE__)
   load File.expand_path('../app/jobs/regular/process_chat_message.rb', __FILE__)
+  load File.expand_path('../app/jobs/regular/send_chat_notifications.rb', __FILE__)
   load File.expand_path('../app/services/chat_publisher.rb', __FILE__)
 
   register_topic_custom_field_type(DiscourseChat::HAS_CHAT_ENABLED, :boolean)

--- a/plugin.rb
+++ b/plugin.rb
@@ -70,6 +70,7 @@ after_initialize do
   load File.expand_path('../lib/chat_message_creator.rb', __FILE__)
   load File.expand_path('../lib/chat_message_processor.rb', __FILE__)
   load File.expand_path('../lib/chat_message_updater.rb', __FILE__)
+  load File.expand_path('../lib/chat_notifier.rb', __FILE__)
   load File.expand_path('../lib/chat_seeder.rb', __FILE__)
   load File.expand_path('../lib/direct_message_channel_creator.rb', __FILE__)
   load File.expand_path('../lib/guardian_extensions.rb', __FILE__)

--- a/spec/components/chat_message_creator_spec.rb
+++ b/spec/components/chat_message_creator_spec.rb
@@ -15,6 +15,7 @@ describe DiscourseChat::ChatMessageCreator do
   before do
     SiteSetting.chat_enabled = true
     SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+    Jobs.run_immediately!
 
     # Create channel memberships
     [admin1, admin2, user1, user2, user3].each do |user|
@@ -167,18 +168,6 @@ describe DiscourseChat::ChatMessageCreator do
         content: "hello @#{user2.username}"
       )
     }.to change { Notification.where(user: user2).count }.by(0)
-  end
-
-  it "enqueues a `process_chat_message` job" do
-    expect_enqueued_with(
-      job: :process_chat_message
-    ) do
-      DiscourseChat::ChatMessageCreator.create(
-        chat_channel: public_chat_channel,
-        user: user1,
-        content: "this is a message"
-      )
-    end
   end
 
   describe "push notifications" do

--- a/spec/components/chat_message_updater_spec.rb
+++ b/spec/components/chat_message_updater_spec.rb
@@ -15,6 +15,7 @@ describe DiscourseChat::ChatMessageUpdater do
   before do
     SiteSetting.chat_enabled = true
     SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+    Jobs.run_immediately!
 
     [admin1, admin2, user1, user2, user3, user4].each do |user|
       Fabricate(:user_chat_channel_membership, chat_channel: public_chat_channel, user: user)

--- a/spec/jobs/send_chat_notifications_spec.rb
+++ b/spec/jobs/send_chat_notifications_spec.rb
@@ -32,4 +32,23 @@ describe Jobs::SendChatNotifications do
       described_class.new.execute(type: :new, chat_message_id: chat_message.id)
     }.not_to change { Notification.where(user: user2).count }
   end
+
+  it "doesn't send chat message 'watching' notifications if the user has already read the message" do
+    chat_message = DiscourseChat::ChatMessageCreator.create(
+      chat_channel: chat_channel,
+      user: user1,
+      content: "Hi @#{user2.username}"
+    ).chat_message
+
+    user2.user_chat_channel_memberships.create(
+      following: true,
+      chat_channel: chat_channel,
+      last_read_message_id: chat_message.id,
+      desktop_notification_level: UserChatChannelMembership::NOTIFICATION_LEVELS[:always],
+      mobile_notification_level: UserChatChannelMembership::NOTIFICATION_LEVELS[:always],
+    )
+
+    PostAlerter.expects(:push_notification).never
+    described_class.new.execute(type: :new, chat_message_id: chat_message.id)
+  end
 end

--- a/spec/jobs/send_chat_notifications_spec.rb
+++ b/spec/jobs/send_chat_notifications_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Jobs::SendChatNotifications do
+  # General spec for this job are found in ChatMessageCreator and ChatMessageUpdater specs.
+  # Here we are just testing the delay, to make sure unnecissary notifications don't go out.
+
+  fab!(:chat_channel) { Fabricate(:chat_channel) }
+  fab!(:user1) { Fabricate(:user) }
+  fab!(:user2) { Fabricate(:user) }
+
+  before do
+    SiteSetting.chat_enabled = true
+    SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+  end
+
+  it "doesn't send mention notifications if the user has already read the message" do
+    chat_message = DiscourseChat::ChatMessageCreator.create(
+      chat_channel: chat_channel,
+      user: user1,
+      content: "Hi @#{user2.username}"
+    ).chat_message
+
+    user2.user_chat_channel_memberships.create(
+      following: true,
+      chat_channel: chat_channel,
+      last_read_message_id: chat_message.id
+    )
+
+    expect {
+      described_class.new.execute(type: :new, chat_message_id: chat_message.id)
+    }.not_to change { Notification.where(user: user2).count }
+  end
+end

--- a/spec/jobs/send_chat_notifications_spec.rb
+++ b/spec/jobs/send_chat_notifications_spec.rb
@@ -3,8 +3,10 @@
 require 'rails_helper'
 
 describe Jobs::SendChatNotifications do
-  # General spec for this job are found in ChatMessageCreator and ChatMessageUpdater specs.
-  # Here we are just testing the delay, to make sure unnecissary notifications don't go out.
+  # The notification logic for this job is integration tested in ChatMessageCreator and
+  # ChatMessageUpdater specs, where jobs are run immediately.
+  # Here we are testing if notifications are blocked when users have already read messages,
+  # and if new revisions are created in between inqueueing the job and it running.
 
   fab!(:chat_channel) { Fabricate(:chat_channel) }
   fab!(:user1) { Fabricate(:user) }

--- a/spec/requests/chat_channel_controller_spec.rb
+++ b/spec/requests/chat_channel_controller_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe DiscourseChat::ChatChannelsController do
 
       it "serializes unread_mentions properly" do
         sign_in(admin)
+        Jobs.run_immediately!
         DiscourseChat::ChatMessageCreator.create(
           chat_channel: public_category_cc,
           user: user,


### PR DESCRIPTION
This moves the chat notification logic from the chat message creator/updater and into a job that is enqueued 5 seconds after message creation/edit.

This job also simply returns in a `ChatMessageRevision` record is created in-between the job being enqueued and it being run. This means the message was edited and a new job will handle it.