### PR TITLE
UX: Remove space between dots in ellipsis

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -622,6 +622,8 @@ body.composer-open .topic-chat-float-container {
     padding: 0.25em 0.75em;
 
     .replying-text {
+      display: inline-flex;
+
       font-size: var(--font-down-2);
 
       &:before {
@@ -633,6 +635,7 @@ body.composer-open .topic-chat-float-container {
 
     .wave {
       flex: 0 0 auto;
+      display: inline-flex;
 
       .dot {
         display: inline-block;


### PR DESCRIPTION
Previously we were relying on the lack of whitespace between `<span>` elements. 14633d88 tidied up the HTML, and added newlines between the spans.

This commit uses `display:inline-flex` to make remove the space between the spans, which should be much less fragile.

Before (broken):
<img width="127" alt="Screenshot 2022-01-10 at 22 24 36" src="https://user-images.githubusercontent.com/6270921/148848672-4664fcd1-2f9c-4b90-8b51-7c993725e917.png">

After (fixed):
<img width="116" alt="Screenshot 2022-01-10 at 22 24 17" src="https://user-images.githubusercontent.com/6270921/148848698-1f7f36f4-9179-4c50-93e3-b6836c7a30c5.png">

