### PR TITLE
FIX: Enter not working inside backticks

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -204,7 +204,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
         // if we are inside a code block just insert newline
         const { pre } = this._getSelected(null, { lineVal: true });
         if (this._isInside(pre, /(^|\n)```/g)) {
-          return false;
+          return;
         }
       }
 


### PR DESCRIPTION
For some reason the fix in c89b05fcbf15f4de6fd9ea84d268f91d00108ec1
stopped working, maybe a core or ember update? Either way, return;
instead of return false; makes it work (when you press Shift+Enter
we just do return; as well)