### PR TITLE
DEV: Remove duplicate declaration

### DIFF
--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -362,7 +362,6 @@ export default Component.extend({
 
     let channelInfo = {
       activeChannel: channel,
-      expanded: this.expectPageChange ? true : this.expanded,
       loading: false,
       hidden: false,
       expanded: true,


### PR DESCRIPTION
`const a = { expanded: false, expanded: true }`
`a.expanded` would be true so I'm keeping the subsequent declaration.