### PR TITLE
FIX: correctly computes channels max height in float panel

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -237,7 +237,7 @@ body.composer-open .topic-chat-float-container {
 
 .topic-chat-drawer-content {
   box-sizing: border-box;
-  height: 100%;
+  height: calc(100% - #{$header-height});
   padding-bottom: 0.25em;
 
   .chat-channels .chat-channel-divider {


### PR DESCRIPTION
Before this change it would be possible to have last channel unreachable as the container would not scroll.