### PR TITLE
FIX: Correctly handle `skip` result

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -417,13 +417,14 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
 
           return resolve(options);
         })
-          .then((list) =>
-            (list || []).map((code) => {
-              return { code, src: emojiUrlFor(code) };
-            })
-          )
           .then((list) => {
-            if (list.length) {
+            if (list === SKIP) {
+              return;
+            }
+            return list.map((code) => ({ code, src: emojiUrlFor(code) }));
+          })
+          .then((list) => {
+            if (list?.length) {
               list.push({ label: I18n.t("composer.more_emoji"), term });
             }
             return list;


### PR DESCRIPTION
Fixes the #334 fix. 😉