### PR TITLE
FIX: Stretchy avatars on iOS < 15.1

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1302,6 +1302,7 @@ body.composer-open .topic-chat-float-container {
   }
 
   .tc-avatar-container {
+    align-items: flex-start;
     display: inline-flex;
     width: 100%;
     height: auto;


### PR DESCRIPTION
Before / After

<img width="300" alt="image" src="https://user-images.githubusercontent.com/66961/148307753-19492fea-1e64-4d74-9ec8-cf6b8d0fb6cc.png"> <img width="300" alt="image" src="https://user-images.githubusercontent.com/66961/148307727-bc561ad2-8b0c-4e17-b747-0c6058acfdf8.png">
