### PR TITLE
UX: Make area beside scroll-to-bottom clickable

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -56,11 +56,14 @@
 </div>
 
 <div class="scroll-stick-wrap">
-  <div class="scroll-stick-wrap2">
-    <a href title={{i18n "chat.scroll_to_bottom"}} class="btn btn-flat chat-scroll-to-bottom {{if this.stickyScroll "hidden"}}" {{on "click" (action "restickScrolling")}}>
-      {{d-icon "arrow-down"}}
-    </a>
-  </div>
+  <a
+    href
+    title={{i18n "chat.scroll_to_bottom"}}
+    class="btn btn-flat chat-scroll-to-bottom {{if this.stickyScroll "hidden"}}"
+    {{on "click" (action "restickScrolling")}}
+  >
+    {{d-icon "arrow-down"}}
+  </a>
 </div>
 
 {{#if expanded}}
@@ -100,4 +103,3 @@
 
   {{chat-replying-indicator chatChannelId=chatChannel.id}}
 {{/if}}
-

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -811,21 +811,18 @@ $float-height: 530px;
   .scroll-stick-wrap {
     position: relative;
   }
-  .scroll-stick-wrap2 {
-    position: absolute;
-    bottom: 0;
-    margin-bottom: 1em;
-    display: flex;
-    width: 100%;
-    justify-content: center;
-  }
 
   .chat-scroll-to-bottom {
     background: var(--primary-medium);
-    padding: 0.5em;
+    bottom: 1em;
     border-radius: 100%;
+    left: 50%;
     opacity: 20%;
+    padding: 0.5em;
+    position: absolute;
+    transform: translateX(-50%);
     z-index: 2;
+
     &:hover {
       opacity: 75%;
     }


### PR DESCRIPTION
The wrapper used to cover the whole width and capture the click events.