### PR TITLE
FIX: Prevent audio from playing on top of each other CAUSING IT TO BE LOUD

### DIFF
--- a/assets/javascripts/discourse/initializers/chat-notification-sounds.js
+++ b/assets/javascripts/discourse/initializers/chat-notification-sounds.js
@@ -5,6 +5,12 @@ export const CHAT_SOUNDS = {
   ding: "/plugins/discourse-chat/audio/ding.mp3",
 };
 
+const MENTION = 29;
+const MESSAGE = 30;
+const CHAT_NOTIFICATION_TYPES = [MENTION, MESSAGE];
+
+const AUDIO_DEBOUNCE_TIMEOUT = 3000;
+
 export default {
   name: "chat-notification-sounds",
   initialize(container) {
@@ -13,13 +19,38 @@ export default {
       return;
     }
 
+    let canPlay = true;
+
+    function playAudio(user) {
+      try {
+        new Audio(CHAT_SOUNDS[user.chat_sound]).play();
+      } catch (error) {
+        if (error instanceof DOMException) {
+          // eslint-disable-next-line no-console
+          console.info(
+            "User needs to interact with DOM before we can play notification sounds"
+          );
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    function playAudioWithDebounce(user) {
+      if (canPlay) {
+        canPlay = false;
+
+        setTimeout(() => {
+          canPlay = true;
+          playAudio(user);
+        }, AUDIO_DEBOUNCE_TIMEOUT);
+      }
+    }
+
     withPluginApi("0.12.1", (api) => {
       api.registerDesktopNotificationHandler((data, siteSettings, user) => {
-        // chat_mention and chat_message are notification_types of 29 and 30.
-        if ([29, 30].includes(data.notification_type)) {
-          const audio = new Audio(CHAT_SOUNDS[user.chat_sound]);
-          audio.volume = 0.8;
-          audio.play();
+        if (CHAT_NOTIFICATION_TYPES.includes(data.notification_type)) {
+          playAudioWithDebounce(user);
         }
       });
     });

--- a/assets/javascripts/discourse/initializers/chat-notification-sounds.js
+++ b/assets/javascripts/discourse/initializers/chat-notification-sounds.js
@@ -22,18 +22,13 @@ export default {
     let canPlay = true;
 
     function playAudio(user) {
-      try {
-        new Audio(CHAT_SOUNDS[user.chat_sound]).play();
-      } catch (error) {
-        if (error instanceof DOMException) {
-          // eslint-disable-next-line no-console
-          console.info(
-            "User needs to interact with DOM before we can play notification sounds"
-          );
-        } else {
-          throw error;
-        }
-      }
+      const audio = new Audio(CHAT_SOUNDS[user.chat_sound]);
+      audio.play().catch(() => {
+        // eslint-disable-next-line no-console
+        console.info(
+          "User needs to interact with DOM before we can play notification sounds"
+        );
+      });
     }
 
     function playAudioWithDebounce(user) {


### PR DESCRIPTION
/t/56762

Debounces the playing of audio notifications.

We also have to think about what we want to do when audio playing fails because the user has not interacted with the app due to [an autoplay policy browsers have](https://developer.chrome.com/blog/autoplay/#audiovideo-elements).

I don't have tests for this because I don't think it's possible to unit test this without sufficiently mocking the plugin API and we seem to be against mocking.