### PR TITLE
FIX: Layout issue with selecting messages

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -336,7 +336,8 @@ export default Component.extend({
     );
     if (messageEl) {
       next(() => {
-        messageEl.scrollIntoView();
+        this._scrollerEl.scrollTop =
+          messageEl.offsetTop - this._scrollerEl.offsetTop - 20;
       });
       if (opts.highlight) {
         messageEl.classList.add("highlighted");

--- a/assets/javascripts/discourse/templates/components/tc-message.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-message.hbs
@@ -1,13 +1,13 @@
-<div class={{messageContainerClasses}}>
-  {{#if message.newestMessage}}
-    <div class="tc-new-messages">
-      <div class="new-message-separator"></div>
-      <span class="new-message-indicator">
-        {{i18n "chat.new_messages"}}
-      </span>
-    </div>
-  {{/if}}
+{{#if message.newestMessage}}
+  <div class="tc-new-messages">
+    <div class="new-message-separator"></div>
+    <span class="new-message-indicator">
+      {{i18n "chat.new_messages"}}
+    </span>
+  </div>
+{{/if}}
 
+<div class={{messageContainerClasses}}>
   {{emoji-picker
     isActive=emojiPickerIsActive
     isEditorFocused=true


### PR DESCRIPTION
Fixes the issue in screenshot. The problem was we adjust the grid layout when selecting messages and the new message indicator was inside the grid. Moving it out, and adjusting the scrollToMessage function to subtract 20 pixels gets us to the same place.

<img width="438" alt="Screen Shot 2021-12-15 at 2 10 39 PM" src="https://user-images.githubusercontent.com/16214023/146257926-b3a6920a-7ed2-46d0-8bcd-995bfbe4a448.png">
 
