### PR TITLE
REFACTOR: extracting uploads from chat-composer code

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer-upload.js
+++ b/assets/javascripts/discourse/components/chat-composer-upload.js
@@ -1,15 +1,25 @@
 import Component from "@ember/component";
+import { action } from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
 import { IMAGES_EXTENSIONS_REGEX } from "discourse/lib/uploads";
 
 export default Component.extend({
   IMAGE_TYPE: "image",
 
-  tagName: "span",
-  classNames: "chat-upload",
-  done: false,
+  tagName: "",
+  isDone: false,
   upload: null,
-  cancel: null,
+  onCancel: null,
+
+  @action
+  handleOnCancel(upload) {
+    this.onCancel?.(upload);
+  },
+
+  @discourseComputed("isDone", "upload.{original_filename,filename}")
+  fileName(isDone, upload) {
+    return isDone ? upload.original_filename : upload.filename;
+  },
 
   @discourseComputed("upload.extension")
   type(extension) {

--- a/assets/javascripts/discourse/components/chat-composer-uploads.js
+++ b/assets/javascripts/discourse/components/chat-composer-uploads.js
@@ -1,0 +1,172 @@
+import Component from "@ember/component";
+import discourseComputed from "discourse-common/utils/decorators";
+import UppyMediaOptimization from "discourse/lib/uppy-media-optimization-plugin";
+import ComposerUploadUppy from "discourse/mixins/composer-upload-uppy";
+import {
+  authorizedExtensions,
+  authorizesAllExtensions,
+} from "discourse/lib/uploads";
+import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
+
+export default Component.extend(ComposerUploadUppy, {
+  classNames: ["chat-composer-uploads"],
+
+  // represents the component state of uploads
+  _uploads: null,
+  inProgressUploads: null,
+  uploads: null,
+  uploadProcessorActions: null,
+  uploadPreProcessors: null,
+  uploadMarkdownResolvers: null,
+  uploadType: "chat-composer",
+  uppyId: "chat-composer-uppy",
+  fullPage: false,
+  composerModelContentKey: "value",
+  composerModel: null,
+  editorInputClass: ".chat-composer-input",
+  mediaOptimizationWorker: service(),
+  eventPrefix: "chat-composer-uploads",
+  onUploadsChanged: null,
+
+  init() {
+    this._super(...arguments);
+
+    this.set("uploadProcessorActions", {});
+    this.set("uploadPreProcessors", []);
+    this.set("uploadMarkdownResolvers", []);
+    this.set("_uploads", []);
+
+    // we fake our own composer model
+    this.set("composerModel", { value: "" });
+
+    if (this.siteSettings.composer_media_optimization_image_enabled) {
+      // TODO:
+      // This whole deal really is not ideal, maybe we need some sort
+      // of ComposerLike mixin that handles adding these processors? But
+      // then again maybe not, because we may not want all processors
+      // for chat...
+      this.uploadPreProcessors.push({
+        pluginClass: UppyMediaOptimization,
+        optionsResolverFn: ({ isMobileDevice }) => {
+          return {
+            optimizeFn: (data, opts) =>
+              this.mediaOptimizationWorker.optimizeImage(data, opts),
+            runParallel: !isMobileDevice,
+          };
+        },
+      });
+    }
+  },
+
+  didInsertElement() {
+    this._super(...arguments);
+
+    this._bindUploadTarget();
+
+    this.set(
+      "fullPage",
+      document.body.classList.contains("has-full-page-chat")
+    );
+
+    this.appEvents.on(
+      `${this.eventPrefix}:upload-success`,
+      this,
+      "_insertUpload"
+    );
+  },
+
+  didReceiveAttrs() {
+    this._super(...arguments);
+
+    this.set("_uploads", this.uploads || []);
+  },
+
+  willDestroyElement() {
+    this._super(...arguments);
+
+    this.set("uploadPreProcessors", null);
+    this.set("uploadProcessorActions", null);
+    this.set("uploadMarkdownResolvers", null);
+
+    this.appEvents.off(
+      `${this.eventPrefix}:upload-success`,
+      this,
+      "_insertUpload"
+    );
+  },
+
+  handleUploadState() {
+    this.onUploadsChanged?.(this._uploads, {
+      inProgressUploads: this.inProgressUploads,
+      isProcessingUpload: this.isProcessingUpload,
+    });
+  },
+
+  @discourseComputed("_uploads.[]", "inProgressUploads.[]")
+  showUploadsContainer() {
+    return this._uploads?.length > 0 || this.inProgressUploads?.length > 0;
+  },
+
+  @discourseComputed("fullPage")
+  fileUploadElementId(fullPage) {
+    return fullPage ? "chat-full-page-uploader" : "chat-widget-uploader";
+  },
+
+  @discourseComputed("fullPage")
+  mobileFileUploaderId(fullPage) {
+    return fullPage
+      ? "chat-full-page-mobile-uploader"
+      : "chat-widget-mobile-uploader";
+  },
+
+  @discourseComputed()
+  acceptedFormats() {
+    const extensions = authorizedExtensions(
+      this.currentUser.staff,
+      this.siteSettings
+    );
+
+    return extensions.map((ext) => `.${ext}`).join();
+  },
+  @discourseComputed()
+  acceptsAllFormats() {
+    return authorizesAllExtensions(this.currentUser.staff, this.siteSettings);
+  },
+
+  @action
+  cancelUploading(upload) {
+    this.appEvents.trigger(`${this.eventPrefix}:cancel-upload`, {
+      fileId: upload.id,
+    });
+    this.handleUploadState();
+  },
+
+  @action
+  removeUpload(upload) {
+    this._uploads.removeObject(upload);
+    this.handleUploadState();
+  },
+
+  _insertUpload(_, upload) {
+    this._uploads.pushObject(upload);
+    this.handleUploadState();
+  },
+
+  _findMatchingUploadHandler() {
+    return;
+  },
+
+  _uploadDropTargetOptions() {
+    const target = document.querySelector(".chat-live-pane");
+    if (!target) {
+      return this._super();
+    }
+
+    return { target };
+  },
+
+  _cursorIsOnEmptyLine() {
+    return true;
+  },
+});

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -442,7 +442,6 @@ export default Component.extend(TextareaTextManipulation, {
   },
 
   messageRecipient(chatChannel) {
-    console.log(chatChannel);
     if (chatChannel.chatable_type === "DirectMessageChannel") {
       const directMessageRecipients = chatChannel.chatable.users;
 
@@ -452,14 +451,6 @@ export default Component.extend(TextareaTextManipulation, {
       ) {
         return I18n.t("chat.placeholder_self");
       }
-
-      console.log(
-        I18n.t("chat.placeholder_others", {
-          messageRecipient: directMessageRecipients
-            .map((u) => u.name || `@${u.username}`)
-            .join(", "),
-        })
-      );
 
       return I18n.t("chat.placeholder_others", {
         messageRecipient: directMessageRecipients

--- a/assets/javascripts/discourse/templates/components/chat-composer-upload.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer-upload.hbs
@@ -1,31 +1,38 @@
-<span class="preview">
-  {{#if (eq type IMAGE_TYPE)}}
-    {{#if done}}
-      <img class="preview-img" src={{upload.short_path}}>
-    {{else}}
-      {{d-icon "far-image"}}
-    {{/if}}
-  {{else}}
-    {{d-icon "file-alt"}}
-  {{/if}}
-</span>
+{{#if upload}}
+  <span class="chat-composer-upload">
+    <span class="preview">
+      {{#if (eq type IMAGE_TYPE)}}
+        {{#if isDone}}
+          <img class="preview-img" src={{upload.short_path}}>
+        {{else}}
+          {{d-icon "far-image"}}
+        {{/if}}
+      {{else}}
+        {{d-icon "file-alt"}}
+      {{/if}}
+    </span>
 
-<span class="data">
-  <div class="top-data">
-    <span class="file-name">{{fileName}}</span>
-    {{d-button
-      class="btn-flat"
-      action=cancel
-      icon="times"
-      title="chat.remove_upload"
-    }}
-  </div>
-  <div class="bottom-data">
-    {{#if done}}
-      <span class="extension-pill">{{upload.extension}}</span>
-    {{else}}
-      <span class="uploading">{{i18n "uploading"}}</span>
-      <progress class="upload-progress" id="file" max="100" value={{upload.progress}}></progress>
-    {{/if}}
-  </div>
-</span>
+    <span class="data">
+      <div class="top-data">
+        <span class="file-name">{{fileName}}</span>
+      </div>
+      <div class="bottom-data">
+        {{#if isDone}}
+          <span class="extension-pill">{{upload.extension}}</span>
+        {{else}}
+          <span class="uploading">{{i18n "uploading"}}</span>
+          <progress class="upload-progress" id="file" max="100" value={{upload.progress}}></progress>
+        {{/if}}
+      </div>
+    </span>
+
+    <span class="actions">
+      {{d-button
+        class="btn-flat remove-upload"
+        action=(action "handleOnCancel" upload)
+        icon="times"
+        title="chat.remove_upload"
+      }}
+    </span>
+  </span>
+{{/if}}

--- a/assets/javascripts/discourse/templates/components/chat-composer-uploads.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer-uploads.hbs
@@ -1,0 +1,19 @@
+{{#if showUploadsContainer}}
+  <div class="chat-composer-uploads-wrapper">
+    {{#each uploads as |upload|}}
+      {{chat-composer-upload
+        upload=upload
+        isDone=true
+        onCancel=(action "removeUpload" upload)
+      }}
+    {{/each}}
+    {{#each inProgressUploads as |upload|}}
+      {{chat-composer-upload
+        upload=upload
+        onCancel=(action "cancelUploading" upload)
+      }}
+    {{/each}}
+  </div>
+{{/if}}
+
+<input type="file" id={{fileUploadElementId}} accept={{acceptedFormats}} multiple>

--- a/assets/javascripts/discourse/templates/components/chat-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer.hbs
@@ -6,6 +6,7 @@
     title="chat.cancel_reply"
   }}
 {{/if}}
+
 {{#if editingMessage}}
   {{chat-composer-message-details
     message=editingMessage
@@ -67,24 +68,7 @@
   {{/if}}
 </div>
 
-{{#if showUploadsContainer}}
-  <div class="chat-composer-uploads-container">
-    {{#each uploads as |upload|}}
-      {{chat-composer-upload
-        upload=upload
-        done=true
-        cancel=(action "removeUpload" upload)
-        fileName=upload.original_filename
-      }}
-    {{/each}}
-
-    {{#each inProgressUploads as |upload|}}
-      {{chat-composer-upload
-        upload=upload
-        cancel=(action "cancelUploading" upload)
-        fileName=upload.fileName
-      }}
-    {{/each}}
-  </div>
-{{/if}}
-<input type="file" id={{fileUploadElementId}} accept={{acceptedFormats}} multiple>
+{{chat-composer-uploads
+  uploads=uploads
+  onUploadsChanged=(action "onUploadsChanged")
+}}

--- a/assets/stylesheets/common/chat-composer-input.scss
+++ b/assets/stylesheets/common/chat-composer-input.scss
@@ -1,0 +1,22 @@
+.chat-composer-input {
+  text-overflow: ellipsis;
+  border: 1px solid var(--primary-low-mid);
+
+  &:focus {
+    border: 1px solid var(--primary-medium);
+    outline: none;
+  }
+
+  .uppy-is-drag-over & {
+    box-shadow: 0 2px 5px 0 var(--tertiary-low),
+      0 2px 10px 0 var(--tertiary-low);
+  }
+
+  &:placeholder-shown {
+    .chat-composer-row & {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+}

--- a/assets/stylesheets/common/chat-composer-upload.scss
+++ b/assets/stylesheets/common/chat-composer-upload.scss
@@ -1,0 +1,70 @@
+.chat-composer-upload {
+  display: inline-flex;
+  height: 50px;
+  padding: 0.5rem;
+  border: 1px solid var(--primary-low-mid);
+  margin-right: 0.5em;
+
+  &:last-child {
+    margin-right: 0;
+  }
+
+  .preview {
+    width: 50px;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 1em 0 0;
+    border-radius: 8px;
+
+    .d-icon {
+      font-size: 3.2rem;
+    }
+
+    .preview-img {
+      max-width: 100%;
+      max-height: 100%;
+    }
+  }
+
+  .data {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    line-height: 1.5em;
+    font-size: var(--font-down-1);
+    color: var(--primary-high);
+
+    .top-data,
+    .bottom-data {
+      display: flex;
+      align-items: center;
+    }
+
+    .file-name {
+      display: inline-block;
+      max-width: 150px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      margin-right: 0.5em;
+    }
+
+    .uploading {
+      font-size: var(--font-down-2);
+      margin-right: 0.75em;
+    }
+
+    .upload-progress {
+      width: 110px;
+    }
+
+    .extension-pill {
+      background: var(--primary-low);
+      border-radius: 5px;
+      font-size: var(--font-down-2-rem);
+      padding: 0.1em 0.4em;
+    }
+  }
+}

--- a/assets/stylesheets/common/chat-composer-uploads.scss
+++ b/assets/stylesheets/common/chat-composer-uploads.scss
@@ -1,0 +1,8 @@
+.chat-composer-uploads {
+  .chat-composer-uploads-wrapper {
+    display: flex;
+    white-space: nowrap;
+    overflow-x: auto;
+    padding: 0.5em;
+  }
+}

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -582,11 +582,6 @@ body.composer-open .topic-chat-float-container {
       }
     }
 
-    .chat-composer-row > .chat-composer-input:focus {
-      border-color: var(--primary-medium);
-      outline: none;
-    }
-
     .chat-composer-row > .chat-composer-input,
     .chat-composer-row::after {
       // `after` pseudo-element should match input styling exactly
@@ -595,11 +590,14 @@ body.composer-open .topic-chat-float-container {
       margin: 0;
       resize: none;
       max-height: 125px;
-      padding: 8px 40px 8px 8px;
-      border: 1px solid var(--primary-low-mid);
       box-sizing: border-box;
       word-break: break-word;
       width: 100%;
+    }
+
+    .chat-composer-row::after {
+      padding: 8px 40px 8px 8px;
+      border: 1px solid var(--primary-low-mid);
     }
 
     .chat-composer-message-details {
@@ -868,81 +866,6 @@ body.composer-open .topic-chat-float-container {
     margin-right: 0.5em;
     line-height: 20px;
     width: 100%;
-  }
-}
-
-.chat-composer-uploads-container {
-  display: flex;
-  padding: 0.5em 0.5em 0 0.5em;
-  white-space: nowrap;
-  overflow-x: auto;
-
-  .chat-upload {
-    display: inline-flex;
-    height: 50px;
-    padding: 0.5em 0.75em;
-    border: 1px solid var(--primary-low);
-    border-radius: 6px;
-    margin-right: 0.5em;
-
-    .preview {
-      width: 50px;
-      height: 100%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      margin: 0 1em 0 0;
-      border-radius: 8px;
-
-      .d-icon {
-        font-size: 3.2rem;
-      }
-
-      .preview-img {
-        max-width: 100%;
-        max-height: 100%;
-      }
-    }
-
-    .data {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      line-height: 1.5em;
-      font-size: var(--font-down-1);
-      color: var(--primary-high);
-
-      .top-data,
-      .bottom-data {
-        display: flex;
-        align-items: center;
-      }
-
-      .file-name {
-        display: inline-block;
-        max-width: 150px;
-        overflow: hidden;
-        white-space: nowrap;
-        text-overflow: ellipsis;
-        margin-right: 0.5em;
-      }
-
-      .uploading {
-        font-size: var(--font-down-2);
-        margin-right: 0.75em;
-      }
-
-      .upload-progress {
-        width: 110px;
-      }
-
-      .extension-pill {
-        background: var(--primary-low);
-        border-radius: 5px;
-        font-size: var(--font-down-2-rem);
-        padding: 0.1em 0.4em;
-      }
-    }
   }
 }
 
@@ -1291,12 +1214,8 @@ body.composer-open .topic-chat-float-container {
   }
 }
 
-.chat-live-pane .chat-composer .chat-composer-row .chat-composer-input {
-  text-overflow: ellipsis;
-
-  &:placeholder-shown {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+.remove-upload {
+  > * {
+    pointer-events: none;
   }
 }

--- a/assets/stylesheets/mobile/chat-composer-input.scss
+++ b/assets/stylesheets/mobile/chat-composer-input.scss
@@ -1,0 +1,7 @@
+.chat-composer-row::after {
+  padding-right: 75px;
+
+  .chat-composer-input {
+    padding-right: 75px;
+  }
+}

--- a/assets/stylesheets/mobile/chat-composer-uploads.scss
+++ b/assets/stylesheets/mobile/chat-composer-uploads.scss
@@ -1,0 +1,3 @@
+.chat-composer-uploads {
+  padding: 0.25em 0.75em;
+}

--- a/assets/stylesheets/mobile/mobile.scss
+++ b/assets/stylesheets/mobile/mobile.scss
@@ -1,8 +1,4 @@
 .chat-live-pane .chat-composer .chat-composer-row {
-  .chat-composer-input {
-    padding-right: 75px;
-  }
-
   .open-toolbar-btn {
     right: 50px;
   }
@@ -17,10 +13,6 @@
       color: var(--tertiary);
     }
   }
-}
-
-.chat-composer-uploads-container {
-  padding: 0.25em 0.75em;
 }
 
 .chat-message:not(.user-info-hidden) {

--- a/plugin.rb
+++ b/plugin.rb
@@ -17,6 +17,11 @@ register_asset 'stylesheets/mobile/mobile.scss', :mobile
 register_asset 'stylesheets/desktop/desktop.scss', :desktop
 register_asset 'stylesheets/sidebar-extensions.scss'
 register_asset 'stylesheets/common/chat-message-separator.scss'
+register_asset 'stylesheets/common/chat-composer-input.scss'
+register_asset 'stylesheets/mobile/chat-composer-input.scss', :mobile
+register_asset 'stylesheets/common/chat-composer-uploads.scss'
+register_asset 'stylesheets/mobile/chat-composer-uploads.scss', :mobile
+register_asset 'stylesheets/common/chat-composer-upload.scss'
 
 register_svg_icon "comments"
 register_svg_icon "comment-slash"

--- a/test/javascripts/components/chat-composer-upload-test.js
+++ b/test/javascripts/components/chat-composer-upload-test.js
@@ -1,0 +1,116 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import {
+  discourseModule,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+import hbs from "htmlbars-inline-precompile";
+import I18n from "I18n";
+
+discourseModule(
+  "Discourse Chat | Component | chat-composer-upload",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    componentTest("file - uploading", {
+      template: hbs`{{chat-composer-upload upload=upload}}`,
+
+      beforeEach() {
+        this.set("upload", { progress: 50, type: ".pdf", done: false });
+      },
+
+      async test(assert) {
+        assert.ok(exists(".upload-progress[value=50]"));
+        assert.strictEqual(
+          query(".uploading").innerText.trim(),
+          I18n.t("uploading")
+        );
+      },
+    });
+
+    componentTest("image - uploading", {
+      template: hbs`{{chat-composer-upload isDone=false upload=upload}}`,
+
+      beforeEach() {
+        this.set("upload", {
+          extension: "png",
+          progress: 50,
+        });
+      },
+
+      async test(assert) {
+        assert.ok(exists(".d-icon-far-image"));
+        assert.ok(exists(".upload-progress[value=50]"));
+        assert.strictEqual(
+          query(".uploading").innerText.trim(),
+          I18n.t("uploading")
+        );
+      },
+    });
+
+    componentTest("file - uploaded", {
+      template: hbs`{{chat-composer-upload isDone=true upload=upload}}`,
+
+      beforeEach() {
+        this.set("upload", {
+          type: ".pdf",
+          filename: "foo",
+          original_filename: "bar",
+          extension: "pdf",
+        });
+      },
+
+      async test(assert) {
+        assert.ok(exists(".d-icon-file-alt"));
+        assert.strictEqual(query(".file-name").innerText.trim(), "bar");
+        assert.strictEqual(query(".extension-pill").innerText.trim(), "pdf");
+      },
+    });
+
+    componentTest("image - uploaded", {
+      template: hbs`{{chat-composer-upload isDone=true upload=upload}}`,
+
+      beforeEach() {
+        this.set("upload", {
+          type: ".png",
+          filename: "foo",
+          original_filename: "bar",
+          extension: "png",
+          short_path: "/my-image.png",
+        });
+      },
+
+      async test(assert) {
+        assert.ok(exists("img.preview-img[src='/my-image.png']"));
+        assert.strictEqual(query(".file-name").innerText.trim(), "bar");
+        assert.strictEqual(query(".extension-pill").innerText.trim(), "png");
+      },
+    });
+
+    componentTest("onCancel action", {
+      template: hbs`{{chat-composer-upload isDone=true upload=upload onCancel=onCancel}}`,
+
+      beforeEach() {
+        this.set("name", null);
+        this.set("onCancel", (upload) => {
+          this.set("name", upload.filename);
+        });
+        this.set("upload", {
+          type: ".png",
+          filename: "foo",
+          original_filename: "bar",
+          extension: "png",
+          short_path: "/my-image.png",
+        });
+      },
+
+      async test(assert) {
+        await click(".remove-upload");
+
+        assert.strictEqual(this.name, this.upload.filename);
+      },
+    });
+  }
+);

--- a/test/javascripts/components/chat-composer-uploads-test.js
+++ b/test/javascripts/components/chat-composer-uploads-test.js
@@ -1,0 +1,95 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import {
+  discourseModule,
+  exists,
+  queryAll,
+} from "discourse/tests/helpers/qunit-helpers";
+import hbs from "htmlbars-inline-precompile";
+
+const fakeUpload = {
+  type: ".png",
+  filename: "foo",
+  original_filename: "bar",
+  extension: "png",
+  short_path: "/my-image.png",
+};
+
+discourseModule(
+  "Discourse Chat | Component | chat-composer-uploads",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    componentTest("no upload", {
+      template: hbs`{{chat-composer-uploads uploads=uploads}}`,
+
+      beforeEach() {
+        this.set("uploads", []);
+      },
+
+      async test(assert) {
+        assert.notOk(exists(".chat-composer-upload"));
+        assert.ok(exists("#chat-widget-uploader[type=file]"));
+      },
+    });
+
+    componentTest("finished upload", {
+      template: hbs`{{chat-composer-uploads uploads=uploads}}`,
+
+      beforeEach() {
+        this.set("uploads", [fakeUpload]);
+      },
+
+      async test(assert) {
+        assert.strictEqual(queryAll(".chat-composer-upload").length, 1);
+      },
+    });
+
+    componentTest("on new upload", {
+      template: hbs`{{chat-composer-uploads onUploadsChanged=onUploadsChanged uploads=uploads}}`,
+
+      beforeEach() {
+        this.set("onUploadsChanged", (uploads) => {
+          this.set("uploads", uploads);
+        });
+      },
+
+      async test(assert) {
+        this.appEvents = this.container.lookup("service:appEvents");
+        this.appEvents.trigger(
+          "chat-composer-uploads:upload-success",
+          this,
+          fakeUpload
+        );
+
+        assert.strictEqual(queryAll(".chat-composer-upload").length, 1);
+      },
+    });
+
+    componentTest("on removed upload", {
+      template: hbs`{{chat-composer-uploads onUploadsChanged=onUploadsChanged uploads=uploads}}`,
+
+      beforeEach() {
+        this.set("onUploadsChanged", (uploads) => {
+          this.set("uploads", uploads);
+        });
+      },
+
+      async test(assert) {
+        this.appEvents = this.container.lookup("service:appEvents");
+        this.appEvents.trigger(
+          "chat-composer-uploads:upload-success",
+          this,
+          fakeUpload
+        );
+
+        assert.strictEqual(queryAll(".chat-composer-upload").length, 1);
+
+        await click(".remove-upload");
+
+        assert.strictEqual(queryAll(".chat-composer-upload").length, 0);
+      },
+    });
+  }
+);


### PR DESCRIPTION
- attempts to test chat-composer-uploads and chat-composer-upload in isolation, note that inProgressUploads are currently very hard to test
- slightly simplify styling
- adds a halo when drag & dropping files on the textarea
- moves css code in dedicated files