### PR TITLE
FIX: ensures chat icon is not shown for closed topics

### DIFF
--- a/assets/javascripts/discourse/connectors/after-topic-status/topic-title-chat-icon.hbs
+++ b/assets/javascripts/discourse/connectors/after-topic-status/topic-title-chat-icon.hbs
@@ -1,3 +1,3 @@
-{{#if topic.has_chat_live}}
+{{#if (and topic.has_chat_live (not topic.closed))}}
   {{mount-widget widget="topic-title-chat-link" args=topic}}
 {{/if}}

--- a/assets/javascripts/discourse/initializers/chat-topic-changes.js
+++ b/assets/javascripts/discourse/initializers/chat-topic-changes.js
@@ -36,7 +36,7 @@ function makeTopicChanges(api, appEvents, chat) {
     statuses() {
       const results = this._super(...arguments);
 
-      if (this.topic.has_chat_live) {
+      if (this.topic.has_chat_live && !this.topic.closed) {
         results.push({
           openTag: "span",
           closeTag: "span",
@@ -66,7 +66,7 @@ function makeTopicChanges(api, appEvents, chat) {
   });
 
   api.decorateWidget("topic-status:after", (dec) => {
-    if (dec.attrs.topic.has_chat_live) {
+    if (dec.attrs.topic.has_chat_live && !dec.attrs.topic.closed) {
       return dec.widget.attach("topic-title-chat-link", dec.attrs.topic);
     }
   });

--- a/assets/javascripts/discourse/widgets/topic-title-chat-link.js
+++ b/assets/javascripts/discourse/widgets/topic-title-chat-link.js
@@ -5,12 +5,14 @@ export default createWidget("topic-title-chat-link", {
   tagName: "span.topic-title-chat-link",
   title: "chat.open",
 
-  html(attrs) {
-    if (attrs.closed) {
-      return;
-    }
-
+  html() {
     return iconNode("far-comments");
+  },
+
+  buildClasses(attrs) {
+    if (attrs.closed || !attrs.has_chat_live) {
+      return "hidden";
+    }
   },
 
   click() {

--- a/test/javascripts/widgets/topic-title-chat-link-test.js
+++ b/test/javascripts/widgets/topic-title-chat-link-test.js
@@ -1,31 +1,47 @@
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
-import { discourseModule, exists } from "discourse/tests/helpers/qunit-helpers";
+import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import hbs from "htmlbars-inline-precompile";
 
 discourseModule(
-  "Discourse Chat | Widget | topic-title-chat-link",
+  "Discourse Chat | Widgets | topic-title-chat-link",
   function (hooks) {
     setupRenderingTest(hooks);
 
-    componentTest("topic is closed", {
+    componentTest("topic is opened", {
       template: hbs`{{mount-widget widget="topic-title-chat-link" args=args}}`,
-      beforeEach() {
-        this.set("args", { closed: true });
+
+      async beforeEach() {
+        this.set("args", { closed: false, has_chat_live: true });
       },
-      test(assert) {
-        assert.notOk(exists(".d-icon-far-comments"));
+
+      async test(assert) {
+        assert.ok(exists(".topic-title-chat-link:not(.hidden)"));
       },
     });
 
-    componentTest("topic is opened", {
+    componentTest("topic is closed", {
       template: hbs`{{mount-widget widget="topic-title-chat-link" args=args}}`,
-      beforeEach() {
-        this.set("args", { closed: false });
+
+      async beforeEach() {
+        this.set("args", { closed: true, has_chat_live: true });
       },
-      test(assert) {
-        assert.ok(exists(".d-icon-far-comments"));
+
+      async test(assert) {
+        assert.ok(exists(".topic-title-chat-link.hidden"));
+      },
+    });
+
+    componentTest("topic doesn’t have chat", {
+      template: hbs`{{mount-widget widget="topic-title-chat-link" args=args}}`,
+
+      async beforeEach() {
+        this.set("args", { closed: false, has_chat_live: false });
+      },
+
+      async test(assert) {
+        assert.ok(exists(".topic-title-chat-link.hidden"));
       },
     });
   }


### PR DESCRIPTION
Not everything is tested as I tried to position the check as soon as I could but in any case the widget behaviour is fully tested and will be hidden if necessary. So worst case would be we add to the DOM a widget we could have avoided but it will be hidden.