### PR TITLE
DEV: Extract tc-text so that tc-message isn't too large

### DIFF
--- a/assets/javascripts/discourse/components/tc-message.js
+++ b/assets/javascripts/discourse/components/tc-message.js
@@ -208,13 +208,6 @@ export default Component.extend({
     return classNames.join(" ");
   },
 
-  @computed("message.cooked")
-  get isCollapsible() {
-    return /^<div class="onebox lazyYT lazyYT-container"/.test(
-      this.message.cooked
-    );
-  },
-
   @discourseComputed("message.user")
   name(user) {
     return this.prioritizeName ? user.name : user.username;

--- a/assets/javascripts/discourse/components/tc-text.js
+++ b/assets/javascripts/discourse/components/tc-text.js
@@ -1,0 +1,13 @@
+import Component from "@ember/component";
+import { computed } from "@ember/object";
+
+export default Component.extend({
+  cooked: null,
+  uploads: null,
+  edited: false,
+
+  @computed("cooked", "uploads")
+  get isCollapsible() {
+    return /^<div class="onebox lazyYT lazyYT-container"/.test(this.cooked);
+  },
+});

--- a/assets/javascripts/discourse/components/tc-text.js
+++ b/assets/javascripts/discourse/components/tc-text.js
@@ -3,10 +3,9 @@ import { computed } from "@ember/object";
 
 export default Component.extend({
   cooked: null,
-  uploads: null,
   edited: false,
 
-  @computed("cooked", "uploads")
+  @computed("cooked")
   get isCollapsible() {
     return /^<div class="onebox lazyYT lazyYT-container"/.test(this.cooked);
   },

--- a/assets/javascripts/discourse/components/tc-text.js
+++ b/assets/javascripts/discourse/components/tc-text.js
@@ -3,9 +3,10 @@ import { computed } from "@ember/object";
 
 export default Component.extend({
   cooked: null,
+  uploads: null,
   edited: false,
 
-  @computed("cooked")
+  @computed("cooked", "uploads")
   get isCollapsible() {
     return /^<div class="onebox lazyYT lazyYT-container"/.test(this.cooked);
   },

--- a/assets/javascripts/discourse/templates/components/tc-message.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-message.hbs
@@ -135,52 +135,36 @@
               {{html-safe actionCodeText}}
             </span>
           {{else}}
-            <div class="tc-text">
-              {{#if isCollapsible}}
-                {{tc-message-collapser cooked=message.cooked}}
-              {{else}}
-                {{html-safe message.cooked}}
-              {{/if}}
-              {{#if message.uploads.length}}
-                <div class="tc-uploads">
-                  {{#each message.uploads as |upload|}}
-                    {{chat-upload upload=upload}}
-                  {{/each}}
-                </div>
-              {{/if}}
-              {{#if message.edited}}
-                <div class="tc-message-edited">
-                  {{i18n "chat.edited"}}
-                </div>
-              {{/if}}
-
-              {{#if hasReactions}}
-                <div class="chat-message-reaction-list">
-                  {{#if reactionLabel}}
-                    <div class="reaction-users-list">
-                      {{replace-emoji reactionLabel}}
-                    </div>
-                  {{/if}}
-                  {{#each-in message.reactions as |emoji reactionAttrs|}}
-                    {{chat-message-reaction
-                      emoji=emoji
-                      count=reactionAttrs.count
-                      users=reactionAttrs.users
-                      reacted=reactionAttrs.reacted
-                      react=(action "react")
-                      showUsersList=(action "showUsersList")
-                      hideUsersList=(action "hideUsersList")
+              {{#tc-text cooked=message.cooked
+                         uploads=message.uploads
+                         edited=message.edited}}
+                {{#if hasReactions}}
+                  <div class="chat-message-reaction-list">
+                    {{#if reactionLabel}}
+                      <div class="reaction-users-list">
+                        {{replace-emoji reactionLabel}}
+                      </div>
+                    {{/if}}
+                    {{#each-in message.reactions as |emoji reactionAttrs|}}
+                      {{chat-message-reaction
+                        emoji=emoji
+                        count=reactionAttrs.count
+                        users=reactionAttrs.users
+                        reacted=reactionAttrs.reacted
+                        react=(action "react")
+                        showUsersList=(action "showUsersList")
+                        hideUsersList=(action "hideUsersList")
+                      }}
+                    {{/each-in}}
+                    {{d-button
+                      class="chat-message-react-btn"
+                      action=(action "startReactionForReactionList")
+                      icon="discourse-emojis"
+                      title="chat.react"
                     }}
-                  {{/each-in}}
-                  {{d-button
-                    class="chat-message-react-btn"
-                    action=(action "startReactionForReactionList")
-                    icon="discourse-emojis"
-                    title="chat.react"
-                  }}
-                </div>
-              {{/if}}
-            </div>
+                  </div>
+                {{/if}}
+              {{/tc-text}}
           {{/if}}
           {{#if message.error}}
             <div class="tc-send-error">

--- a/assets/javascripts/discourse/templates/components/tc-message.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-message.hbs
@@ -135,36 +135,36 @@
               {{html-safe actionCodeText}}
             </span>
           {{else}}
-              {{#tc-text cooked=message.cooked
-                         uploads=message.uploads
-                         edited=message.edited}}
-                {{#if hasReactions}}
-                  <div class="chat-message-reaction-list">
-                    {{#if reactionLabel}}
-                      <div class="reaction-users-list">
-                        {{replace-emoji reactionLabel}}
-                      </div>
-                    {{/if}}
-                    {{#each-in message.reactions as |emoji reactionAttrs|}}
-                      {{chat-message-reaction
-                        emoji=emoji
-                        count=reactionAttrs.count
-                        users=reactionAttrs.users
-                        reacted=reactionAttrs.reacted
-                        react=(action "react")
-                        showUsersList=(action "showUsersList")
-                        hideUsersList=(action "hideUsersList")
-                      }}
-                    {{/each-in}}
-                    {{d-button
-                      class="chat-message-react-btn"
-                      action=(action "startReactionForReactionList")
-                      icon="discourse-emojis"
-                      title="chat.react"
+            {{#tc-text cooked=message.cooked
+                       uploads=message.uploads
+                       edited=message.edited}}
+              {{#if hasReactions}}
+                <div class="chat-message-reaction-list">
+                  {{#if reactionLabel}}
+                    <div class="reaction-users-list">
+                      {{replace-emoji reactionLabel}}
+                    </div>
+                  {{/if}}
+                  {{#each-in message.reactions as |emoji reactionAttrs|}}
+                    {{chat-message-reaction
+                      emoji=emoji
+                      count=reactionAttrs.count
+                      users=reactionAttrs.users
+                      reacted=reactionAttrs.reacted
+                      react=(action "react")
+                      showUsersList=(action "showUsersList")
+                      hideUsersList=(action "hideUsersList")
                     }}
-                  </div>
-                {{/if}}
-              {{/tc-text}}
+                  {{/each-in}}
+                  {{d-button
+                    class="chat-message-react-btn"
+                    action=(action "startReactionForReactionList")
+                    icon="discourse-emojis"
+                    title="chat.react"
+                  }}
+                </div>
+              {{/if}}
+            {{/tc-text}}
           {{/if}}
           {{#if message.error}}
             <div class="tc-send-error">

--- a/assets/javascripts/discourse/templates/components/tc-text.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-text.hbs
@@ -1,0 +1,20 @@
+<div class="tc-text">
+  {{#if isCollapsible}}
+    {{tc-message-collapser cooked=cooked uploads=uploads}}
+  {{else}}
+    {{html-safe cooked}}
+  {{/if}}
+  {{#if uploads.length}}
+    <div class="tc-uploads">
+      {{#each uploads as |upload|}}
+        {{chat-upload upload=upload}}
+      {{/each}}
+    </div>
+  {{/if}}
+  {{#if edited}}
+    <div class="tc-message-edited">
+      {{i18n "chat.edited"}}
+    </div>
+  {{/if}}
+  {{yield}}
+</div>


### PR DESCRIPTION
Also to set up collapsing for images. `tc-message` is also growing so this feels like it's a useful complexity reduction in that file.

I may have a look at extracting reactions (`chat-message-reaction-list`) too to make `tc-message` less overwhelming. On first look it does look quite trivial to extract but there are a lot of minor details which need to be tested to prevent regressions.