### PR TITLE
UX: Remove emoji specific margins

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1217,16 +1217,7 @@ body.composer-open.topic-chat-floar-container {
 
     .emoji {
       height: 1.2em;
-      margin: 0 0.5em;
       width: 1.2em;
-
-      &:first-child {
-        margin-left: 0;
-      }
-
-      &:last-child {
-        margin-right: 0;
-      }
     }
   }
 


### PR DESCRIPTION
I do not believe we need specific emoji targeted margins here as they should receive the same spacing as the text tag they are located in.