### PR TITLE
FEATURE: Expanded drop target for files

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -456,6 +456,16 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
     }
   },
 
+  _uploadDropTargetOptions() {
+    const targetEl = document.querySelector(".tc-live-pane");
+    if (!targetEl) {
+      return this._super();
+    }
+    return {
+      target: targetEl,
+    };
+  },
+
   addText(text) {
     const selected = this._getSelected(null, {
       lineVal: true,


### PR DESCRIPTION
The entire .tc-live-pane element can now be used to
drop files into for uploads. An .uppy-is-drag-over class
is added to the element on drag over and removed on
drag leave, and we can also hook into those events
if we want to do anything fancy with CSS or JS. This
commit just expands the area so it's no longer just
the text box.