### PR TITLE
UX: Full-page & exit button changes

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -248,6 +248,16 @@ body.composer-open .topic-chat-float-container {
   }
 }
 
+.btn.exit-chat-btn {
+  background: transparent;
+  color: var(--primary-medium);
+  font-size: var(--font-0-rem);
+  padding: 0.6rem;
+  &:hover {
+    background: transparent;
+  }
+}
+
 .tc-channels {
   overflow-y: auto;
   height: 100%;

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -94,6 +94,10 @@
       max-width: 1200px;
     }
   }
+  .alert-info:last-of-type {
+    margin-bottom: 0;
+    border-bottom: 1px solid var(--primary-low);
+  }
   .full-page-chat {
     border-right: 1px solid var(--primary-low);
     border-left: 1px solid var(--primary-low);

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -89,14 +89,23 @@
 // Full Page Styling in Core
 .has-full-page-chat:not(.discourse-sidebar) {
   #main-outlet {
-    padding: 1.5em 0em;
+    padding: 0em;
+    &.wrap {
+      max-width: 1200px;
+    }
   }
   .full-page-chat {
-    border: 1px solid var(--primary-low);
+    border-right: 1px solid var(--primary-low);
+    border-left: 1px solid var(--primary-low);
     overflow: hidden;
+
+    .tc-full-page-header {
+      padding: 1em 1em 0.5em;
+    }
 
     .tc-channels {
       background: var(--primary-very-low);
+      padding-top: 1em;
 
       .chat-channel-divider {
         padding: 0.5rem 0.5rem 0.5rem 1rem;


### PR DESCRIPTION
This PR adjusts the look slightly for chat on full page with a non sidebar theme. It also applies consistent hover styling to the exit chat button.

### After
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30537603/148106144-80d5ac8b-63aa-45a7-b6c8-59f47481ac3e.png">

### Before
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30537603/148106221-625d69b4-ae7c-4a8e-8aa7-9ad3f3917eb5.png">
