### PR TITLE
FIX: Desktop notification for group new message

### DIFF
--- a/app/jobs/regular/notify_users_watching_chat.rb
+++ b/app/jobs/regular/notify_users_watching_chat.rb
@@ -33,13 +33,17 @@ module Jobs
       return if DiscourseChat::ChatNotifier.user_has_seen_message?(membership, @chat_message.id)
       return if online_user_ids.include?(user.id)
 
+      translated_title = @chat_channel.group_direct_message_channel? ?
+        I18n.t("discourse_push_notifications.popup.group_chat_message") :
+        I18n.t("discourse_push_notifications.popup.chat_message",
+               chat_channel_title: @chat_channel.title(user)
+              )
+
       payload = {
         username: @creator.username,
         notification_type: Notification.types[:chat_message],
         post_url: "/chat/channel/#{@chat_channel.id}/#{@chat_channel.title(user)}",
-        translated_title: I18n.t("discourse_push_notifications.popup.chat_message",
-                                 chat_channel_title: @chat_channel.title(membership.user)
-                                ),
+        translated_title: translated_title,
         tag: DiscourseChat::ChatNotifier.push_notification_tag(:message, @chat_channel.id),
         excerpt: @chat_message.push_notification_excerpt
       }

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -37,6 +37,10 @@ class ChatChannel < ActiveRecord::Base
     chatable_type == "DirectMessageChannel"
   end
 
+  def group_direct_message_channel?
+    direct_message_channel? && chatable.users.count > 2
+  end
+
   def chatable_has_custom_fields?
     topic_channel? || category_channel?
   end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -14,8 +14,9 @@ en:
 
   discourse_push_notifications:
     popup:
-      chat_message: "New chat message in %{chat_channel_title}"
       chat_mention: "@%{username} mentioned you in chat"
+      chat_message: "New chat message in %{chat_channel_title}"
+      group_chat_message: "New chat message in a personal chat channel"
 
   discourse_automation:
     scriptables:


### PR DESCRIPTION
Group personal chat messages don't have a title right now so instead of 
> New chat message in 134

it's

> New chat message in a personal chat channel