### PR TITLE
FIX: Max-width an image

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1306,11 +1306,6 @@ body.composer-open .topic-chat-float-container {
   .tc-message-collapsible-header {
     display: flex;
     align-items: center;
-
-    img {
-      max-width: 100%;
-      height: unset;
-    }
   }
 
   .tc-message-collapsible-filename {

--- a/assets/stylesheets/common/tc-message.scss
+++ b/assets/stylesheets/common/tc-message.scss
@@ -498,6 +498,11 @@
   }
 }
 
+.tc-text img.chat-img-upload {
+  max-width: 100%;
+  height: unset;
+}
+
 .full-page-chat {
   .tc-message {
     background: var(--primary-very-low);


### PR DESCRIPTION
This fixes an issue in mobile where the image is bigger than the width of the screen. This was caused due to a missing style which was there before but got lost in translation.