### PR TITLE
FIX: Save new draft when upload is removed

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -634,6 +634,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   @action
   removeUpload(upload) {
     this.uploads.removeObject(upload);
+    this.onValueChange(this.value, this.uploads);
   },
 
   @discourseComputed("uploads.[]", "inProgressUploads.[]")


### PR DESCRIPTION
It's impossible to clear uploads from drafts without changing the composer text. It's wildly annoying.

The problem is that we weren't triggering the callback that should be triggered when uploads or composer value is changed. Call the callback and it works!