### PR TITLE
FIX: Don't scroll the entire chat pane to GitHub oneboxes

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -942,7 +942,31 @@ export default Component.extend({
     this.element
       .querySelectorAll(".onebox.githubblob li.selected")
       .forEach((line) => {
-        line.scrollIntoView({ block: "center" });
+        const scrollingElementSelector = ".onebox .onebox-body";
+
+        let linePosition = line.offsetTop + line.offsetHeight / 2;
+
+        // offsetTop is relative to the offsetParent (i.e. a position: relative element)
+        // Keep iterating up them until we reach the topmost one within the onebox
+        // Sum up the offsetTop values as we go
+        let offsetParent = line.offsetParent;
+        while (true) {
+          linePosition += offsetParent.offsetTop;
+          if (!offsetParent.offsetParent?.closest(scrollingElementSelector)) {
+            // The next offsetParent would be outside the onebox
+            break;
+          }
+        }
+        let onebox = line.closest(scrollingElementSelector);
+        if (onebox !== offsetParent) {
+          // The onebox body itself is not position: relative, so we need to subtract it's offsetTop
+          linePosition -= onebox.offsetTop;
+        }
+
+        onebox.scroll({
+          // Scroll so the selected line is in the middle of the div
+          top: linePosition - onebox.offsetHeight / 2,
+        });
       });
   },
 });


### PR DESCRIPTION
When a GitHub onebox renders off-screen, calling `scrollIntoView` would scroll the entire chat window up to the onebox. This is not what we want.

All we want to do is scroll the `.onebox .onebox-body` div so that the selected line is in view

Unfortunately calculating the y-position of that line relative to the `.onebox-body` is quite complicated, but I think this should be pretty robust.