### PR TITLE
UI: Single-line chat placeholder

### DIFF
--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -226,10 +226,6 @@ export default Service.extend({
   },
 
   async getChannelBy(key, value) {
-    if (this.siteSettings.chat_channel_placeholders) {
-      // eslint-disable-next-line no-console
-      console.log(`chat.getChannelBy ${key} ${value}`);
-    }
     return this.getChannels().then(() => {
       if (!isNaN(value)) {
         value = parseInt(value, 10);

--- a/assets/stylesheets/mobile/mobile.scss
+++ b/assets/stylesheets/mobile/mobile.scss
@@ -29,7 +29,14 @@
 .tc-live-pane .tc-composer .tc-composer-row {
   .tc-composer-input {
     padding-right: 75px;
+
+    &::-webkit-input-placeholder {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
   }
+
   .open-toolbar-btn {
     right: 50px;
   }


### PR DESCRIPTION
Chat channels with long names have end up with two awkward rows of placeholder. This shortens it to just one

from
<img width="384" alt="Screenshot 2021-12-27 at 3 53 32 PM" src="https://user-images.githubusercontent.com/1555215/147448829-7f7e9ab9-4b64-44cb-a3de-54a443f9354b.png">

to
<img width="384" alt="Screenshot 2021-12-27 at 3 53 11 PM" src="https://user-images.githubusercontent.com/1555215/147448807-b4fc09f4-444a-4335-86dc-123dc2a07eab.png">
.