### PR TITLE
DEV: Rename tc-message's inner classes

### DIFF
--- a/assets/javascripts/discourse/components/tc-message.js
+++ b/assets/javascripts/discourse/components/tc-message.js
@@ -45,7 +45,7 @@ export default Component.extend({
       return;
     }
     this.element
-      .querySelector(".tc-message-container .tc-text")
+      .querySelector(".chat-message-content .tc-text")
       ?.querySelectorAll(".mention")
       .forEach((node) => {
         const mention = node.textContent.trim().substring(1);
@@ -183,7 +183,7 @@ export default Component.extend({
     "message.action_code",
     "isHovered"
   )
-  innerMessageClasses(staged, deletedAt, inReplyTo, actionCode, isHovered) {
+  chatMessageClasses(staged, deletedAt, inReplyTo, actionCode, isHovered) {
     let classNames = ["tc-message"];
 
     if (staged) {

--- a/assets/javascripts/discourse/templates/components/tc-message.hbs
+++ b/assets/javascripts/discourse/templates/components/tc-message.hbs
@@ -40,7 +40,7 @@
         }}
       </div>
     {{else}}
-      <div class={{innerMessageClasses}}>
+      <div class={{chatMessageClasses}}>
         {{#unless message.staged}}
           <div class="tc-msgactions-hover">
             <div class="tc-msgactions">
@@ -113,9 +113,9 @@
           {{/if}}
         {{/if}}
 
-        <div class="tc-message-container">
+        <div class="chat-message-content">
           {{#unless hideUserInfo}}
-            <div class="tc-meta-data">
+            <div class="chat-message-sender-data">
               <span class={{usernameClasses}}>
                 {{#if message.chat_webhook_event.username}}
                   {{message.chat_webhook_event.username}}

--- a/assets/stylesheets/common/tc-message.scss
+++ b/assets/stylesheets/common/tc-message.scss
@@ -120,12 +120,12 @@
       width: 100%;
     }
 
-    .tc-message-container {
+    .chat-message-content {
       grid-area: message;
     }
   }
 
-  .tc-message-container {
+  .chat-message-content {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
@@ -416,7 +416,7 @@
   }
 }
 
-.tc-meta-data {
+.chat-message-sender-data {
   color: var(--secondary-medium);
   width: 100%;
 


### PR DESCRIPTION
Part 2 of https://github.com/discourse/discourse-chat/pull/483

Within tc-message, the intent for classnames is

```
  chat-message-container
    chat-message (currently tc-message)
      chat-message-content (currently tc-message-container, changed in this commit)
...
```