### PR TITLE
FIX: Chat channel timestamps columns defaults were static

### DIFF
--- a/db/post_migrate/20220104051326_change_chat_channels_timestamp_columns_to_timestamp_type.rb
+++ b/db/post_migrate/20220104051326_change_chat_channels_timestamp_columns_to_timestamp_type.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ChangeChatChannelsTimestampColumnsToTimestampType < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :chat_channels, :created_at, nil
+    change_column_default :chat_channels, :updated_at, nil
+    change_column :chat_channels, :created_at, :timestamp
+    change_column :chat_channels, :updated_at, :timestamp
+  end
+end


### PR DESCRIPTION
In the migration added in https://github.com/discourse-org/discourse-topic-chat/commit/ba49568c2307e7abe1097312402be48102b28709
we added the created_at and updated_at columns after the
chat_channels table already existed. The way we did this was
not quite right; we used `Time.now` as the `default` for the
column, but Rails appears to take that to mean "use the now time
from the same date + time as the migration". Therefore any time
these columns were set to default, the date + time was always
`2021-08-24 23:48:01.169413`.

This commit fixes the issue by removing the default value for
the columns and changing the columns from `datetime` to `timestamp`,
which lets Rails wield its wizardry with the timestamps, and the
defaults are now correct for new channels.