### PR TITLE
DEV: Remove minimal chat view user preference

### DIFF
--- a/assets/javascripts/discourse/controllers/preferences-chat.js
+++ b/assets/javascripts/discourse/controllers/preferences-chat.js
@@ -8,12 +8,6 @@ const chatAttrs = [
   "only_chat_push_notifications",
 ];
 export default Controller.extend({
-  setMinimalChatView() {
-    this.model.minimalChatView
-      ? localStorage.setItem("minimalChatView", true)
-      : localStorage.removeItem("minimalChatView");
-  },
-
   @action
   save() {
     this.set("saved", false);
@@ -21,7 +15,6 @@ export default Controller.extend({
       .save(chatAttrs)
       .then(() => {
         this.set("saved", true);
-        this.setMinimalChatView();
         location.reload();
       })
       .catch(popupAjaxError);

--- a/assets/javascripts/discourse/routes/preferences-chat.js
+++ b/assets/javascripts/discourse/routes/preferences-chat.js
@@ -11,13 +11,6 @@ export default RestrictedUserRoute.extend({
       return this.transitionTo(`discovery.${defaultHomepage()}`);
     }
 
-    user.set(
-      "minimalChatView",
-      localStorage.getItem("minimalChatView") || false
-    );
-    controller.setProperties({
-      model: user,
-      sidebarActive: this.chat.getSidebarActive(),
-    });
+    controller.set("model", user);
   },
 });

--- a/assets/javascripts/discourse/templates/preferences/chat.hbs
+++ b/assets/javascripts/discourse/templates/preferences/chat.hbs
@@ -32,17 +32,4 @@
   <span class="control-instructions">{{i18n "chat.isolate.description"}}</span>
 </div>
 
-{{#if sidebarActive}}
-  <div class="control-group chat-setting">
-    <label class="controls">
-      {{input
-        type="checkbox"
-        checked=model.minimalChatView
-      }}
-      {{i18n "chat.minimal_view.title"}}
-    </label>
-    <span class="control-instructions">{{i18n "chat.minimal_view.description"}}</span>
-  </div>
-{{/if}}
-
 {{save-controls model=model action=(action "save") saved=saved}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -38,9 +38,6 @@ en:
       join_channel: "Join channel"
       new_messages: "new messages"
       mention_notification: "<span>%{username} mentioned you in chat</span>"
-      minimal_view:
-        title: "Minimal chat view"
-        description: "Hides all non-chat related sidebar items when on the chat page. Applies only to the current browser."
       no_public_channels: "You have not joined any channels."
       only_chat_push_notifications:
         title: "Only send chat push notifications"

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -1019,16 +1019,8 @@ acceptance("Discourse Chat - chat preferences", function (needs) {
     assert.equal(currentURL(), "/latest");
   });
 
-  test("There are all 4 settings shown when sidebar is active", async function (assert) {
+  test("There are all 3 settings shown", async function (assert) {
     this.container.lookup("service:chat").setSidebarActive(true);
-    await visit("/u/eviltrout/preferences/chat");
-    assert.equal(currentURL(), "/u/eviltrout/preferences/chat");
-    assert.equal(queryAll(".chat-setting input").length, 4);
-  });
-
-  test("The 4th setting is hidden when sidebar isn't active", async function (assert) {
-    await visit("/");
-    this.container.lookup("service:chat").setSidebarActive(false);
     await visit("/u/eviltrout/preferences/chat");
     assert.equal(currentURL(), "/u/eviltrout/preferences/chat");
     assert.equal(queryAll(".chat-setting input").length, 3);


### PR DESCRIPTION
This is to merge the functionality of `minimal_chat_view` into `isolate_chat`. The sidebar plugin is what actually uses the preference - https://github.com/discourse-org/discourse-teams-sidebar/pull/254