### PR TITLE
FEATURE: Show last 20 personal channels when chat is isolated

### DIFF
--- a/assets/javascripts/discourse/components/channel-list.js
+++ b/assets/javascripts/discourse/components/channel-list.js
@@ -47,7 +47,7 @@ export default Component.extend({
             return unreadCountA > unreadCountB ? -1 : 1;
           }
         })
-        .slice(0, 10);
+        .slice(0, this.currentUser.chat_isolated ? 20 : 10);
     }
   ),
 


### PR DESCRIPTION
With chat isolated, the sidebar is much smaller and there is room to show the latest 20 personal that channels instead of 10.