### PR TITLE
FIX: ensure we also check for array in favorites

### DIFF
--- a/assets/javascripts/discourse/components/tc-message.js
+++ b/assets/javascripts/discourse/components/tc-message.js
@@ -634,7 +634,8 @@ export default Component.extend({
 
   @discourseComputed("emojiStore.favorites.[]")
   favoritesEmojis(favorites) {
-    if (!favorites) {
+    // may be a {} if no favs defined in some production builds
+    if (!favorites || !favorites.slice) {
       return [];
     }
 


### PR DESCRIPTION
In certain builds it appears that favorites can be {} somehow in production
This ensures the object we get responds to slice and thus is an array
