### PR TITLE
REFACTOR: Mobile back btn takes you to channel index

### DIFF
--- a/assets/javascripts/discourse/components/chat-channel-title.js
+++ b/assets/javascripts/discourse/components/chat-channel-title.js
@@ -17,6 +17,6 @@ export default Component.extend({
 
   @action
   handleOnClick(event) {
-    return this?.onClick(event);
+    return this.onClick?.(event);
   },
 });

--- a/assets/javascripts/discourse/components/full-page-chat.js
+++ b/assets/javascripts/discourse/components/full-page-chat.js
@@ -7,29 +7,21 @@ import { next } from "@ember/runloop";
 export default Component.extend({
   tagName: "",
   teamsSidebarOn: false,
-  showingChannels: false,
   router: service(),
   chat: service(),
 
-  @discourseComputed("teamsSidebarOn", "showingChannels")
-  wrapperClassNames(teamsSidebarOn, showingChannels) {
+  @discourseComputed("teamsSidebarOn")
+  wrapperClassNames(teamsSidebarOn) {
     const classNames = ["full-page-chat"];
     if (teamsSidebarOn) {
       classNames.push("teams-sidebar-on");
     }
-    if (showingChannels) {
-      classNames.push("showing-channels");
-    }
     return classNames.join(" ");
   },
 
-  @discourseComputed("site.mobileView", "teamsSidebarOn", "showingChannels")
-  showChannelSelector(mobileView, sidebarOn, showingChannels) {
-    if (mobileView) {
-      return showingChannels;
-    }
-
-    return !sidebarOn;
+  @discourseComputed("site.mobileView", "teamsSidebarOn")
+  showChannelSelector(mobileView, sidebarOn) {
+    return !mobileView && !sidebarOn;
   },
 
   init() {
@@ -92,9 +84,12 @@ export default Component.extend({
   },
 
   @action
-  switchChannel(channel) {
-    this.set("showingChannels", false);
+  navigateToIndex() {
+    this.router.transitionTo("chat.index");
+  },
 
+  @action
+  switchChannel(channel) {
     if (channel.id !== this.chatChannel.id) {
       this.router.transitionTo("chat.channel", channel.id, channel.title);
     }

--- a/assets/javascripts/discourse/templates/components/full-page-chat.hbs
+++ b/assets/javascripts/discourse/templates/components/full-page-chat.hbs
@@ -13,6 +13,6 @@
     fullPage=true
     previewing=previewing
     joinChannel=joinChannel
-    onBackClick=(action (mut showingChannels) true)
+    onBackClick=(action "navigateToIndex")
   }}
 </div>

--- a/assets/stylesheets/mobile/mobile.scss
+++ b/assets/stylesheets/mobile/mobile.scss
@@ -77,13 +77,6 @@ body.has-full-page-chat {
   overflow-x: hidden;
   width: 100%;
 
-  &.showing-channels {
-    .tc-live-pane {
-      display: none;
-    }
-  }
-
-  .tc-channels,
   .tc-live-pane {
     border-radius: 0;
   }
@@ -99,20 +92,6 @@ body.has-full-page-chat {
   }
   .tc-composer {
     background-color: var(--primary-very-low);
-  }
-
-  .tc-channels {
-    background-color: var(--secondary);
-    border: none;
-    border-top: 1px solid var(--primary-low);
-    font-weight: 500;
-    height: calc(100% - 1px);
-
-    .topic-chat-badge {
-      .d-icon {
-        background-color: var(--secondary);
-      }
-    }
   }
 
   .tc-full-page-header {


### PR DESCRIPTION
Previously when there was no `chat.index` route, we needed the channel selector to be rendered for mobile, and the back btn hid the chat live pane and showed the channel selector. Now we can simply navigate back to the chat index route which is the channel selector :)

Also a little JS bug in channel-title.