### PR TITLE
FEATURE: Collapse images

### DIFF
--- a/assets/javascripts/discourse/components/tc-message-collapser.js
+++ b/assets/javascripts/discourse/components/tc-message-collapser.js
@@ -2,6 +2,7 @@ import Component from "@ember/component";
 import { action, computed } from "@ember/object";
 import escape from "discourse-common/lib/escape";
 import domFromString from "discourse-common/lib/dom-from-string";
+import I18n from "I18n";
 
 export default Component.extend({
   collapsed: false,
@@ -11,6 +12,17 @@ export default Component.extend({
   @computed("cooked")
   get title() {
     return domFromString(this.cooked).dataset.youtubeTitle;
+  },
+
+  @computed("uploads")
+  get filename() {
+    if (this.uploads) {
+      if (this.uploads.length === 1) {
+        return this.uploads[0].original_filename;
+      } else {
+        return I18n.t(`chat.uploaded_files`, { count: this.uploads.length });
+      }
+    }
   },
 
   @computed("cooked")

--- a/assets/javascripts/discourse/components/tc-message-collapser.js
+++ b/assets/javascripts/discourse/components/tc-message-collapser.js
@@ -5,7 +5,7 @@ import domFromString from "discourse-common/lib/dom-from-string";
 
 export default Component.extend({
   collapsed: false,
-  upload: null,
+  uploads: null,
   cooked: null,
 
   @computed("cooked")

--- a/assets/javascripts/discourse/components/tc-message-collapser.js
+++ b/assets/javascripts/discourse/components/tc-message-collapser.js
@@ -1,24 +1,22 @@
 import Component from "@ember/component";
-import { action } from "@ember/object";
+import { action, computed } from "@ember/object";
 import escape from "discourse-common/lib/escape";
 import domFromString from "discourse-common/lib/dom-from-string";
 
 export default Component.extend({
   collapsed: false,
+  upload: null,
   cooked: null,
-  link: null,
-  title: null,
 
-  init() {
-    this._super(...arguments);
+  @computed("cooked")
+  get title() {
+    return domFromString(this.cooked).dataset.youtubeTitle;
+  },
 
-    const cookedElement = domFromString(this.cooked);
-
-    const title = cookedElement.dataset.youtubeTitle;
-    this.set("title", title);
-
-    const id = cookedElement.dataset.youtubeId;
-    this.set("link", `https://www.youtube.com/watch?v=${escape(id)}`);
+  @computed("cooked")
+  get link() {
+    const id = domFromString(this.cooked).dataset.youtubeId;
+    return `https://www.youtube.com/watch?v=${escape(id)}`;
   },
 
   @action

--- a/assets/javascripts/discourse/components/tc-text.js
+++ b/assets/javascripts/discourse/components/tc-text.js
@@ -6,8 +6,13 @@ export default Component.extend({
   uploads: null,
   edited: false,
 
-  @computed("cooked", "uploads")
-  get isCollapsible() {
+  @computed("cooked")
+  get isYoutubeCollapsible() {
     return /^<div class="onebox lazyYT lazyYT-container"/.test(this.cooked);
+  },
+
+  @computed("uploads")
+  get isImageCollapsible() {
+    return this.uploads.length > 0;
   },
 });

--- a/assets/javascripts/discourse/components/tc-text.js
+++ b/assets/javascripts/discourse/components/tc-text.js
@@ -13,6 +13,6 @@ export default Component.extend({
 
   @computed("uploads")
   get isImageCollapsible() {
-    return this.uploads.length > 0;
+    return this.uploads?.length > 0;
   },
 });

--- a/assets/javascripts/discourse/templates/components/chat-upload.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-upload.hbs
@@ -1,5 +1,6 @@
 {{#if (eq type IMAGE_TYPE)}}
-  <img class="chat-img-upload" data-orig-src={{upload.short_url}} height={{size.height}} width={{size.width}}>
+  <img class="chat-img-upload" data-orig-src={{upload.short_url}} height={{size.height}} width={{size.width}}
+       src={{upload.url}}>
 {{else}}
   <a class="chat-other-upload" data-orig-href={{upload.short_url}}>{{upload.original_filename}}</a>
 {{/if}}

--- a/assets/javascripts/discourse/templates/components/tc-message-collapser.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-message-collapser.hbs
@@ -1,7 +1,7 @@
 <div class="tc-message-collapsible">
   <div class="tc-message-collapsible-header">
 
-    {{#unless upload}}
+    {{#unless uploads}}
       <a
         target="_blank"
         class="tc-message-collapsible-link"
@@ -30,10 +30,14 @@
   </div>
 
   {{#unless collapsed}}
-    {{#unless upload}}
+    {{#unless uploads}}
       {{html-safe cooked}}
     {{else}}
-      {{chat-upload upload=upload}}
+      <div class="tc-uploads">
+        {{#each uploads as |upload|}}
+          {{chat-upload upload=upload}}
+        {{/each}}
+      </div>
     {{/unless}}
   {{/unless}}
 </div>

--- a/assets/javascripts/discourse/templates/components/tc-message-collapser.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-message-collapser.hbs
@@ -1,6 +1,9 @@
 <div class="tc-message-collapsible">
-  <div class="tc-message-collapsible-header">
+  {{#if uploads}}
+    {{html-safe cooked}}
+  {{/if}}
 
+  <div class="tc-message-collapsible-header">
     {{#unless uploads}}
       <a
         target="_blank"
@@ -11,7 +14,9 @@
         {{title}}
       </a>
     {{else}}
-      {{html-safe cooked}}
+      <span class="tc-message-collapsible-filename">
+        {{filename}}
+      </span>
     {{/unless}}
 
     {{#if collapsed}}

--- a/assets/javascripts/discourse/templates/components/tc-message-collapser.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-message-collapser.hbs
@@ -1,13 +1,19 @@
 <div class="tc-message-collapsible">
   <div class="tc-message-collapsible-header">
-    <a
-      target="_blank"
-      class="tc-message-collapsible-link"
-      rel="noopener noreferrer"
-      href={{link}}
-    >
-      {{title}}
-    </a>
+
+    {{#unless upload}}
+      <a
+        target="_blank"
+        class="tc-message-collapsible-link"
+        rel="noopener noreferrer"
+        href={{link}}
+      >
+        {{title}}
+      </a>
+    {{else}}
+      {{html-safe cooked}}
+    {{/unless}}
+
     {{#if collapsed}}
       {{d-button
         action=(action "open")
@@ -24,6 +30,10 @@
   </div>
 
   {{#unless collapsed}}
-    {{html-safe cooked}}
+    {{#unless upload}}
+      {{html-safe cooked}}
+    {{else}}
+      {{chat-upload upload=upload}}
+    {{/unless}}
   {{/unless}}
 </div>

--- a/assets/javascripts/discourse/templates/components/tc-message.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-message.hbs
@@ -135,9 +135,11 @@
               {{html-safe actionCodeText}}
             </span>
           {{else}}
-            {{#tc-text cooked=message.cooked
-                       uploads=message.uploads
-                       edited=message.edited}}
+            {{#tc-text
+              cooked=message.cooked
+              uploads=message.uploads
+              edited=message.edited
+            }}
               {{#if hasReactions}}
                 <div class="chat-message-reaction-list">
                   {{#if reactionLabel}}

--- a/assets/javascripts/discourse/templates/components/tc-text.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-text.hbs
@@ -1,8 +1,7 @@
 <div class="tc-text">
-
   {{#if isYoutubeCollapsible}}
     {{tc-message-collapser cooked=cooked}}
-  {{else if isImageCollapsible }}
+  {{else if isImageCollapsible}}
     {{tc-message-collapser cooked=cooked uploads=uploads}}
   {{else}}
     {{html-safe cooked}}
@@ -15,5 +14,4 @@
   {{/if}}
 
   {{yield}}
-
 </div>

--- a/assets/javascripts/discourse/templates/components/tc-text.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-text.hbs
@@ -2,17 +2,10 @@
 
   {{#if isYoutubeCollapsible}}
     {{tc-message-collapser cooked=cooked}}
-
   {{else if isImageCollapsible }}
-    <div class="tc-uploads">
-      {{#each uploads as |upload|}}
-        {{tc-message-collapser cooked=cooked upload=upload}}
-      {{/each}}
-    </div>
-
+    {{tc-message-collapser cooked=cooked uploads=uploads}}
   {{else}}
     {{html-safe cooked}}
-
   {{/if}}
 
   {{#if edited}}

--- a/assets/javascripts/discourse/templates/components/tc-text.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-text.hbs
@@ -1,20 +1,26 @@
 <div class="tc-text">
-  {{#if isCollapsible}}
-    {{tc-message-collapser cooked=cooked uploads=uploads}}
-  {{else}}
-    {{html-safe cooked}}
-  {{/if}}
-  {{#if uploads.length}}
+
+  {{#if isYoutubeCollapsible}}
+    {{tc-message-collapser cooked=cooked}}
+
+  {{else if isImageCollapsible }}
     <div class="tc-uploads">
       {{#each uploads as |upload|}}
-        {{chat-upload upload=upload}}
+        {{tc-message-collapser cooked=cooked upload=upload}}
       {{/each}}
     </div>
+
+  {{else}}
+    {{html-safe cooked}}
+
   {{/if}}
+
   {{#if edited}}
     <div class="tc-message-edited">
       {{i18n "chat.edited"}}
     </div>
   {{/if}}
+
   {{yield}}
+
 </div>

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -574,22 +574,11 @@ body.composer-open .topic-chat-float-container {
       min-width: 0;
       width: 100%;
 
-      img {
-        max-width: 100%;
-        height: unset;
-      }
       code {
         font-size: var(--font-down-1);
         width: 100%;
       }
-      .tc-uploads {
-        margin-top: 1em;
 
-        .chat-img-upload,
-        .chat-other-upload {
-          margin-bottom: 1em;
-        }
-      }
       .mention.highlighted {
         background: var(--tertiary-low);
         color: var(--primary);
@@ -1860,6 +1849,15 @@ body.composer-open .topic-chat-float-container {
   .tc-message-collapsible-header {
     display: flex;
     align-items: center;
+
+    img {
+      max-width: 100%;
+      height: unset;
+    }
+  }
+
+  .tc-message-collapsible-filename {
+    font-size: 0.75em;
   }
 
   .tc-message-collapsible-button {
@@ -1869,13 +1867,24 @@ body.composer-open .topic-chat-float-container {
 
     &:hover {
       background: none;
+
       .d-icon {
         color: var(--primary);
       }
     }
   }
+
+  .tc-uploads {
+    margin-top: 0.5em;
+
+    .chat-img-upload,
+    .chat-other-upload {
+      margin-bottom: 1em;
+    }
+  }
 }
 
+.tc-message-collapsible,
 .tc-text {
   > p {
     margin: 0.5em 0 0.5em;

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1875,8 +1875,6 @@ body.composer-open .topic-chat-float-container {
   }
 
   .tc-uploads {
-    margin-top: 0.5em;
-
     .chat-img-upload,
     .chat-other-upload {
       margin-bottom: 1em;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -82,6 +82,7 @@ en:
       title: "chat"
       title_capitalized: "Chat"
       upload: "Attach a file"
+      uploaded_files: "%{count} files"
       exit: "back"
 
       create_channel:

--- a/test/javascripts/components/tc-message-collapser-test.js
+++ b/test/javascripts/components/tc-message-collapser-test.js
@@ -1,0 +1,145 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import hbs from "htmlbars-inline-precompile";
+import {
+  discourseModule,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+
+discourseModule(
+  "Discourse Chat | Component | tc message collapser",
+  function (hooks) {
+    setupRenderingTest(hooks);
+    const youtubeCooked =
+      '<div class="onebox lazyYT lazyYT-container" data-youtube-id="WaT_rLGuUr8" data-youtube-title="Japanese Katsu Curry (Pork Cutlet)"/>';
+    const imageCooked = "<p>A picture of Tomtom</p>";
+
+    // youtube
+    componentTest("shows youtube link in header", {
+      template: hbs`{{tc-message-collapser cooked=cooked}}`,
+
+      beforeEach() {
+        this.set("cooked", youtubeCooked);
+      },
+
+      async test(assert) {
+        const link = query(".tc-message-collapsible-link");
+
+        assert.ok(link);
+        assert.strictEqual(
+          link.href,
+          "https://www.youtube.com/watch?v=WaT_rLGuUr8"
+        );
+      },
+    });
+
+    componentTest("does not show filename since it's not an image", {
+      template: hbs`{{tc-message-collapser cooked=cooked}}`,
+
+      beforeEach() {
+        this.set("cooked", youtubeCooked);
+      },
+
+      async test(assert) {
+        assert.notOk(exists(".tc-message-collapsible-filename"));
+      },
+    });
+
+    componentTest("collapses and expands cooked youtube", {
+      template: hbs`{{tc-message-collapser cooked=cooked}}`,
+
+      beforeEach() {
+        this.set("cooked", youtubeCooked);
+      },
+
+      async test(assert) {
+        const youtubeDivSelector = ".onebox.lazyYT";
+
+        assert.ok(exists(youtubeDivSelector));
+
+        await click(".tc-message-collapsible-open");
+
+        assert.notOk(exists(youtubeDivSelector));
+
+        await click(".tc-message-collapsible-close");
+
+        assert.ok(exists(youtubeDivSelector));
+      },
+    });
+
+    // images
+    componentTest("shows filename for one image", {
+      template: hbs`{{tc-message-collapser cooked=cooked uploads=uploads}}`,
+
+      beforeEach() {
+        this.set("cooked", imageCooked);
+        this.set("uploads", [{ original_filename: "tomtom.jpeg" }]);
+      },
+
+      async test(assert) {
+        assert.strictEqual(
+          query(".tc-message-collapsible-filename").innerText,
+          "tomtom.jpeg"
+        );
+      },
+    });
+
+    componentTest("shows number of files for multiple images", {
+      template: hbs`{{tc-message-collapser cooked=cooked uploads=uploads}}`,
+
+      beforeEach() {
+        this.set("cooked", imageCooked);
+        this.set("uploads", [{}, {}]);
+      },
+
+      async test(assert) {
+        assert.strictEqual(
+          query(".tc-message-collapsible-filename").innerText,
+          "2 files"
+        );
+      },
+    });
+
+    componentTest("does not show link in header since it's not youtube", {
+      template: hbs`{{tc-message-collapser cooked=cooked uploads=uploads}}`,
+
+      beforeEach() {
+        this.set("cooked", imageCooked);
+        this.set("uploads", [{}, {}]);
+      },
+
+      async test(assert) {
+        assert.notOk(exists(".tc-message-collapsible-link"));
+      },
+    });
+
+    componentTest("collapses and expands images", {
+      template: hbs`{{tc-message-collapser cooked=cooked uploads=uploads}}`,
+
+      beforeEach() {
+        this.set("cooked", imageCooked);
+        this.set("uploads", [{ extension: "png" }]);
+      },
+
+      async test(assert) {
+        const uploads = ".tc-uploads";
+        const chatImageUpload = ".chat-img-upload";
+
+        assert.ok(exists(uploads));
+        assert.ok(exists(chatImageUpload));
+
+        await click(".tc-message-collapsible-open");
+
+        assert.notOk(exists(uploads));
+        assert.notOk(exists(chatImageUpload));
+
+        await click(".tc-message-collapsible-close");
+
+        assert.ok(exists(uploads));
+        assert.ok(exists(chatImageUpload));
+      },
+    });
+  }
+);

--- a/test/javascripts/components/tc-text-test.js
+++ b/test/javascripts/components/tc-text-test.js
@@ -1,0 +1,92 @@
+import { set } from "@ember/object";
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import hbs from "htmlbars-inline-precompile";
+import {
+  discourseModule,
+  exists,
+  query,
+  queryAll,
+} from "discourse/tests/helpers/qunit-helpers";
+
+discourseModule("Discourse Chat | Component | tc text", function (hooks) {
+  setupRenderingTest(hooks);
+
+  componentTest("yields", {
+    template: hbs`{{#tc-text cooked=cooked uploads=uploads edited=edited}} <div class="yield-me"></div> {{/tc-text}}`,
+
+    beforeEach() {
+      this.set("cooked", "<p></p>");
+    },
+
+    async test(assert) {
+      assert.ok(exists(".yield-me"));
+    },
+  });
+
+  componentTest("is youtube and shows collapsed", {
+    template: hbs`{{tc-text cooked=cooked uploads=uploads edited=edited}}`,
+
+    beforeEach() {
+      this.set(
+        "cooked",
+        '<div class="onebox lazyYT lazyYT-container" data-youtube-id="WaT_rLGuUr8" data-youtube-title="Japanese Katsu Curry (Pork Cutlet)"/>'
+      );
+    },
+
+    async test(assert) {
+      assert.ok(exists(".tc-message-collapsible"));
+    },
+  });
+
+  componentTest("is image and shows collapsed", {
+    template: hbs`{{tc-text cooked=cooked uploads=uploads edited=edited}}`,
+
+    beforeEach() {
+      this.set("cooked", "<p></p>");
+      this.set("uploads", [{}]);
+    },
+
+    async test(assert) {
+      assert.ok(exists(".tc-message-collapsible"));
+    },
+  });
+
+  componentTest("is neither youtube nor image and does not show collapse", {
+    template: hbs`{{tc-text cooked=cooked uploads=uploads edited=edited}}`,
+
+    beforeEach() {
+      this.set("cooked", "<p></p>");
+    },
+
+    async test(assert) {
+      assert.notOk(exists(".tc-message-collapsible"));
+    },
+  });
+
+  componentTest("is edited and shows that it's edited", {
+    template: hbs`{{tc-text cooked=cooked uploads=uploads edited=edited}}`,
+
+    beforeEach() {
+      this.set("cooked", "<p></p>");
+      this.set("edited", true);
+    },
+
+    async test(assert) {
+      assert.ok(exists(".tc-message-edited"));
+    },
+  });
+
+  componentTest("is not edited and does not show", {
+    template: hbs`{{tc-text cooked=cooked uploads=uploads edited=edited}}`,
+
+    beforeEach() {
+      this.set("cooked", "<p></p>");
+    },
+
+    async test(assert) {
+      assert.notOk(exists(".tc-message-edited"));
+    },
+  });
+});


### PR DESCRIPTION
Introduces a slack-esque image collapsing ability

One file with no accompanying text
<img width="443" alt="Showing one image with file name" src="https://user-images.githubusercontent.com/1555215/148208090-3769bda6-561c-43d3-819f-f49ae0834456.png">

Folded
<img width="167" alt="Screenshot 2022-01-05 at 7 10 14 PM" src="https://user-images.githubusercontent.com/1555215/148208391-0e85c994-dde3-4a40-8351-a90dbb4f443d.png">

One file with accompanying text
<img width="436" alt="Screenshot 2022-01-05 at 7 06 49 PM" src="https://user-images.githubusercontent.com/1555215/148208174-d0cbb836-50f1-4fcc-866a-f35440ef3277.png">

Folded
<img width="173" alt="Screenshot 2022-01-05 at 7 10 25 PM" src="https://user-images.githubusercontent.com/1555215/148208410-bfbdb85b-5654-49e8-8dfe-9e4e5669adde.png">

Multiple files with multiple lines of accompanying text
<img width="446" alt="Screenshot 2022-01-05 at 7 07 01 PM" src="https://user-images.githubusercontent.com/1555215/148208199-2e54e479-58d7-4426-8d90-1b0b1333155c.png">

Sanity check for youtube collapsing
<img width="404" alt="Screenshot 2022-01-05 at 7 07 17 PM" src="https://user-images.githubusercontent.com/1555215/148208230-dcac6ee7-3dc6-4025-a3a8-f5cc59ceae96.png">

