### PR TITLE
REFACTOR: channel-row

### DIFF
--- a/assets/javascripts/discourse/components/chat-channel-leave-btn.js
+++ b/assets/javascripts/discourse/components/chat-channel-leave-btn.js
@@ -1,0 +1,25 @@
+import discourseComputed from "discourse-common/utils/decorators";
+import Component from "@ember/component";
+import { equal } from "@ember/object/computed";
+import { inject as service } from "@ember/service";
+import { CHATABLE_TYPES } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
+
+export default Component.extend({
+  tagName: "",
+  channel: null,
+  chat: service(),
+
+  isDirectMessageRow: equal(
+    "channel.chatable_type",
+    CHATABLE_TYPES.directMessageChannel
+  ),
+
+  @discourseComputed("isDirectMessageRow")
+  leaveChatTitleKey(isDirectMessageRow) {
+    if (isDirectMessageRow) {
+      return "chat.direct_messages.leave";
+    } else {
+      return "chat.leave";
+    }
+  },
+});

--- a/assets/javascripts/discourse/components/chat-channel-row.js
+++ b/assets/javascripts/discourse/components/chat-channel-row.js
@@ -6,8 +6,10 @@ import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
 
 export default Component.extend({
+  tagName: "",
   channel: null,
   switchChannel: null,
+  isUnfollowing: false,
   isDirectMessageRow: equal("channel.chatable_type", "DirectMessageChannel"),
   router: service(),
   chat: service(),
@@ -24,9 +26,10 @@ export default Component.extend({
     return classes.join(" ");
   },
 
-  mouseDown(e) {
-    if (e.which === 2) {
-      // Middle mouse click
+  @action
+  handleNewWindow(event) {
+    // Middle mouse click
+    if (event.which === 2) {
       window
         .open(
           getURL(`/chat/channel/${this.channel.id}/${this.channel.title}`),
@@ -36,12 +39,22 @@ export default Component.extend({
     }
   },
 
-  click() {
-    if (this.switchChannel) {
-      return this.switchChannel(this.channel);
+  @action
+  handleSwitchChannel(event) {
+    if (event.target.classList.contains("chat-channel-leave-btn")) {
+      return;
     }
 
-    return false;
+    if (this.switchChannel) {
+      this.switchChannel(this.channel);
+      event.preventDefault();
+    }
+  },
+
+  @action
+  onLeaveChannel() {
+    this.set("isUnfollowing", true);
+    this.chat.unfollowChannel(this.channel);
   },
 
   @discourseComputed("channel", "router.currentRoute")
@@ -50,10 +63,5 @@ export default Component.extend({
       currentRoute?.name === "chat.channel" &&
       currentRoute?.params?.channelId === channel.id.toString(10)
     );
-  },
-
-  @action
-  async leaveChatChannel() {
-    return this.chat.unfollowDirectMessageChannel(this.channel);
   },
 });

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -471,7 +471,7 @@ export default Service.extend({
     });
   },
 
-  async unfollowDirectMessageChannel(channel) {
+  async unfollowChannel(channel) {
     return ajax(`/chat/chat_channels/${channel.id}/unfollow`, {
       method: "POST",
     })

--- a/assets/javascripts/discourse/templates/components/chat-channel-leave-btn.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-leave-btn.hbs
@@ -1,0 +1,6 @@
+{{d-button
+  icon="times"
+  action=onLeaveChannel
+  class="btn-flat chat-channel-leave-btn"
+  title=leaveChatTitleKey
+}}

--- a/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
@@ -3,6 +3,7 @@
   class="{{rowClassNames}} {{if isUnfollowing "unfollowing"}}"
   {{on "click" (fn this.handleSwitchChannel)}}
   {{on "mousedown" (fn this.handleNewWindow)}}
+  role="button"
 >
   {{chat-channel-title channel=channel}}
   {{chat-channel-unread-indicator channel=channel}}

--- a/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
@@ -1,13 +1,13 @@
-<div class={{rowClassNames}}>
+<div
+  id="chat-channel-row-{{channel.id}}"
+  class="{{rowClassNames}} {{if isUnfollowing "unfollowing"}}"
+  {{on "click" (fn this.handleSwitchChannel)}}
+  {{on "mousedown" (fn this.handleNewWindow)}}
+>
   {{chat-channel-title channel=channel}}
   {{chat-channel-unread-indicator channel=channel}}
-
-  {{#if isDirectMessageRow}}
-    {{d-button
-      icon="times"
-      action=(action "leaveChatChannel")
-      class="btn-flat leave-channel-btn"
-      title="chat.direct_messages.leave"
-    }}
-  {{/if}}
+  {{chat-channel-leave-btn
+    channel=channel
+    onLeaveChannel=(action "onLeaveChannel")
+  }}
 </div>

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -278,7 +278,7 @@ body.composer-open .topic-chat-float-container {
 
   .edit-channel-membership-btn,
   .new-dm,
-  .leave-channel-btn {
+  .chat-channel-leave-btn {
     background: transparent;
     color: var(--primary-medium);
     font-size: var(--font-0-rem);
@@ -685,14 +685,25 @@ body.composer-open .topic-chat-float-container {
   position: relative;
   cursor: pointer;
   color: var(--primary-high);
+  transition: all 50ms ease-in;
+  transition-property: opacity;
+  opacity: 1;
 
-  .leave-channel-btn {
+  &.unfollowing {
+    opacity: 0;
+  }
+
+  .chat-channel-leave-btn {
     margin-left: auto;
     visibility: hidden;
+
+    > * {
+      pointer-events: none;
+    }
   }
 
   &:hover {
-    .leave-channel-btn {
+    .chat-channel-leave-btn {
       visibility: visible;
     }
   }
@@ -860,7 +871,7 @@ body.composer-open .topic-chat-float-container {
     .new-dm,
     .edit-channel-membership-btn,
     .edit-channels-dropdown .select-kit-header,
-    .leave-channel-btn {
+    .chat-channel-leave-btn {
       display: flex;
       padding: 0.25em;
       border-radius: 0.25em;
@@ -875,7 +886,7 @@ body.composer-open .topic-chat-float-container {
       }
     }
 
-    .leave-channel-btn:hover {
+    .chat-channel-leave-btn:hover {
       background-color: var(--tertiary-medium);
     }
 

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -685,8 +685,7 @@ body.composer-open .topic-chat-float-container {
   position: relative;
   cursor: pointer;
   color: var(--primary-high);
-  transition: all 50ms ease-in;
-  transition-property: opacity;
+  transition: opacity 50ms ease-in;
   opacity: 1;
 
   &.unfollowing {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -11,6 +11,7 @@ en:
       cancel: "Cancel"
       cancel_reply: "Cancel reply"
       chat_channels: "Channels"
+      leave: "Leave channel"
       channel_list_popup:
         browse: "Browse channels"
         create: "Create a channel"

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -259,11 +259,11 @@ acceptance("Discourse Chat - without unread", function (needs) {
 
   test("Unfollowing a direct message channel transitions to another channel", async function (assert) {
     await visit("/chat/channel/75/@hawk");
-    await click(".chat-channel-row.chat-channel-76 .leave-channel-btn");
+    await click(".chat-channel-row.chat-channel-76 .chat-channel-leave-btn");
 
     assert.ok(/^\/chat\/channel\/75/.test(currentURL()));
 
-    await click(".chat-channel-row.chat-channel-75 .leave-channel-btn");
+    await click(".chat-channel-row.chat-channel-75 .chat-channel-leave-btn");
 
     assert.ok(/^\/chat\/channel\/4/.test(currentURL()));
   });

--- a/test/javascripts/components/chat-channel-leave-btn-test.js
+++ b/test/javascripts/components/chat-channel-leave-btn-test.js
@@ -1,0 +1,69 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import { discourseModule, query } from "discourse/tests/helpers/qunit-helpers";
+import hbs from "htmlbars-inline-precompile";
+import pretender from "discourse/tests/helpers/create-pretender";
+import I18n from "I18n";
+
+discourseModule(
+  "Discourse Chat | Component | chat-channel-leave-btn",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    componentTest("accepts an optional onLeaveChannel callback", {
+      template: hbs`{{chat-channel-leave-btn channel=channel onLeaveChannel=onLeaveChannel}}`,
+
+      beforeEach() {
+        this.set("foo", 1);
+        this.set("onLeaveChannel", () => this.set("foo", 2));
+        this.set("channel", {
+          id: 1,
+          chatable_type: "DirectMessageChannel",
+          chatable: {
+            users: [{ id: 1 }],
+          },
+        });
+      },
+
+      async test(assert) {
+        pretender.post("/chat/chat_channels/:chatChannelId/unfollow", () => {
+          return [200, { success: "OK" }, {}];
+        });
+        assert.equal(this.foo, 1);
+
+        await click(".chat-channel-leave-btn");
+
+        assert.equal(this.foo, 2);
+      },
+    });
+
+    componentTest("has a specific title for direct message channel", {
+      template: hbs`{{chat-channel-leave-btn channel=channel}}`,
+
+      beforeEach() {
+        this.set("channel", { chatable_type: "DirectMessageChannel" });
+      },
+
+      async test(assert) {
+        const btn = query(".chat-channel-leave-btn");
+
+        assert.equal(btn.title, I18n.t("chat.direct_messages.leave"));
+      },
+    });
+
+    componentTest("has a specific title for message channel", {
+      template: hbs`{{chat-channel-leave-btn channel=channel}}`,
+
+      beforeEach() {
+        this.set("channel", { chatable_type: "Topic" });
+      },
+
+      async test(assert) {
+        const btn = query(".chat-channel-leave-btn");
+
+        assert.equal(btn.title, I18n.t("chat.leave"));
+      },
+    });
+  }
+);


### PR DESCRIPTION
- allows to quickly leave all channels and not only direct message channels
- makes channel-row tag less
- adds an instant animation when unfollowing a channel to make UI more responsive
- introduces `chat-channel-leave-btn` to encapsulate all this btn logic