### PR TITLE
FIX: Use discourseComputed value to get updated chatChannel

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -485,13 +485,11 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
     this.set("emojiPickerIsActive", false);
   },
 
-  @discourseComputed("previewing")
-  placeholder(previewing) {
+  @discourseComputed("previewing", "chatChannel")
+  placeholder(previewing, chatChannel) {
     return previewing
       ? I18n.t("chat.placeholder_previewing")
-      : this.siteSettings.chat_channel_placeholders
-      ? this.messageRecipient(this.chatChannel)
-      : I18n.t("chat.placeholder");
+      : this.messageRecipient(chatChannel);
   },
 
   messageRecipient(chatChannel) {

--- a/assets/javascripts/discourse/components/full-page-chat.js
+++ b/assets/javascripts/discourse/components/full-page-chat.js
@@ -96,20 +96,7 @@ export default Component.extend({
     this.set("showingChannels", false);
 
     if (channel.id !== this.chatChannel.id) {
-      if (this.siteSettings.chat_channel_placeholders) {
-        // eslint-disable-next-line no-console
-        console.log(
-          `full-page-chat.switchChannels from: ${this.chatChannel.id} -> ${channel.id}`
-        );
-      }
-
       this.router.transitionTo("chat.channel", channel.id, channel.title);
-      if (this.siteSettings.chat_channel_placeholders) {
-        // eslint-disable-next-line no-console
-        console.log(
-          `full-page-chat.switchChannels router.transitionedTo ${channel.id}`
-        );
-      }
     }
 
     return false;

--- a/assets/javascripts/discourse/routes/chat-channel.js
+++ b/assets/javascripts/discourse/routes/chat-channel.js
@@ -27,10 +27,6 @@ export default DiscourseRoute.extend({
   },
 
   async getChannel(id) {
-    if (this.siteSettings.chat_channel_placeholders) {
-      // eslint-disable-next-line no-console
-      console.log("chat-channel.getChannel " + id);
-    }
     let channel = await this.chat.getChannelBy("id", id);
     let previewing = false;
     if (!channel) {

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,7 +15,3 @@ plugins:
   chat_debug_webhook_payloads:
     default: false
     hidden: true
-  chat_channel_placeholders:
-    default: false
-    hidden: true
-    client: true

--- a/test/javascripts/components/chat-composer-placeholder-test.js
+++ b/test/javascripts/components/chat-composer-placeholder-test.js
@@ -14,7 +14,6 @@ discourseModule(
       template: hbs`{{chat-composer chatChannel=chatChannel}}`,
 
       beforeEach() {
-        set(this.siteSettings, "chat_channel_placeholders", true);
         set(this.currentUser, "id", 1);
         this.set("chatChannel", {
           chatable_type: "DirectMessageChannel",
@@ -36,7 +35,6 @@ discourseModule(
       template: hbs`{{chat-composer chatChannel=chatChannel}}`,
 
       beforeEach() {
-        set(this.siteSettings, "chat_channel_placeholders", true);
         this.set("chatChannel", {
           chatable_type: "DirectMessageChannel",
           chatable: {
@@ -61,7 +59,6 @@ discourseModule(
       template: hbs`{{chat-composer chatChannel=chatChannel}}`,
 
       beforeEach() {
-        set(this.siteSettings, "chat_channel_placeholders", true);
         this.set("chatChannel", {
           chatable_type: "Category",
           title: "just-cats",
@@ -73,22 +70,6 @@ discourseModule(
           query(".tc-composer-input").placeholder,
           "Send a message to #just-cats"
         );
-      },
-    });
-
-    componentTest("site setting off so message to channel shows 'chat...'", {
-      template: hbs`{{chat-composer chatChannel=chatChannel}}`,
-
-      beforeEach() {
-        set(this.siteSettings, "chat_channel_placeholders", false);
-        this.set("chatChannel", {
-          chatable_type: "Category",
-          title: "just-cats",
-        });
-      },
-
-      async test(assert) {
-        assert.equal(query(".tc-composer-input").placeholder, "chat...");
       },
     });
   }


### PR DESCRIPTION
This solves the problem when the channel is changed but the chatChannel value isn't modified due to the loading slider plugin.

Related: https://github.com/discourse/discourse-chat/pull/384 and https://github.com/discourse/discourse-chat/pull/391