### PR TITLE
FIX: Show channel list in sidebar on browse page

### DIFF
--- a/assets/javascripts/discourse/components/sidebar-channels.js
+++ b/assets/javascripts/discourse/components/sidebar-channels.js
@@ -34,7 +34,12 @@ export default Component.extend({
   },
 
   calcShouldShow() {
-    this.set("show", !this.currentUser.chat_isolated || this.chat.onChatPage());
+    this.set(
+      "show",
+      !this.currentUser.chat_isolated ||
+        this.chat.onChatPage() ||
+        this.chat.onBrowsePage()
+    );
     if (this.show && !this.fetchedChannels) {
       this.fetchChannels();
     }

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -93,6 +93,10 @@ export default Service.extend({
     );
   },
 
+  onBrowsePage() {
+    return this.router.currentRouteName === "chat.browse";
+  },
+
   getSidebarActive() {
     return this.sidebarActive;
   },


### PR DESCRIPTION
This is kind of impossible to test since it relies on the sidebar plugin being installed to be render...