### PR TITLE
FEATURE?: Mobile chat header icon opens channel list

### DIFF
--- a/assets/javascripts/discourse/controllers/chat-index.js
+++ b/assets/javascripts/discourse/controllers/chat-index.js
@@ -6,6 +6,7 @@ import { inject as service } from "@ember/service";
 export default Controller.extend({
   creatingDm: false,
   router: service(),
+  blankPage: false,
 
   @action
   openFollowModal() {
@@ -26,5 +27,10 @@ export default Controller.extend({
   @action
   cancelDmCreation() {
     this.set("creatingDm", false);
+  },
+
+  @action
+  selectChannel(channel) {
+    return this.router.transitionTo("chat.channel", channel.id, channel.title);
   },
 });

--- a/assets/javascripts/discourse/routes/chat-index.js
+++ b/assets/javascripts/discourse/routes/chat-index.js
@@ -1,8 +1,33 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import { ajax } from "discourse/lib/ajax";
+import { inject as service } from "@ember/service";
 
 export default DiscourseRoute.extend({
+  chat: service(),
+
   model() {
-    return ajax("/chat/chat_channels/all.json");
+    if (this.site.mobileView) {
+      return this.chat.getChannels().then((channels) => {
+        if (
+          channels.publicChannels.length ||
+          channels.directMessageChannels.length
+        ) {
+          return channels;
+        }
+      });
+    }
+  },
+
+  setupController(controller, model) {
+    this._super(...arguments);
+
+    if (!model) {
+      return ajax("/chat/chat_channels/all.json").then((channels) => {
+        controller.setProperties({
+          model: channels,
+          blankPage: true,
+        });
+      });
+    }
   },
 });

--- a/assets/javascripts/discourse/routes/chat.js
+++ b/assets/javascripts/discourse/routes/chat.js
@@ -23,6 +23,10 @@ export default DiscourseRoute.extend({
       return;
     }
 
+    if (this.site.mobileView) {
+      return this.transitionTo("chat.index");
+    }
+
     return this.chat.getIdealFirstChannelIdAndTitle().then((channelInfo) => {
       if (channelInfo) {
         return this.transitionTo(

--- a/assets/javascripts/discourse/templates/chat-index.hbs
+++ b/assets/javascripts/discourse/templates/chat-index.hbs
@@ -1,29 +1,37 @@
-<div class="empty-state">
-  <span class="empty-state-title">{{i18n "chat.empty_state.title"}}</span>
-  <div class="empty-state-body">
-    {{#if model.length}}
-      <p>{{i18n "chat.empty_state.public_available"}}</p>
-      {{d-button
-        class="btn-primary"
-        action=(action "openFollowModal")
-        label="chat.empty_state.follow_channels"
-      }}
-    {{else}}
-      <p>{{i18n "chat.empty_state.no_public_available"}}</p>
-    {{/if}}
-    <hr>
-    <p>{{i18n "chat.empty_state.start_direct_message"}}</p>
-    {{#if creatingDm}}
-      {{dm-creator
-        afterCreate=(action "afterDmCreation")
-        onCancel=(action "cancelDmCreation")
-      }}
-    {{else}}
-      {{d-button
-        class="btn-primary"
-        action=(action "startCreatingDm")
-        label="chat.empty_state.create_personal_chat"
-      }}
-    {{/if}}
+{{#if (eq mode "blankPage")}}
+  <div class="empty-state">
+    <span class="empty-state-title">{{i18n "chat.empty_state.title"}}</span>
+    <div class="empty-state-body">
+      {{#if model.length}}
+        <p>{{i18n "chat.empty_state.public_available"}}</p>
+        {{d-button
+          class="btn-primary"
+          action=(action "openFollowModal")
+          label="chat.empty_state.follow_channels"
+        }}
+      {{else}}
+        <p>{{i18n "chat.empty_state.no_public_available"}}</p>
+      {{/if}}
+      <hr>
+      <p>{{i18n "chat.empty_state.start_direct_message"}}</p>
+      {{#if creatingDm}}
+        {{dm-creator
+          afterCreate=(action "afterDmCreation")
+          onCancel=(action "cancelDmCreation")
+        }}
+      {{else}}
+        {{d-button
+          class="btn-primary"
+          action=(action "startCreatingDm")
+          label="chat.empty_state.create_personal_chat"
+        }}
+      {{/if}}
+    </div>
   </div>
-</div>
+{{else}}
+  {{channel-list
+    publicChannels=model.publicChannels
+    directMessageChannels=model.directMessageChannels
+    onSelect=(action "selectChannel")
+  }}
+{{/if}}


### PR DESCRIPTION
This overloads the chat index route a bit to handle 2 cases - 
1. for when the user has not joined any channels
2. channel selector index

The reason for this: We need a channel selector index for mobile chat. Can't use`chat.channel` route, as we need a channel ID and title for that route, and we really just want this channel index to live at `/chat`. This solution seems fine for now, but I could see us moving the blank page to `/chat/get-started` if it needs more complex logic or we add more rich features.