### PR TITLE
FIX: Uniform sidebar channel row heights

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1387,9 +1387,6 @@ body.composer-open .topic-chat-float-container {
     }
 
     .chat-channel-row {
-      padding: 0.35em 1.8rem;
-      min-height: 28px;
-
       &:hover {
         background-color: var(--tertiary-low);
       }
@@ -1397,6 +1394,13 @@ body.composer-open .topic-chat-float-container {
         font-weight: unset;
         margin: 0;
       }
+    }
+
+    .public-channels .chat-channel-row {
+      padding: 0.5rem 1.8rem;
+    }
+    .direct-message-channels .chat-channel-row {
+      padding: 0.3rem 1.8rem;
     }
   }
 }


### PR DESCRIPTION
Right now public channels are tiny and it looks bad. II hate having 2 sets of paddings here, but IDK else to do. I don't really want a set height (what if font-size changes)

![Screen Shot 2022-01-05 at 8 48 49 AM](https://user-images.githubusercontent.com/16214023/148237261-d682f07b-3ab4-4738-bd34-032b80f5cb33.png)
