### PR TITLE
FIX: Make file names small like before

### DIFF
--- a/assets/javascripts/discourse/components/chat-message-collapser.js
+++ b/assets/javascripts/discourse/components/chat-message-collapser.js
@@ -34,11 +34,13 @@ export default Component.extend({
 
   @computed("uploads")
   get uploadsHeader() {
+    let name = "";
     if (this.uploads.length === 1) {
-      return this.uploads[0].original_filename;
+      name = this.uploads[0].original_filename;
     } else {
-      return I18n.t("chat.uploaded_files", { count: this.uploads.length });
+      name = I18n.t("chat.uploaded_files", { count: this.uploads.length });
     }
+    return `<span class="chat-message-collapser-link-small">${name}</span>`;
   },
 
   @computed("cooked")

--- a/test/javascripts/components/chat-message-collapser-test.js
+++ b/test/javascripts/components/chat-message-collapser-test.js
@@ -153,7 +153,7 @@ discourseModule(
 
       async test(assert) {
         assert.ok(
-          query(".chat-message-collapser-header").innerText.includes(
+          query(".chat-message-collapser-link-small").innerText.includes(
             "tomtom.jpeg"
           )
         );
@@ -170,7 +170,9 @@ discourseModule(
 
       async test(assert) {
         assert.ok(
-          query(".chat-message-collapser-header").innerText.includes("2 files")
+          query(".chat-message-collapser-link-small").innerText.includes(
+            "2 files"
+          )
         );
       },
     });


### PR DESCRIPTION
From https://github.com/discourse/discourse-chat/pull/441, the image filenames were supposed to be small but regressed in the recent PR https://github.com/discourse/discourse-chat/pull/504