### PR TITLE
FIX: reconciliate state of live-pane

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -169,6 +169,11 @@ export default Component.extend({
           this.chat.set("messageId", null);
 
           if (this.chatChannel.id !== channelId) {
+            this.router.transitionTo(
+              "chat.channel",
+              this.chatChannel.id,
+              this.chatChannel.title
+            );
             return;
           }
           this.focusComposer();


### PR DESCRIPTION
This is not the root issue, we should investigate more on why in some cases, we are processing a request to fetch a list of messages we don't care about anymore.

This commit will ensure that if it ever happens, we try to force transition to the channel the chat-live-pane is currently in, instead of showing a blank page.