### PR TITLE
PERF: prevents N+1 on direct message channel title

### DIFF
--- a/app/models/direct_message_channel.rb
+++ b/app/models/direct_message_channel.rb
@@ -9,7 +9,7 @@ class DirectMessageChannel < ActiveRecord::Base
   end
 
   def chat_channel_title_for_user(chat_channel, user)
-    return chat_channel.id if users.count > 2
+    return chat_channel.id if users.size > 2
 
     users = direct_message_users.map(&:user) - [user]
 


### PR DESCRIPTION
Before this commit each call to `chat_channel_title_for_user` would trigger an N+1:

```
plugins/discourse-chat/app/models/direct_message_channel.rb:12:in `chat_channel_title_for_user'
plugins/discourse-chat/app/models/chat_channel.rb:79:in `title'
plugins/discourse-chat/app/serializers/chat_channel_serializer.rb:30:in `title'
lib/freedom_patches/ams_include_without_root.rb:57:in `include!'
app/controllers/application_controller.rb:486:in `serialize_data'
app/controllers/application_controller.rb:495:in `render_serialized'
plugins/discourse-chat/app/controllers/chat_channels_controller.rb:6:in `index'
app/controllers/application_controller.rb:387:in `block in with_resolved_locale'
app/controllers/application_controller.rb:387:in `with_resolved_locale'
lib/middleware/omniauth_bypass_middleware.rb:71:in `call'
lib/content_security_policy/middleware.rb:12:in `call'
lib/middleware/anonymous_cache.rb:356:in `call'
config/initializers/008-rack-cors.rb:25:in `call'
config/initializers/100-quiet_logger.rb:23:in `call'
config/initializers/100-silence_logger.rb:31:in `call'
lib/middleware/enforce_hostname.rb:23:in `call'
plugins/discourse-prometheus/lib/middleware/metrics.rb:17:in `call'
lib/middleware/request_tracker.rb:198:in `call'
SELECT COUNT(*) FROM "users" INNER JOIN "direct_message_users" ON "users"."id" = "direct_message_users"."user_id" WHERE "direct_message_users"."direct_message_channel_id" = 200;
```