### PR TITLE
UX: Fix composer sizing

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1055,11 +1055,12 @@ body.composer-open .topic-chat-floar-container {
       // `after` pseudo-element should match input styling exactly
       // via https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/
       grid-area: 1 / 1 / 2 / 2;
-      margin-bottom: 0;
+      margin: 0;
       resize: none;
       max-height: 125px;
       padding: 8px 40px 8px 8px;
       border: 1px solid var(--primary-low-mid);
+      box-sizing: border-box;
       word-break: break-word;
       width: 100%;
     }

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -52,8 +52,6 @@
     }
 
     .tc-composer-row {
-      padding: 0 0.5em;
-
       .chat-composer-toolbar {
         right: 1em;
       }


### PR DESCRIPTION
The pseudo-element trick wasn't working correctly because `after` element had a bit different size.