### PR TITLE
UX: Prevent message overflow; circular indicators

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-message-render.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message-render.hbs
@@ -1,7 +1,0 @@
-<div class="tc-meta-data">
-  {{avatar message.user imageSize="tiny"}}
-  {{! TODO make computed, respect prioritize name}}
-  <span class="chat-user-name">{{message.user.username}}</span>
-  <span class="chat-timestamp">{{format-date message.created_at format="tiny"}}</span>
-</div>
-<div class="tc-msgbody">{{message.message}}</div>

--- a/assets/javascripts/discourse/templates/components/tc-message.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-message.hbs
@@ -156,7 +156,7 @@
               {{html-safe actionCodeText}}
             </span>
           {{else}}
-            <p class="tc-text">
+            <div class="tc-text">
               {{html-safe message.cooked}}
               {{#if message.uploads.length}}
                 <div class="tc-uploads">
@@ -197,7 +197,7 @@
                   }}
                 </div>
               {{/if}}
-            </p>
+            </div>
           {{/if}}
           {{#if message.error}}
             <div class="tc-send-error">

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -2,8 +2,7 @@ $header-height: 2.5rem;
 $float-height: 530px;
 
 :root {
-  --small-message-left-width: 28px;
-  --large-message-left-width: 38px;
+  --message-left-width: 38px;
   --full-page-border-radius: 12px;
   --full-page-sidebar-width: 275px;
 }
@@ -294,22 +293,30 @@ $float-height: 530px;
 
 .tc-avatar-container {
   position: relative;
+
   .avatar {
     width: 100%;
     height: auto;
   }
+
   .tc-presence-flair {
+    box-sizing: border-box;
     display: none;
     position: absolute;
-    right: 0;
-    bottom: 0;
-
+    right: -2px;
+    bottom: -2px;
     background-color: var(--success);
-    width: 30%;
-    height: 30%;
-
+    width: 8px;
+    height: 8px;
     border: 1px solid var(--secondary);
     border-radius: 50%;
+
+    .tc-messages-container & {
+      right: -1px;
+      bottom: -1px;
+      width: 10px;
+      height: 10px;
+    }
 
     &.online {
       display: block;
@@ -337,8 +344,8 @@ $float-height: 530px;
   white-space: normal;
 
   .tc-message-deleted {
-    margin-left: calc(var(--large-message-left-width) + 1em);
-    padding: 0.25em;
+    margin-left: calc(var(--message-left-width) + 0.75em);
+    padding: 0;
 
     .tc-message-expand-deleted {
       color: var(--primary-low-mid);
@@ -365,18 +372,31 @@ $float-height: 530px;
     &.tc-action {
       background-color: var(--highlight-medium);
     }
+
     &.deleted {
-      background-color: var(--danger-medium);
+      background-color: var(--danger-low);
     }
+
+    .not-mobile-device &.deleted:hover {
+      background-color: var(--danger-hover);
+    }
+
     &.transition-slow {
       transition: 2s linear background-color;
     }
+
+    .tc-avatar {
+      flex-shrink: 0;
+      width: var(--message-left-width);
+    }
+
     &.user-info-hidden {
       .tc-meta-data {
-        display: inline-block;
-        width: var(--small-message-left-width);
-        padding-right: 0.2em;
-        vertical-align: top;
+        display: flex;
+        flex-shrink: 0;
+        justify-content: center;
+        padding-top: 0.3em;
+        width: var(--message-left-width);
 
         .relative-date {
           visibility: hidden;
@@ -384,20 +404,22 @@ $float-height: 530px;
       }
 
       .tc-message-container {
-        margin-left: 0;
+        flex-direction: row;
       }
 
       .tc-msgactions-hover {
         top: -2em;
       }
     }
+
     &.is-reply {
       display: grid;
-      grid-template-columns: var(--small-message-left-width) 1fr;
+      grid-template-columns: var(--message-left-width) 1fr;
       grid-template-rows: 30px auto;
       grid-template-areas:
         "replyto replyto"
         "avatar message";
+
       .tc-reply-display {
         grid-area: replyto;
         cursor: pointer;
@@ -410,24 +432,28 @@ $float-height: 530px;
         grid-area: avatar;
         width: 100%;
       }
+
       .tc-message-container {
         grid-area: message;
-        width: 100%;
       }
     }
+
     .tc-message-container {
-      margin-left: 0.5em;
+      display: flex;
+      flex-direction: column;
       flex-grow: 1;
       word-break: break-word;
       overflow-wrap: break-word;
+      min-width: 0;
     }
 
     .tc-avatar-container {
       align-items: flex-start;
       display: flex;
       cursor: pointer;
+      flex-shrink: 0;
       justify-content: center;
-      width: var(--small-message-left-width);
+      width: 28px;
     }
 
     .tc-bot-indicator {
@@ -438,9 +464,8 @@ $float-height: 530px;
       font-size: var(--font-down-2);
       margin-left: -0.25em;
     }
+
     .tc-text {
-      display: inline-block;
-      margin: 0;
       img {
         max-width: 100%;
         height: unset;
@@ -633,13 +658,14 @@ $float-height: 530px;
 
   .tc-meta-data {
     color: var(--secondary-medium);
+    width: 100%;
 
     .names {
       color: var(--secondary-low);
       display: inline-block;
       vertical-align: bottom;
-      margin-left: 0;
-      margin-right: 4px;
+      margin-right: 0.25em;
+
       &.first {
         font-weight: bold;
       }
@@ -686,21 +712,22 @@ $float-height: 530px;
 }
 
 .tc-reply-display {
-  height: 2em;
+  display: flex;
   align-items: center;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
   font-size: var(--font-down-1);
-  margin-bottom: -0.5em;
+  padding-left: 0.5em;
 
   .tc-reply-av {
-    padding: 0 0.5em 0 0.3em;
+    padding: 0 0.5em;
   }
 
   .tc-reply-username {
     padding: 0 0.5em 0 0;
   }
+
   .tc-reply-msg {
     align-self: baseline;
     color: var(--primary-high);

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -27,19 +27,17 @@
       .tc-message {
         &.user-info-hidden {
           .tc-meta-data {
-            width: var(--large-message-left-width);
-            padding-right: 0.3em;
+            justify-content: flex-start;
+            width: var(--message-left-width);
           }
         }
-        &.is-reply {
-          grid-template-columns: var(--large-message-left-width) 1fr;
 
-          .tc-avatar {
-            width: var(--large-message-left-width);
-          }
+        &.is-reply {
+          grid-template-columns: var(--message-left-width) 1fr;
         }
+
         .tc-avatar {
-          width: var(--large-message-left-width);
+          width: var(--message-left-width);
         }
       }
     }
@@ -71,20 +69,13 @@
 .tc-message:not(.user-info-hidden) {
   padding: 0.15em 1em;
   margin-top: 0.5em;
-
-  .tc-message-container {
-    max-width: calc(100% - (var(--large-message-left-width) + 1em));
-
-    .tc-text {
-      width: 100%;
-    }
-  }
 }
 
 .tc-text {
   img:not(.emoji):not(.avatar) {
     -webkit-transition: all 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
     transition: all 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
+
     &:hover {
       cursor: pointer;
       border-radius: 5px;
@@ -96,14 +87,6 @@
 
 .tc-message.user-info-hidden {
   padding: 0.15em 1em;
-
-  .tc-message-container {
-    width: 100%;
-
-    .tc-text {
-      width: calc(100% - (var(--large-message-left-width) + 1em));
-    }
-  }
 }
 
 // Full Page Styling in Core
@@ -132,10 +115,10 @@
     }
     .tc-live-pane,
     .tc-messages-scroll,
-    .tc-message:not(.highlighted) {
+    .tc-message:not(.highlighted):not(.deleted) {
       background-color: transparent;
     }
-    .tc-message:hover {
+    .tc-message:not(.highlighted):not(.deleted):hover {
       background-color: var(--primary-very-low);
     }
   }

--- a/assets/stylesheets/mobile/mobile.scss
+++ b/assets/stylesheets/mobile/mobile.scss
@@ -53,32 +53,10 @@
 .tc-message:not(.user-info-hidden) {
   padding: 0.25em 1em 0.1em;
   margin-top: 0.5em;
-
-  .tc-message-container {
-    max-width: calc(100% - (var(--small-message-left-width) + 1em));
-
-    .tc-text {
-      width: 100%;
-    }
-  }
 }
 
 .tc-message.user-info-hidden {
   padding: 0.1em 1em;
-
-  .tc-message-container {
-    width: 100%;
-
-    .tc-text {
-      max-width: calc(100% - (var(--small-message-left-width) + 1em));
-    }
-  }
-}
-
-.tc-messages-container {
-  .tc-message-deleted {
-    margin-left: calc(var(--small-message-left-width) + 1em);
-  }
 }
 
 body.has-full-page-chat .footer-nav {


### PR DESCRIPTION
Mostly message sizing, to prevent them from expanding beyond parent element bounds.
Also: circular (i.e. not oval) presence indicators. 🟢 

Chance of regressing something: pretty high.
But I tried it out in full-chat mode, floating, and mobile. Short messages, long, replies, images.