### PR TITLE
UI: Single line placeholder text

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1355,3 +1355,13 @@ body.composer-open .topic-chat-float-container {
     margin-bottom: 0.1em;
   }
 }
+
+.tc-live-pane .tc-composer .tc-composer-row .tc-composer-input {
+  text-overflow: ellipsis;
+
+  &::-webkit-input-placeholder {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1359,7 +1359,7 @@ body.composer-open .topic-chat-float-container {
 .tc-live-pane .tc-composer .tc-composer-row .tc-composer-input {
   text-overflow: ellipsis;
 
-  &::-webkit-input-placeholder {
+  &:placeholder-shown {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/assets/stylesheets/mobile/mobile.scss
+++ b/assets/stylesheets/mobile/mobile.scss
@@ -1,12 +1,6 @@
 .tc-live-pane .tc-composer .tc-composer-row {
   .tc-composer-input {
     padding-right: 75px;
-
-    &::-webkit-input-placeholder {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
   }
 
   .open-toolbar-btn {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -61,7 +61,7 @@ en:
       open_full_page: "Open full-screen chat"
       open_message: "Open message in chat"
       placeholder_self: "Jot something down"
-      placeholder_others: "Send a message to %{messageRecipient}"
+      placeholder_others: "Chat with %{messageRecipient}"
       placeholder_previewing: "Join the channel to send a message."
       remove_upload: "Remove file"
       react: "React with emoji"

--- a/test/javascripts/components/chat-composer-placeholder-test.js
+++ b/test/javascripts/components/chat-composer-placeholder-test.js
@@ -50,7 +50,7 @@ discourseModule(
       async test(assert) {
         assert.equal(
           query(".tc-composer-input").placeholder,
-          "Send a message to Tomtom, Steaky, @zorro"
+          "Chat with Tomtom, Steaky, @zorro"
         );
       },
     });
@@ -68,7 +68,7 @@ discourseModule(
       async test(assert) {
         assert.equal(
           query(".tc-composer-input").placeholder,
-          "Send a message to #just-cats"
+          "Chat with #just-cats"
         );
       },
     });


### PR DESCRIPTION
Related: https://github.com/discourse/discourse-chat/pull/394

The previous commit only made the ellipsis show on mobile. 
This one does it on desktop too for the mini-chat popup.

One thing to note is that when the placeholder is clicked, the
ellipsis actually goes away. This is also evident on 
https://developer.mozilla.org/en-US/docs/Web/CSS/:placeholder-shown
