### PR TITLE
FIX: Clicking mentions doesn't leave weird state

### DIFF
--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -45,7 +45,11 @@ export default Component.extend({
       "openChannelForChatable"
     );
     this.appEvents.on("chat:open-channel", this, "switchChannel");
-    this.appEvents.on("chat:open-message", this, "openChannelAtMessage");
+    this.appEvents.on(
+      "chat:open-channel-at-message",
+      this,
+      "openChannelAtMessage"
+    );
     this.appEvents.on("chat:refresh-channels", this, "refreshChannels");
     this.appEvents.on("topic-chat-enable", this, "chatEnabledForTopic");
     this.appEvents.on("topic-chat-disable", this, "chatDisabledForTopic");
@@ -76,7 +80,11 @@ export default Component.extend({
         "openChannelForChatable"
       );
       this.appEvents.off("chat:open-channel", this, "switchChannel");
-      this.appEvents.off("chat:open-message", this, "openChannelAtMessage");
+      this.appEvents.off(
+        "chat:open-channel-at-message",
+        this,
+        "openChannelAtMessage"
+      );
       this.appEvents.off("chat:refresh-channels", this, "refreshChannels");
       this.appEvents.off("topic-chat-enable", this, "chatEnabledForTopic");
       this.appEvents.off("topic-chat-disable", this, "chatDisabledForTopic");
@@ -130,14 +138,15 @@ export default Component.extend({
     }
   },
 
-  openChannelAtMessage(chatChannelId, messageId, openFloat) {
-    if (!openFloat) {
-      return;
-    }
-
-    this.chat.getChannelBy("id", chatChannelId).then((channel) => {
+  openChannelAtMessage(channel, messageId) {
+    if (this.activeChannel?.id === channel.id) {
+      // Already have this channel open. Fire app event to notify chat-live-pane
+      // to highlight or fetch the message.
+      this.appEvents.trigger("chat-live-pane:highlight-message", messageId);
+    } else {
+      this.chat.setTargetMessageId(messageId);
       this.switchChannel(channel);
-    });
+    }
   },
 
   chatEnabledForTopic(topic) {

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -123,15 +123,15 @@ export default Service.extend({
     });
   },
 
-  setMessageId(messageId) {
+  setTargetMessageId(messageId) {
     this.set("messageId", messageId);
   },
 
-  getMessageId() {
+  getTargetMessageId() {
     return this.messageId;
   },
 
-  clearMessageId() {
+  clearTargetMessageId() {
     this.set("messageId", null);
   },
 
@@ -362,7 +362,7 @@ export default Service.extend({
       this.router.currentRouteName === "chat.channel" &&
       this.router.currentRoute.params.channelTitle === channel.title
     ) {
-      this._fireOpenMessageAppEvent(channel.id, messageId);
+      this._fireOpenMessageAppEvent(messageId);
     } else if (
       Site.currentProp("mobileView") ||
       this.router.currentRouteName === "chat" ||
@@ -373,18 +373,16 @@ export default Service.extend({
         queryParams: { messageId: messageId },
       });
     } else {
-      this.setMessageId(messageId);
-      this._fireOpenMessageAppEvent(channel.id, messageId, { openFloat: true });
+      this._fireOpenFloatAppEvent(channel, messageId);
     }
   },
 
-  _fireOpenMessageAppEvent(channelId, messageId, opts = { openFloat: false }) {
-    this.appEvents.trigger(
-      "chat:open-message",
-      channelId,
-      messageId,
-      opts.openFloat
-    );
+  _fireOpenFloatAppEvent(channel, messageId) {
+    this.appEvents.trigger("chat:open-channel-at-message", channel, messageId);
+  },
+
+  _fireOpenMessageAppEvent(messageId) {
+    this.appEvents.trigger("chat-live-pane:highlight-message", messageId);
   },
 
   async startTrackingChannel(channel) {


### PR DESCRIPTION
This does a few things
1. Clicking mentions when the channel was already open would call `fetchChannels` without passing in the `chatChannelId`, causing the chat live pane to not recover. Simply add the `chatChannelId` into the calls, and that issue is fixed.

2. Refactor the open channel at message logic to be more clear to follow (for me at least). The `chat float` and `chat live pane` (a child of the float) were listening to the same appEvent and it was really messy. This make the `chat float` pick up appEvents from the chat service, and then pass that information to the `chat live pane`.