### PR TITLE
FIX: Prevent JS error from emoji autocomplete

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -411,11 +411,13 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
 
           return resolve(options);
         })
-          .then((list) =>
-            list.map((code) => {
-              return { code, src: emojiUrlFor(code) };
-            })
-          )
+          .then((list) => {
+            if (list) {
+              list.map((code) => {
+                return { code, src: emojiUrlFor(code) };
+              });
+            }
+          })
           .then((list) => {
             if (list.length) {
               list.push({ label: I18n.t("composer.more_emoji"), term });

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -411,13 +411,11 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
 
           return resolve(options);
         })
-          .then((list) => {
-            if (list) {
-              list.map((code) => {
-                return { code, src: emojiUrlFor(code) };
-              });
-            }
-          })
+          .then((list) =>
+            (list || []).map((code) => {
+              return { code, src: emojiUrlFor(code) };
+            })
+          )
           .then((list) => {
             if (list.length) {
               list.push({ label: I18n.t("composer.more_emoji"), term });


### PR DESCRIPTION
I keep seeing this JS error, and I don't want to see it anymoreeee

![Screen Shot 2021-12-13 at 9 37 42 AM](https://user-images.githubusercontent.com/16214023/145841727-ebb05419-0c63-4ddc-be2e-9b0b1c6102ed.png)
![Screen Shot 2021-12-13 at 9 37 37 AM](https://user-images.githubusercontent.com/16214023/145841731-130dde09-52f5-48cc-a0ec-eb0687c72ad8.png)
