### PR TITLE
UX: Tweak message-separator styling

### DIFF
--- a/assets/stylesheets/common/tc-message.scss
+++ b/assets/stylesheets/common/tc-message.scss
@@ -456,7 +456,7 @@
 }
 
 .tc-message-separator {
-  margin: 1em 0 1em 0.75em;
+  margin: 0.25rem 0 0.25rem 1rem;
   display: flex;
   font-size: var(--font-down-1);
   position: relative;
@@ -473,7 +473,6 @@
     .tc-text {
       color: var(--secondary-low);
       font-weight: 600;
-      padding: 2px 10px;
     }
 
     .tc-separator {
@@ -483,7 +482,7 @@
 
   .tc-text {
     margin: 0 auto;
-    padding: 0 0.5em;
+    padding: 0 0.75rem;
     z-index: 1;
     background: var(--secondary);
   }

--- a/assets/stylesheets/common/tc-message.scss
+++ b/assets/stylesheets/common/tc-message.scss
@@ -471,9 +471,7 @@
 
   &.first-daily-message {
     .tc-text {
-      border: 1px solid var(--secondary-high);
-      border-radius: 3px;
-      color: var(--primary-high);
+      color: var(--secondary-low);
       font-weight: 600;
       padding: 2px 10px;
     }


### PR DESCRIPTION
Less is more + better text contrast + tighter spacing + align left margin

Before / After

<img width="919" alt="image" src="https://user-images.githubusercontent.com/66961/148548524-a2462166-a9a3-45ff-b190-0f08b8b03d07.png">
<img width="920" alt="image" src="https://user-images.githubusercontent.com/66961/148548424-dc938d26-84fe-44c5-870d-614518404734.png">
