### PR TITLE
FEATURE: Mark unread chat mentions as read when messages are read

### DIFF
--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -278,6 +278,15 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
       .where(user: current_user, chat_channel: @chat_channel)
       .update_all(last_read_message_id: params[:message_id])
 
+    mention_notifications = Notification
+      .where(user: current_user)
+      .where(notification_type: Notification.types[:chat_mention])
+      .where("data LIKE ?", "%\"chat_channel_id\":#{@chat_channel.id}%")
+
+    mention_notifications.each do |mention|
+      mention.update(read: true)
+    end
+
     ChatPublisher.publish_user_tracking_state(
       current_user,
       @chat_channel.id,

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -281,6 +281,7 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
     mention_notifications = Notification
       .where(user: current_user)
       .where(notification_type: Notification.types[:chat_mention])
+      .where(read: false)
       .where("data LIKE ?", "%\"chat_channel_id\":#{@chat_channel.id}%")
 
     mention_notifications.each do |mention|

--- a/lib/chat_message_creator.rb
+++ b/lib/chat_message_creator.rb
@@ -40,7 +40,7 @@ class DiscourseChat::ChatMessageCreator
       attach_uploads
       ChatPublisher.publish_new!(@chat_channel, @chat_message, @staged_id)
       Jobs.enqueue(:process_chat_message, { chat_message_id: @chat_message.id })
-      Jobs.enqueue_in(5.seconds, :send_chat_notifications, { type: :new, chat_message_id: @chat_message.id, timestamp: @chat_message.created_at })
+      Jobs.enqueue_in(3.seconds, :send_chat_notifications, { type: :new, chat_message_id: @chat_message.id, timestamp: @chat_message.created_at })
     rescue => error
       @error = error
       if Rails.env.test?

--- a/lib/chat_message_updater.rb
+++ b/lib/chat_message_updater.rb
@@ -27,7 +27,7 @@ class DiscourseChat::ChatMessageUpdater
       update_uploads!
       ChatPublisher.publish_edit!(@chat_channel, @chat_message)
       Jobs.enqueue(:process_chat_message, { chat_message_id: @chat_message.id })
-      Jobs.enqueue_in(5.seconds, :send_chat_notifications, { type: :edit, chat_message_id: @chat_message.id, timestamp: revision.created_at })
+      Jobs.enqueue_in(3.seconds, :send_chat_notifications, { type: :edit, chat_message_id: @chat_message.id, timestamp: revision.created_at })
     rescue => error
       puts error.inspect
       @error = error


### PR DESCRIPTION
I'm sorry @eviltrout I have to do multiple queries here for the AR callbacks to run and send message_bus data to the client to the count actually clears.

Also lower time to enqueue notify job to 3 seconds. 5 is so long.

