### PR TITLE
FIX: Track all DM channels in frontend even if hidden

### DIFF
--- a/assets/javascripts/discourse/components/channel-list.js
+++ b/assets/javascripts/discourse/components/channel-list.js
@@ -29,9 +29,25 @@ export default Component.extend({
   sortedDirectMessageChannels: computed(
     "directMessageChannels.@each.updated_at",
     function () {
+      if (!this.directMessageChannels?.length) {
+        return [];
+      }
+
       return this.directMessageChannels
-        ? this.directMessageChannels.sortBy("updated_at").reverse()
-        : [];
+        .sort((a, b) => {
+          const unreadCountA =
+            this.currentUser.chat_channel_tracking_state[a.id]?.unread_count ||
+            0;
+          const unreadCountB =
+            this.currentUser.chat_channel_tracking_state[b.id]?.unread_count ||
+            0;
+          if (unreadCountA === unreadCountB) {
+            return new Date(a.updated_at) > new Date(b.updated_at) ? -1 : 1;
+          } else {
+            return unreadCountA > unreadCountB ? -1 : 1;
+          }
+        })
+        .slice(0, 10);
     }
   ),
 

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -453,7 +453,6 @@ export default Service.extend({
       );
       if (dmChatChannel) {
         dmChatChannel.set("updated_at", new Date());
-        this.notifyPropertyChange("directMessageChannels");
       }
     });
   },

--- a/lib/chat_channel_fetcher.rb
+++ b/lib/chat_channel_fetcher.rb
@@ -89,7 +89,6 @@ module DiscourseChat::ChatChannelFetcher
       .where(user_chat_channel_memberships: { user_id: user_id, following: true })
       .where(chatable_type: "DirectMessageChannel")
       .order(updated_at: :desc)
-      .limit(10)
       .to_a
 
     channels.map do |channel|


### PR DESCRIPTION
I keep seeing this issue where someone personal chats me, and I don't see it until I do a page refresh. I thought the issue was with personal chat channel creation, but then I realized it's the limit on the DM channel query.

Currently the client is only tracking the latest 10 channels... so if Robin is 11th most recently updated and sends me a new message, I will not get it.

This PR does 2 things:
* Serializer _all_ your DM channels, and hides channels 11-on. This allows tracking of all channels.
* Keeps unread DM channels at the top of the list. First sort by unread messages count, then sort by `updated_at` on the channel