### PR TITLE
UX: remove online count from channels

### DIFF
--- a/assets/javascripts/discourse/templates/components/channel-list.hbs
+++ b/assets/javascripts/discourse/templates/components/channel-list.hbs
@@ -12,11 +12,7 @@
         {{d-icon "angle-up"}}
       </span>
     {{/if}}
-    {{#if chat.presenceChannel.count}}
-      {{i18n "chat.chat_channels_with_count" count=chat.presenceChannel.count}}
-    {{else}}
-      {{i18n "chat.chat_channels"}}
-    {{/if}}
+    {{i18n "chat.chat_channels"}}
     {{flat-button
       class="edit-channel-membership-btn"
       icon="pencil-alt"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -11,7 +11,6 @@ en:
       cancel_edit: "Cancel edit"
       category_chat_enabled: "Chat enabled for category"
       chat_channels: "Channels"
-      chat_channels_with_count: "Channels (%{count} online)"
       click_to_join: "Click here to view available channels."
       close: "Close"
       collapse: "Collapse Chat Drawer"


### PR DESCRIPTION
Online count is a bit rough at the moment due to online definition.

It tends to go up and down, no way to easily drill in and see who and just
is becoming somewhat distracting and confusting.

You can pick the people you would like to see online status of by adding to
personal chat.

This has better parity with other chat application that do not surface
the total number.
