### PR TITLE
FIX: Make highlighted mentions standout in dark themes

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -458,7 +458,7 @@ $float-height: 530px;
       }
       .mention.highlighted {
         background: var(--tertiary-low);
-        color: var(--primary-very-high);
+        color: var(--primary);
       }
       .valid-mention {
         padding: 0 4px 1px;


### PR DESCRIPTION
Screenshot:

![image](https://user-images.githubusercontent.com/17474474/145519281-d1f7679a-3088-4764-b13e-4eb2ab346fd3.png)

This styling matches core's styling for alerts/banners like these:

![image](https://user-images.githubusercontent.com/17474474/145519561-a604955f-8ec3-4918-89ba-be5ce05b4da4.png)
