### PR TITLE
DEV: Add model annotations

### DIFF
--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -90,3 +90,25 @@ class ChatChannel < ActiveRecord::Base
     ChatChannel.where(chatable: topic).exists?
   end
 end
+
+# == Schema Information
+#
+# Table name: chat_channels
+#
+#  id                      :bigint           not null, primary key
+#  chatable_id             :integer          not null
+#  deleted_at              :datetime
+#  deleted_by_id           :integer
+#  featured_in_category_id :integer
+#  delete_after_seconds    :integer
+#  chatable_type           :string           not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  name                    :string
+#  description             :text
+#
+# Indexes
+#
+#  index_chat_channels_on_chatable_id                    (chatable_id)
+#  index_chat_channels_on_chatable_id_and_chatable_type  (chatable_id,chatable_type)
+#

--- a/app/models/chat_mention.rb
+++ b/app/models/chat_mention.rb
@@ -5,3 +5,19 @@ class ChatMention < ActiveRecord::Base
   belongs_to :chat_message
   belongs_to :notification
 end
+
+# == Schema Information
+#
+# Table name: chat_mentions
+#
+#  id              :bigint           not null, primary key
+#  chat_message_id :integer          not null
+#  user_id         :integer          not null
+#  notification_id :integer          not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  chat_mentions_index  (chat_message_id,user_id,notification_id) UNIQUE
+#

--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -107,3 +107,26 @@ class ChatMessage < ActiveRecord::Base
     "watched-words": true,
   }
 end
+
+# == Schema Information
+#
+# Table name: chat_messages
+#
+#  id              :bigint           not null, primary key
+#  chat_channel_id :integer          not null
+#  user_id         :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  deleted_at      :datetime
+#  deleted_by_id   :integer
+#  in_reply_to_id  :integer
+#  message         :text
+#  action_code     :string
+#  cooked          :text
+#  cooked_version  :integer
+#
+# Indexes
+#
+#  index_chat_messages_on_chat_channel_id_and_created_at  (chat_channel_id,created_at)
+#  index_chat_messages_on_post_id                         (post_id)
+#

--- a/app/models/chat_message_post_connection.rb
+++ b/app/models/chat_message_post_connection.rb
@@ -4,3 +4,18 @@ class ChatMessagePostConnection < ActiveRecord::Base
   belongs_to :chat_message
   belongs_to :post
 end
+
+# == Schema Information
+#
+# Table name: chat_message_post_connections
+#
+#  id              :bigint           not null, primary key
+#  post_id         :integer          not null
+#  chat_message_id :integer          not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  chat_message_post_connections_index  (post_id,chat_message_id) UNIQUE
+#

--- a/app/models/chat_message_reaction.rb
+++ b/app/models/chat_message_reaction.rb
@@ -4,3 +4,19 @@ class ChatMessageReaction < ActiveRecord::Base
   belongs_to :chat_message
   belongs_to :user
 end
+
+# == Schema Information
+#
+# Table name: chat_message_reactions
+#
+#  id              :bigint           not null, primary key
+#  chat_message_id :integer
+#  user_id         :integer
+#  emoji           :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  chat_message_reactions_index  (chat_message_id,user_id,emoji) UNIQUE
+#

--- a/app/models/chat_message_revision.rb
+++ b/app/models/chat_message_revision.rb
@@ -3,3 +3,19 @@
 class ChatMessageRevision < ActiveRecord::Base
   belongs_to :chat_message
 end
+
+# == Schema Information
+#
+# Table name: chat_message_revisions
+#
+#  id              :bigint           not null, primary key
+#  chat_message_id :integer
+#  old_message     :text             not null
+#  new_message     :text             not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  index_chat_message_revisions_on_chat_message_id  (chat_message_id)
+#

--- a/app/models/chat_upload.rb
+++ b/app/models/chat_upload.rb
@@ -4,3 +4,18 @@ class ChatUpload < ActiveRecord::Base
   belongs_to :chat_message
   belongs_to :upload
 end
+
+# == Schema Information
+#
+# Table name: chat_uploads
+#
+#  id              :bigint           not null, primary key
+#  chat_message_id :integer          not null
+#  upload_id       :integer          not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  index_chat_uploads_on_chat_message_id_and_upload_id  (chat_message_id,upload_id) UNIQUE
+#

--- a/app/models/chat_webhook_event.rb
+++ b/app/models/chat_webhook_event.rb
@@ -7,3 +7,18 @@ class ChatWebhookEvent < ActiveRecord::Base
   delegate :username, to: :incoming_chat_webhook
   delegate :emoji, to: :incoming_chat_webhook
 end
+
+# == Schema Information
+#
+# Table name: chat_webhook_events
+#
+#  id                       :bigint           not null, primary key
+#  chat_message_id          :integer          not null
+#  incoming_chat_webhook_id :integer          not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+# Indexes
+#
+#  chat_webhook_events_index  (chat_message_id,incoming_chat_webhook_id) UNIQUE
+#

--- a/app/models/direct_message_channel.rb
+++ b/app/models/direct_message_channel.rb
@@ -23,3 +23,12 @@ class DirectMessageChannel < ActiveRecord::Base
       &.first
   end
 end
+
+# == Schema Information
+#
+# Table name: direct_message_channels
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#

--- a/app/models/direct_message_user.rb
+++ b/app/models/direct_message_user.rb
@@ -4,3 +4,18 @@ class DirectMessageUser < ActiveRecord::Base
   belongs_to :directory_message_channel
   belongs_to :user
 end
+
+# == Schema Information
+#
+# Table name: direct_message_users
+#
+#  id                        :bigint           not null, primary key
+#  direct_message_channel_id :integer          not null
+#  user_id                   :integer          not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#
+# Indexes
+#
+#  direct_message_users_index  (direct_message_channel_id,user_id) UNIQUE
+#

--- a/app/models/incoming_chat_webhook.rb
+++ b/app/models/incoming_chat_webhook.rb
@@ -12,3 +12,22 @@ class IncomingChatWebhook < ActiveRecord::Base
     "#{Discourse.base_url}/chat/hooks/#{key}.json"
   end
 end
+
+# == Schema Information
+#
+# Table name: incoming_chat_webhooks
+#
+#  id              :bigint           not null, primary key
+#  name            :string           not null
+#  key             :string           not null
+#  chat_channel_id :integer          not null
+#  username        :string
+#  description     :string
+#  emoji           :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  index_incoming_chat_webhooks_on_key_and_chat_channel_id  (key,chat_channel_id)
+#

--- a/app/models/user_chat_channel_membership.rb
+++ b/app/models/user_chat_channel_membership.rb
@@ -33,3 +33,24 @@ class UserChatChannelMembership < ActiveRecord::Base
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: user_chat_channel_memberships
+#
+#  id                         :bigint           not null, primary key
+#  user_id                    :integer          not null
+#  chat_channel_id            :integer          not null
+#  last_read_message_id       :integer
+#  following                  :boolean          default(FALSE), not null
+#  muted                      :boolean          default(FALSE), not null
+#  desktop_notification_level :integer          default("mention"), not null
+#  mobile_notification_level  :integer          default("mention"), not null
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#
+# Indexes
+#
+#  user_chat_channel_memberships_index   (user_id,chat_channel_id,desktop_notification_level,mobile_notification_level,following)
+#  user_chat_channel_unique_memberships  (user_id,chat_channel_id) UNIQUE
+#


### PR DESCRIPTION
We should be doing this for plugins that have more than
one table I think...at least periodically, if not every
commit having it enforced like Discourse Core.