### PR TITLE
FIX: "All loaded" message was shown too early

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -238,7 +238,7 @@ export default Component.extend({
       registeredChatChannelId: this.chatChannel.id,
     });
 
-    if (!this.targetMessageId && this.messages.length < PAGE_SIZE) {
+    if (!this.targetMessageId && messages.length < PAGE_SIZE) {
       this.set("allPastMessagesLoaded", true);
     }
 


### PR DESCRIPTION
Wrong variable was being used.