### PR TITLE
FIX: Emoji picker position

### DIFF
--- a/assets/javascripts/discourse/components/tc-message.js
+++ b/assets/javascripts/discourse/components/tc-message.js
@@ -328,7 +328,6 @@ export default Component.extend({
 
     // Calculate bottom pixel value
     let bottomValue = reactBtnPositions.bottom - emojiPicker.offsetHeight + 50;
-
     const messageContainer = document.querySelector(".tc-messages-scroll");
     const bottomOfMessageContainer =
       window.innerHeight - messageContainer.getBoundingClientRect().bottom;

--- a/assets/javascripts/discourse/components/tc-message.js
+++ b/assets/javascripts/discourse/components/tc-message.js
@@ -302,23 +302,42 @@ export default Component.extend({
     if (!emojiPicker || !btn) {
       return;
     }
-    const bounds = btn.getBoundingClientRect();
-    const btnPositions = {
-      top: bounds.top + window.pageYOffset,
-      left: bounds.left + window.pageXOffset,
+    const reactBtnBounds = btn.getBoundingClientRect();
+    const reactBtnPositions = {
+      bottom: window.innerHeight - reactBtnBounds.bottom,
+      left: reactBtnBounds.left + window.pageXOffset,
     };
-    const xAdjustment =
-      position === this.SHOW_RIGHT && this.fullPage
-        ? btn.offsetWidth + 10
-        : (emojiPicker.offsetWidth + 10) * -1;
 
-    const yHeight =
-      window.innerHeight - btnPositions.top - emojiPicker.offsetHeight;
-    const yAdjustment = yHeight < 0 ? -yHeight + 20 : 20;
-    emojiPicker.style.top = `${btnPositions.top - yAdjustment}px`;
-    emojiPicker.style.left = this.site.mobileView
-      ? "0"
-      : `${btnPositions.left + xAdjustment}px`;
+    // Calculate left pixel value
+    let leftValue = 0;
+
+    if (!this.site.mobileView) {
+      const xAdjustment =
+        position === this.SHOW_RIGHT && this.fullPage
+          ? btn.offsetWidth + 10
+          : (emojiPicker.offsetWidth + 10) * -1;
+      leftValue = reactBtnPositions.left + xAdjustment;
+      if (
+        leftValue < 0 ||
+        leftValue + emojiPicker.getBoundingClientRect().width >
+          window.innerWidth
+      ) {
+        leftValue = 0;
+      }
+    }
+
+    // Calculate bottom pixel value
+    let bottomValue = reactBtnPositions.bottom - emojiPicker.offsetHeight + 50;
+
+    const messageContainer = document.querySelector(".tc-messages-scroll");
+    const bottomOfMessageContainer =
+      window.innerHeight - messageContainer.getBoundingClientRect().bottom;
+    if (bottomValue < bottomOfMessageContainer) {
+      bottomValue = bottomOfMessageContainer;
+    }
+
+    emojiPicker.style.bottom = `${bottomValue}px`;
+    emojiPicker.style.left = `${leftValue}px`;
   },
 
   @action

--- a/assets/javascripts/discourse/templates/components/tc-message.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-message.hbs
@@ -11,6 +11,7 @@
   {{emoji-picker
     isActive=emojiPickerIsActive
     isEditorFocused=true
+    usePopper=false
     emojiSelected=(action "selectReaction")
     onEmojiPickerClose=(action (mut emojiPickerIsActive) false)
   }}


### PR DESCRIPTION
We can't use popper here because we want the position to be `fixed` not `absolute`. The previous calculations were _good_, but do not work when the composer opened. 

This uses `bottom` instead of `top` so that we can keep the emoji picker moving up with the chat window when the composer opens up. Also uses `usePopper: false` [added here](https://github.com/discourse/discourse/pull/15256), to make sure the position doesn't change when the composer is opened.