### PR TITLE
FIX: ensures loading state is removed

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -167,12 +167,13 @@ export default Component.extend({
           }
 
           this.chat.set("messageId", null);
+          this.set("loading", false);
 
           if (this.chatChannel.id !== channelId) {
             return;
           }
+
           this.focusComposer();
-          this.set("loading", false);
         });
     });
   },


### PR DESCRIPTION
Before this fix we could enter the previous condition:

```javascript
if (this.chatChannel.id !== channelId) {
  return;
}
```

And would never reach the point where we set to false the loading property.