### PR TITLE
FIX: Loading past messages

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -126,8 +126,10 @@ export default Component.extend({
         this.messageBus.unsubscribe(`/chat/${this.registeredChatChannelId}`);
         this.messages.clear();
       }
+
       this.messageLookup = {};
       this.registeredChatChannelId = null;
+      this.set("allPastMessagesLoaded", false);
 
       if (this.chatChannel.id != null) {
         this.fetchMessages(this.chatChannel.id);


### PR DESCRIPTION
A follow-up to #466. Turns out the bug I was hunting was caused by `allPastMessagesLoaded` being persisted between channel changes, which meant that once you saw an "end" of one channel you couldn't scroll-to-load in any channels.