### PR TITLE
FIX: Don't collapse all oneboxes

### DIFF
--- a/assets/javascripts/discourse/components/chat-message-collapser.js
+++ b/assets/javascripts/discourse/components/chat-message-collapser.js
@@ -103,7 +103,9 @@ function externalImageOnebox(e) {
   return (
     e.firstElementChild &&
     e.firstElementChild.nodeName === "A" &&
-    e.firstElementChild.classList.contains("onebox")
+    e.firstElementChild.classList.contains("onebox") &&
+    e.firstElementChild.firstElementChild &&
+    e.firstElementChild.firstElementChild.nodeName === "IMG"
   );
 }
 

--- a/test/javascripts/components/chat-message-collapser-test.js
+++ b/test/javascripts/components/chat-message-collapser-test.js
@@ -24,9 +24,9 @@ const animatedImageCooked =
 
 const externalImageCooked =
   "<p>written text</p>" +
-  '<p><a href="http://cat1.com" class="onebox"></a></p>' +
+  '<p><a href="http://cat1.com" class="onebox"><img src=""></img></a></p>' +
   "<p>more written text</p>" +
-  '<p><a href="http://cat2.com" class="onebox"></a></p>' +
+  '<p><a href="http://cat2.com" class="onebox"><img src=""></img></a></p>' +
   "<p>and even more</p>";
 
 discourseModule(

--- a/test/javascripts/components/chat-message-text-test.js
+++ b/test/javascripts/components/chat-message-text-test.js
@@ -36,6 +36,21 @@ discourseModule(
       },
     });
 
+    componentTest("does not collapse a non-image onebox", {
+      template: hbs`{{chat-message-text cooked=cooked}}`,
+
+      beforeEach() {
+        this.set(
+          "cooked",
+          '<p><a href="http://cat1.com" class="onebox"></a></p>'
+        );
+      },
+
+      async test(assert) {
+        assert.notOk(exists(".chat-message-collapser"));
+      },
+    });
+
     componentTest("is edited and shows that it's edited", {
       template: hbs`{{chat-message-text cooked=cooked uploads=uploads edited=edited}}`,
 


### PR DESCRIPTION
This was happening and we don't want that to happen.

<img width="425" alt="Screenshot 2022-01-12 at 10 43 54 PM" src="https://user-images.githubusercontent.com/1555215/149161963-663423a3-0f8a-4958-9879-224baf9a1ce2.png">
