### PR TITLE
FIX: don't crash on missing favs

### DIFF
--- a/assets/javascripts/discourse/components/tc-message.js
+++ b/assets/javascripts/discourse/components/tc-message.js
@@ -634,6 +634,10 @@ export default Component.extend({
 
   @discourseComputed("emojiStore.favorites.[]")
   favoritesEmojis(favorites) {
+    if (!favorites) {
+      return [];
+    }
+
     const userReactions = Object.keys(this.message.reactions).filter((key) => {
       return this.message.reactions[key].reacted;
     });


### PR DESCRIPTION
On new instances of browsers where there were no favorite emojis,
do not crash
