### PR TITLE
FEATURE: Collapse youtube previews in chat

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -966,7 +966,7 @@ export default Component.extend({
     }
 
     this.element.querySelectorAll(".lazyYT").forEach((iframe) => {
-      $(iframe).lazyYT({ collapsible: true });
+      $(iframe).lazyYT();
       collapseLazyYT(iframe);
     });
 

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -22,6 +22,7 @@ import { resolveAllShortUrls } from "pretty-text/upload-short-url";
 import { samePrefix } from "discourse-common/lib/get-url";
 import { spinnerHTML } from "discourse/helpers/loading-spinner";
 import { decorateGithubOneboxBody } from "discourse/initializers/onebox-decorators";
+import collapseLazyYT from "discourse/plugins/discourse-chat/discourse/lib/collapse-lazy-yt";
 
 const MAX_RECENT_MSGS = 100;
 const STICKY_SCROLL_LENIENCE = 4;
@@ -965,7 +966,8 @@ export default Component.extend({
     }
 
     this.element.querySelectorAll(".lazyYT").forEach((iframe) => {
-      $(iframe).lazyYT();
+      $(iframe).lazyYT({ collapsible: true });
+      collapseLazyYT(iframe);
     });
 
     decorateGithubOneboxBody(this.element);

--- a/assets/javascripts/discourse/lib/collapse-lazy-yt.js
+++ b/assets/javascripts/discourse/lib/collapse-lazy-yt.js
@@ -1,0 +1,56 @@
+import escape from "discourse-common/lib/escape";
+
+export default function collapseLazyYT(onebox) {
+  const parent = onebox.parentElement;
+  const title = onebox.getAttribute("data-youtube-title");
+  const id = onebox.getAttribute("data-youtube-id");
+
+  parent.removeChild(onebox);
+  const [text, collapsible] = createCollapsibleToggle(onebox, id, title);
+  parent.appendChild(text);
+  parent.appendChild(collapsible);
+}
+
+function createVideoLink(videoLinkClass, id, title) {
+  const link = document.createElement("a");
+  link.classList.add(videoLinkClass);
+  link.setAttribute("target", "_blank");
+  link.setAttribute("href", `https://www.youtube.com/watch?v=${escape(id)}`);
+  link.text = title;
+  return link;
+}
+
+function createSvgIcon(className, direction) {
+  const svg = document.createElement("div");
+  svg.innerHTML = `<svg class="${className} fa svg-icon" xmlns="http://www.w3.org/2000/svg"><use href="#caret-${direction}"></use></svg>`;
+  return svg.firstChild;
+}
+
+function createCollapsibleToggle(onebox, id, title) {
+  const toggle = document.createElement("span");
+  const open = createSvgIcon("lazyYT-collapsible-open", "down");
+  const closed = createSvgIcon("lazyYT-collapsible-closed", "right");
+  closed.setAttribute("hidden", true);
+
+  toggle.appendChild(createVideoLink("lazyYT-collapsible-link", id, title));
+  toggle.appendChild(open);
+  toggle.appendChild(closed);
+
+  const collapsibleDiv = document.createElement("div");
+  collapsibleDiv.classList.add("lazyYT-collapsible");
+  collapsibleDiv.appendChild(onebox);
+
+  closed.addEventListener("click", (e) => {
+    e.target.setAttribute("hidden", true);
+    open.removeAttribute("hidden");
+    collapsibleDiv.removeAttribute("hidden");
+  });
+
+  open.addEventListener("click", (e) => {
+    e.target.setAttribute("hidden", true);
+    closed.removeAttribute("hidden");
+    collapsibleDiv.setAttribute("hidden", true);
+  });
+
+  return [toggle, collapsibleDiv];
+}

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -583,6 +583,12 @@ $float-height: 530px;
           border-radius: 0;
         }
       }
+
+      .lazyYT-collapsible[hidden],
+      .lazyYT-collapsible-open[hidden],
+      .lazyYT-collapsible-closed[hidden] {
+        display: none;
+      }
     }
     .tc-message-edited {
       display: inline-block;

--- a/test/javascripts/acceptance/chat-live-pane-collapse-test.js
+++ b/test/javascripts/acceptance/chat-live-pane-collapse-test.js
@@ -1,0 +1,80 @@
+import { visit } from "@ember/test-helpers";
+import {
+  acceptance,
+  exists,
+  visible,
+} from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+
+acceptance("Discourse Chat - Chat live pane", function (needs) {
+  needs.user({
+    username: "eviltrout",
+    id: 1,
+    can_chat: true,
+    has_chat_enabled: true,
+  });
+  needs.settings({
+    chat_enabled: true,
+  });
+  needs.pretender((server, helper) => {
+    server.get("/chat/:chatChannelId/messages.json", () =>
+      helper.response({
+        chat_messages: [
+          {
+            id: 1,
+            message: "https://www.youtube.com/watch?v=aOWkVdU4NH0",
+            cooked:
+              '<div class="onebox lazyYT lazyYT-container" data-youtube-id="aOWkVdU4NH0" data-youtube-title="Picnic with my cat (shaved ice &amp; lemonade)" data-parameters="feature=oembed&amp;wmode=opaque"> <a href="https:/*www.youtube.com/watch?v=aOWkVdU4NH0" target="_blank" rel="nofollow ugc noopener">*/ <img class="ytp-thumbnail-image" src="https://img.youtube.com/vi/aOWkVdU4NH0/hqdefault.jpg" title="Picnic with my cat (shaved ice &amp; lemonade)"></a></div>',
+            excerpt:
+              '<a href="https://www.youtube.com/watch?v=aOWkVdU4NH0">[Picnic with my cat (shaved ice &amp; lemonade&hellip;</a>',
+            action_code: null,
+            created_at: "2021-07-20T08:14:16.950Z",
+            flag_count: 0,
+            user: {
+              avatar_template:
+                "/letter_avatar_proxy/v4/letter/t/a9a28c/{size}.png",
+              id: 1,
+              name: "Tomtom",
+              username: "tomtom",
+            },
+          },
+        ],
+      })
+    );
+
+    server.get("/chat/chat_channels.json", () =>
+      helper.response({
+        public_channels: [],
+        direct_message_channels: [],
+      })
+    );
+
+    server.get("/chat/chat_channels/:chatChannelId", () =>
+      helper.response({ chat_channel: { id: 1 } })
+    );
+  });
+
+  test("can collapse and expand youtube chat", async function (assert) {
+    const youtubeContainerSelector = ".lazyYT-collapsible .lazyYT-container";
+    const closed = ".lazyYT-collapsible-closed";
+    const open = ".lazyYT-collapsible-open";
+
+    await visit("/chat/channel/1/cat");
+
+    assert.ok(visible(youtubeContainerSelector));
+    assert.ok(exists(`${closed}[hidden]`), "the closed arrow is hidden");
+    assert.notOk(exists(`${open}[hidden]`), "the open arrow is not hidden");
+
+    await click(".lazyYT-collapsible-open");
+
+    assert.notOk(visible(youtubeContainerSelector));
+    assert.ok(exists(`${open}[hidden]`), "the open arrow is hidden");
+    assert.notOk(exists(`${closed}[hidden]`), "the closed arrow is not hidden");
+
+    await click(".lazyYT-collapsible-closed");
+
+    assert.ok(visible(youtubeContainerSelector));
+    assert.ok(exists(`${closed}[hidden]`), "the closed arrow is hidden again");
+    assert.notOk(exists(`${open}[hidden]`), "the open arrow is shown again");
+  });
+});


### PR DESCRIPTION
Introduce slack-esque folding for youtube onebox. /t/57501

(I actually spent some time looking at core's `lazyYT` to see if I could introduce a "collapsible" setting, but it had proved to be more difficult than just doing just this because of how it's padding the bottom manually.)

Here it is expanded:
<img width="811" alt="expanded youtube preview in chat" src="https://user-images.githubusercontent.com/1555215/147943061-4661817e-64f2-431b-abe1-8786e34a0039.png">


Here it is collapsed:
<img width="822" alt="collapsed youtube preview in chat" src="https://user-images.githubusercontent.com/1555215/147943069-67008c5c-f71f-4831-8d81-a978fb551f76.png">

