### PR TITLE
FIX: DOMParser is very picky especially on firefox

### DIFF
--- a/assets/javascripts/discourse/components/tc-message-collapser.js
+++ b/assets/javascripts/discourse/components/tc-message-collapser.js
@@ -1,6 +1,7 @@
 import Component from "@ember/component";
 import { action } from "@ember/object";
 import escape from "discourse-common/lib/escape";
+import domFromString from "discourse-common/lib/dom-from-string";
 
 export default Component.extend({
   collapsed: false,
@@ -11,14 +12,12 @@ export default Component.extend({
   init() {
     this._super(...arguments);
 
-    const cookedElement = new DOMParser().parseFromString(
-      this.cooked,
-      "text/xml"
-    ).firstChild;
-    const title = cookedElement.getAttribute("data-youtube-title");
-    const id = cookedElement.getAttribute("data-youtube-id");
+    const cookedElement = domFromString(this.cooked);
 
+    const title = cookedElement.dataset.youtubeTitle;
     this.set("title", title);
+
+    const id = cookedElement.dataset.youtubeId;
     this.set("link", `https://www.youtube.com/watch?v=${escape(id)}`);
   },
 


### PR DESCRIPTION
Firefox:

```
new DOMParser().parseFromString("<img>test</p>", "text/xml").firstChild
// XML Parsing Error: mismatched tag. Expected: </img>.
```

Chrome:

```
new DOMParser().parseFromString("<img>test</p>", "text/xml").firstChild

// <img><parsererror xmlns="http://www.w3.org/1999/xhtml" style="display: block; white-space: pre; border: 2px solid #c77; padding: 0 1em 0 1em; margin: 1em; background-color: #fdd; color: black"><h3>This page contains the following errors:</h3><div style="font-family:monospace;font-size:12px">error on line 1 at column 14: Opening and ending tag mismatch: img line 1 and p
</div><h3>Below is a rendering of the page up to the first error.</h3></parsererror></img>
```

Using `document.createElement("template");` will allow us to not fail on unexpected HTML which is what we want given this is third party HTML and we have no control over it.