### PR TITLE
FEATURE: Open non-chat routes in new tab with chat isolated

### DIFF
--- a/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/assets/javascripts/discourse/initializers/chat-setup.js
@@ -44,27 +44,22 @@ export default {
           if (!currentUser.chat_isolated) {
             return;
           }
+          const currentUrl = window.location.href;
           const from = transition?.from;
-          if (from?.name !== "chat.channel") {
+          const to = transition.to;
+          if (from?.name !== "chat.channel" || to.name === "loading") {
             return;
           }
 
-          const to = transition.to;
-          if (
-            to.name &&
-            !to.name.startsWith("chat.") &&
-            !to.name.startsWith("preferences.")
-          ) {
+          if (to.name && !to.name.startsWith("chat.")) {
+            const destinationUrl =
+              to.paramNames.length > 0
+                ? router.urlFor(to.name, to.params)
+                : router.urlFor(to.name);
             transition.abort();
-            window.open(transition.intent.url);
+            window.open(destinationUrl);
             next(() => {
-              let originalUrl;
-              if (to.paramNames.length > 0) {
-                originalUrl = router.urlFor(from.name, from.params);
-              } else {
-                originalUrl = router.urlFor(from.name);
-              }
-              history.replaceState({}, "", originalUrl);
+              history.replaceState({}, "", currentUrl);
             });
             return false;
           }

--- a/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/assets/javascripts/discourse/initializers/chat-setup.js
@@ -1,4 +1,6 @@
+import { action } from "@ember/object";
 import { withPluginApi } from "discourse/lib/plugin-api";
+export const PLUGIN_ID = "discourse-chat";
 
 export default {
   name: "chat-setup",
@@ -35,6 +37,30 @@ export default {
         "chat:rerender-header"
       );
       api.addToHeaderIcons("header-chat-link");
+
+      if (currentUser.chat_isolated) {
+        api.modifyClass("route:application", {
+          pluginId: PLUGIN_ID,
+
+          @action
+          willTransition(transition) {
+            this._super(...arguments);
+
+            if (!currentUser.chat_isolated) {
+              return;
+            }
+
+            const fromInsideChat = transition.from.name === "chat.channel";
+            const toOutsideChat =
+              transition.to.name !== "chat" &&
+              transition.to.name !== "chat.channel";
+            if (fromInsideChat && toOutsideChat) {
+              window.open(transition.intent.url);
+              transition.abort();
+            }
+          },
+        });
+      }
     });
   },
 };

--- a/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/assets/javascripts/discourse/initializers/chat-setup.js
@@ -1,4 +1,3 @@
-import { action } from "@ember/object";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { next } from "@ember/runloop";
 export const PLUGIN_ID = "discourse-chat";

--- a/assets/javascripts/discourse/initializers/chat-topic-changes.js
+++ b/assets/javascripts/discourse/initializers/chat-topic-changes.js
@@ -4,8 +4,7 @@ import RawTopicStatus from "discourse/raw-views/topic-status";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { withPluginApi } from "discourse/lib/plugin-api";
-
-export const PLUGIN_ID = "discourse-chat";
+import { PLUGIN_ID } from "discourse/plugins/discourse-chat/discourse/initializers/chat-setup";
 
 function toggleChatForTopic(topic, appEvents, chat) {
   topic.set("has_chat_live", !topic.has_chat_live);

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -903,17 +903,7 @@ acceptance(
           ".header-dropdown-toggle.open-chat .chat-unread-urgent-indicator"
         )
       );
-    });
-
-    test("Unread indicator does show on chat page when use has chat_isolated", async function (assert) {
-      updateCurrentUser({ chat_isolated: true });
-      await visit("/chat/channel/9/Site");
-      await click(".header-dropdown-toggle.open-chat"); // Force re-render. Flakey otherwise.
-      assert.ok(
-        exists(
-          ".header-dropdown-toggle.open-chat .chat-unread-urgent-indicator"
-        )
-      );
+      updateCurrentUser({ chat_isolated: false });
     });
 
     test("Chat float open to DM channel with unread messages with sidebar off", async function (assert) {


### PR DESCRIPTION
Followed the ember guide on this one - https://guides.emberjs.com/release/routing/preventing-and-retrying-transitions/

The only quirk is that the URL will transition even after a route is aborted... There is an ugly hack to fix this using `next` and `replaceState` to fix the URL. It _works_.

EDIT:
There are so many little issues that keep popping up. IDK if this approach will work.