### PR TITLE
REFACTOR: tc-avatar

### DIFF
--- a/assets/javascripts/discourse/components/chat-user-avatar.js
+++ b/assets/javascripts/discourse/components/chat-user-avatar.js
@@ -3,13 +3,16 @@ import discourseComputed from "discourse-common/utils/decorators";
 import { inject as service } from "@ember/service";
 
 export default Component.extend({
-  tagName: "div",
-  classNames: ["tc-presence-flair"],
-  classNameBindings: ["online"],
+  tagName: "",
+
   chat: service(),
 
+  user: null,
+
+  avatarSize: "tiny",
+
   @discourseComputed("chat.presenceChannel.users.[]", "user.id")
-  online(users, userId) {
-    return !!users?.find((u) => u.id === userId);
+  isOnline(users, userId) {
+    return !!users?.findBy("id", userId);
   },
 });

--- a/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
@@ -6,10 +6,7 @@
       </span>
       <span class="dm-usernames">{{usernames}}</span>
     {{else}}
-      <span class="tc-avatar-container">
-        {{avatar channel.chatable.users.firstObject imageSize="medium"}}
-        {{tc-user-presence-flair user=channel.chatable.users.firstObject}}
-      </span>
+      {{chat-user-avatar user=channel.chatable.users.firstObject}}
       <span class="dm-usernames">
         {{#let channel.chatable.users.firstObject as |user|}}
           <span class="dm-username">{{user.username}}</span>

--- a/assets/javascripts/discourse/templates/components/chat-composer-message-details.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer-message-details.hbs
@@ -1,7 +1,7 @@
 <div class="chat-composer-message-details">
   <div class="tc-reply-display">
     {{d-icon icon}}
-    <span class="tc-reply-av">{{avatar message.user imageSize="tiny"}}</span>
+    {{chat-user-avatar user=message.user}}
     <span class="tc-reply-username">{{message.user.username}}</span>
     <span class="tc-reply-msg">{{replace-emoji message.excerpt}}</span>
   </div>

--- a/assets/javascripts/discourse/templates/components/chat-emoji-avatar.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-emoji-avatar.hbs
@@ -1,0 +1,5 @@
+<div class="chat-emoji-avatar">
+  <div class="chat-emoji-avatar-container">
+    {{replace-emoji emoji}}
+  </div>
+</div>

--- a/assets/javascripts/discourse/templates/components/chat-message.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message.hbs
@@ -81,13 +81,11 @@
         {{#if message.in_reply_to}}
           <div role="button" onclick={{action "viewReply"}} class="tc-reply-display">
             {{d-icon "share" title="chat.in_reply_to"}}
-            <span class="tc-reply-av">
-              {{#if message.in_reply_to.chat_webhook_event.emoji}}
-                {{replace-emoji message.in_reply_to.chat_webhook_event.emoji}}
-              {{else}}
-                {{avatar message.in_reply_to.user imageSize="tiny"}}
-              {{/if}}
-            </span>
+            {{#if message.in_reply_to.chat_webhook_event.emoji}}
+              {{chat-emoji-avatar emoji=message.in_reply_to.chat_webhook_event.emoji}}
+            {{else}}
+              {{chat-user-avatar user=message.in_reply_to.user}}
+            {{/if}}
             <span class="tc-reply-msg">
               {{replace-emoji message.in_reply_to.excerpt}}
             </span>
@@ -98,18 +96,9 @@
           {{format-chat-date message details "tiny"}}
         {{else}}
           {{#if message.chat_webhook_event.emoji}}
-            <div class="tc-avatar">
-              <div class="tc-avatar-container">
-                {{replace-emoji message.chat_webhook_event.emoji}}
-              </div>
-            </div>
+            {{chat-emoji-avatar emoji=message.chat_webhook_event.emoji}}
           {{else}}
-            <div class="tc-avatar">
-              <div class="tc-avatar-container" data-user-card={{message.user.username}}>
-                {{avatar message.user imageSize="medium"}}
-                {{tc-user-presence-flair user=message.user}}
-              </div>
-            </div>
+            {{chat-user-avatar user=message.user avatarSize="medium"}}
           {{/if}}
         {{/if}}
 

--- a/assets/javascripts/discourse/templates/components/chat-user-avatar.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-user-avatar.hbs
@@ -1,0 +1,9 @@
+<div class="chat-user-avatar">
+  <div class="chat-user-avatar-container" data-user-card={{user.username}}>
+    {{avatar user imageSize=avatarSize}}
+
+    {{#if isOnline}}
+      <div class="chat-user-presence-flair"></div>
+    {{/if}}
+  </div>
+</div>

--- a/assets/stylesheets/common/chat-message.scss
+++ b/assets/stylesheets/common/chat-message.scss
@@ -78,11 +78,6 @@
     transition: 2s linear background-color;
   }
 
-  .tc-avatar {
-    flex-shrink: 0;
-    width: var(--message-left-width);
-  }
-
   &.user-info-hidden {
     .chat-time {
       color: var(--secondary-medium);
@@ -115,9 +110,8 @@
       }
     }
 
-    .tc-avatar {
+    .chat-user-avatar {
       grid-area: avatar;
-      width: 100%;
     }
 
     .chat-message-content {
@@ -132,15 +126,6 @@
     word-break: break-word;
     overflow-wrap: break-word;
     min-width: 0;
-  }
-
-  .tc-avatar-container {
-    align-items: flex-start;
-    display: flex;
-    cursor: pointer;
-    flex-shrink: 0;
-    justify-content: center;
-    width: 28px;
   }
 
   .tc-bot-indicator {

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -358,40 +358,7 @@ body.composer-open .topic-chat-float-container {
   }
 }
 
-.tc-avatar-container {
-  position: relative;
-
-  .avatar {
-    width: 100%;
-    height: auto;
-  }
-
-  .tc-presence-flair {
-    box-sizing: border-box;
-    display: none;
-    position: absolute;
-    right: -2px;
-    bottom: -2px;
-    background-color: var(--success);
-    width: 8px;
-    height: 8px;
-    border: 1px solid var(--secondary);
-    border-radius: 50%;
-
-    .chat-messages-container & {
-      right: -1px;
-      bottom: -1px;
-      width: 10px;
-      height: 10px;
-    }
-
-    &.online {
-      display: block;
-    }
-  }
-}
-
-.chat-message-container {
+.chat-message {
   position: relative;
   display: grid;
 
@@ -426,6 +393,65 @@ body.composer-open .topic-chat-float-container {
   }
 }
 
+.chat-emoji-avatar {
+  width: var(--message-left-width);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.chat-user-avatar {
+  width: var(--message-left-width);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .chat-user-avatar-container {
+    position: relative;
+
+    .avatar {
+      .tc-message:not(.is-reply) & {
+        width: 28px;
+        height: 28px;
+      }
+    }
+
+    .chat-user-presence-flair {
+      box-sizing: border-box;
+      position: absolute;
+      background-color: var(--success);
+      border: 1px solid var(--secondary);
+      border-radius: 50%;
+
+      .tc-message.is-reply .tc-reply-display &,
+      .tc-composer-message-details .tc-reply-display & {
+        width: 8px;
+        height: 8px;
+        right: -1px;
+        bottom: -1px;
+      }
+
+      .tc-message:not(.is-reply) & {
+        width: 10px;
+        height: 10px;
+        right: 0px;
+        bottom: 0px;
+      }
+
+      .chat-channel-title & {
+        width: 8px;
+        height: 8px;
+        right: -1px;
+        bottom: -1px;
+      }
+    }
+  }
+
+  .chat-channel-title & {
+    width: auto;
+  }
+}
+
 .tc-reply-display {
   display: flex;
   align-items: center;
@@ -435,16 +461,11 @@ body.composer-open .topic-chat-float-container {
   font-size: var(--font-down-1);
   padding-left: 0.5em;
 
-  .tc-reply-av {
-    padding: 0 0.5em;
-  }
-
   .tc-reply-username {
     padding: 0 0.5em 0 0;
   }
 
   .tc-reply-msg {
-    align-self: baseline;
     color: var(--primary-high);
     > * {
       margin-top: 0;
@@ -818,17 +839,6 @@ body.composer-open .topic-chat-float-container {
     color: var(--primary-medium);
     width: 100%;
     display: flex;
-  }
-
-  .tc-avatar {
-    display: flex;
-  }
-
-  .tc-avatar-container {
-    align-items: flex-start;
-    display: inline-flex;
-    width: 100%;
-    height: auto;
   }
 
   .dm-multi-count {

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -401,10 +401,18 @@ body.composer-open .topic-chat-float-container {
 }
 
 .chat-user-avatar {
-  width: var(--message-left-width);
   display: flex;
   align-items: center;
-  justify-content: center;
+
+  .chat-message:not(.is-reply) & {
+    padding-right: 0.5rem;
+  }
+
+  .chat-message.is-reply .tc-reply-display &,
+  .chat-composer-message-details .tc-reply-display & {
+    padding-right: 0.5rem;
+    padding-left: 0.5rem;
+  }
 
   .chat-user-avatar-container {
     position: relative;
@@ -415,7 +423,7 @@ body.composer-open .topic-chat-float-container {
         height: 28px;
       }
 
-      .chat-message .tc-reply-display & {
+      .chat-message.is-reply .tc-reply-display & {
         width: 20px;
         height: 20px;
       }

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -410,9 +410,14 @@ body.composer-open .topic-chat-float-container {
     position: relative;
 
     .avatar {
-      .tc-message:not(.is-reply) & {
+      .chat-message & {
         width: 28px;
         height: 28px;
+      }
+
+      .chat-message .tc-reply-display & {
+        width: 20px;
+        height: 20px;
       }
     }
 
@@ -423,15 +428,15 @@ body.composer-open .topic-chat-float-container {
       border: 1px solid var(--secondary);
       border-radius: 50%;
 
-      .tc-message.is-reply .tc-reply-display &,
-      .tc-composer-message-details .tc-reply-display & {
+      .chat-message.is-reply .tc-reply-display &,
+      .chat-composer-message-details .tc-reply-display & {
         width: 8px;
         height: 8px;
         right: -1px;
         bottom: -1px;
       }
 
-      .tc-message:not(.is-reply) & {
+      .chat-message:not(.is-reply) & {
         width: 10px;
         height: 10px;
         right: 0px;

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -29,7 +29,7 @@
           grid-template-columns: var(--message-left-width) 1fr;
         }
 
-        .tc-avatar {
+        .chat-user {
           width: var(--message-left-width);
         }
       }

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -438,7 +438,7 @@ acceptance("Discourse Chat - without unread", function (needs) {
     assert.ok(lastMessage.classList.contains("chat-message-staged"));
 
     // Last message was from a different user; full meta data is shown
-    assert.ok(lastMessage.querySelector(".tc-avatar"), "Avatar is present");
+    assert.ok(lastMessage.querySelector(".chat-user"), "Avatar is present");
     assert.ok(lastMessage.querySelector(".full-name"), "Username is present");
     assert.equal(
       lastMessage.querySelector(".chat-message-text").innerText.trim(),
@@ -476,7 +476,7 @@ acceptance("Discourse Chat - without unread", function (needs) {
 
       // We just sent a message so avatar/username will not be present for the last message
       assert.notOk(
-        lastMessage.querySelector(".tc-avatar"),
+        lastMessage.querySelector(".chat-user"),
         "Avatar is not shown"
       );
       assert.notOk(

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -438,7 +438,10 @@ acceptance("Discourse Chat - without unread", function (needs) {
     assert.ok(lastMessage.classList.contains("chat-message-staged"));
 
     // Last message was from a different user; full meta data is shown
-    assert.ok(lastMessage.querySelector(".chat-user"), "Avatar is present");
+    assert.ok(
+      lastMessage.querySelector(".chat-user-avatar"),
+      "Avatar is present"
+    );
     assert.ok(lastMessage.querySelector(".full-name"), "Username is present");
     assert.equal(
       lastMessage.querySelector(".chat-message-text").innerText.trim(),
@@ -476,7 +479,7 @@ acceptance("Discourse Chat - without unread", function (needs) {
 
       // We just sent a message so avatar/username will not be present for the last message
       assert.notOk(
-        lastMessage.querySelector(".chat-user"),
+        lastMessage.querySelector(".chat-user-avatar"),
         "Avatar is not shown"
       );
       assert.notOk(

--- a/test/javascripts/components/chat-channel-title-test.js
+++ b/test/javascripts/components/chat-channel-title-test.js
@@ -140,7 +140,7 @@ discourseModule(
         const user = this.channel.chatable.users[0];
 
         assert.ok(
-          exists(`.tc-avatar-container .avatar[title="${user.username}"]`)
+          exists(`.chat-user-container .avatar[title="${user.username}"]`)
         );
         assert.equal(
           query(`.dm-usernames .dm-username`).innerText,

--- a/test/javascripts/components/chat-channel-title-test.js
+++ b/test/javascripts/components/chat-channel-title-test.js
@@ -140,7 +140,9 @@ discourseModule(
         const user = this.channel.chatable.users[0];
 
         assert.ok(
-          exists(`.chat-user-container .avatar[title="${user.username}"]`)
+          exists(
+            `.chat-user-avatar-container .avatar[title="${user.username}"]`
+          )
         );
         assert.equal(
           query(`.dm-usernames .dm-username`).innerText,

--- a/test/javascripts/components/chat-emoji-avatar-test.js
+++ b/test/javascripts/components/chat-emoji-avatar-test.js
@@ -1,0 +1,28 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import { discourseModule, exists } from "discourse/tests/helpers/qunit-helpers";
+import hbs from "htmlbars-inline-precompile";
+
+discourseModule(
+  "Discourse Chat | Component | chat-emoji-avatar",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    componentTest("uses an emoji as avatar", {
+      template: hbs`{{chat-emoji-avatar emoji=emoji}}`,
+
+      async beforeEach() {
+        this.set("emoji", ":otter:");
+      },
+
+      async test(assert) {
+        assert.ok(
+          exists(
+            `.chat-emoji-avatar .chat-emoji-avatar-container .emoji[title=otter]`
+          )
+        );
+      },
+    });
+  }
+);

--- a/test/javascripts/components/chat-user-avatar-test.js
+++ b/test/javascripts/components/chat-user-avatar-test.js
@@ -1,0 +1,57 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import { discourseModule, exists } from "discourse/tests/helpers/qunit-helpers";
+import hbs from "htmlbars-inline-precompile";
+
+const user = {
+  id: 1,
+  username: "markvanlan",
+  name: null,
+  avatar_template: "/letter_avatar_proxy/v4/letter/m/48db29/{size}.png",
+};
+
+discourseModule(
+  "Discourse Chat | Component | chat-user-avatar",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    componentTest("user is not online", {
+      template: hbs`{{chat-user-avatar chat=chat user=user}}`,
+
+      async beforeEach() {
+        this.set("user", user);
+        this.set("chat", { presenceChannel: { users: [] } });
+      },
+
+      async test(assert) {
+        assert.ok(
+          exists(
+            `.chat-user-avatar .chat-user-avatar-container[data-user-card=${user.username}] .avatar[title=${user.username}]`
+          )
+        );
+        assert.notOk(exists(".chat-user-avatar .chat-user-presence-flair"));
+      },
+    });
+
+    componentTest("user is online", {
+      template: hbs`{{chat-user-avatar chat=chat user=user}}`,
+
+      async beforeEach() {
+        this.set("user", user);
+        this.set("chat", {
+          presenceChannel: { users: [{ id: user.id }] },
+        });
+      },
+
+      async test(assert) {
+        assert.ok(
+          exists(
+            `.chat-user-avatar .chat-user-avatar-container[data-user-card=${user.username}] .avatar[title=${user.username}]`
+          )
+        );
+        assert.ok(exists(".chat-user-avatar .chat-user-presence-flair"));
+      },
+    });
+  }
+);


### PR DESCRIPTION
- chat-user-avatar, with tests (previously tc-avatar)
- chat-emoji-avatar, with test
- chat-user-presence-flair, tested in isolation (previously tc-user-presence-flair)
- fixes an issue where html for tc-user-presence-flair was also present for each avatar even if not online
- displays presence indicator for reply messages
- removes a lot duplicated css