### PR TITLE
FIX: No more large images, except youtube

### DIFF
--- a/assets/stylesheets/common/chat-message-collapser.scss
+++ b/assets/stylesheets/common/chat-message-collapser.scss
@@ -39,8 +39,13 @@
     }
   }
 
-  a.onebox img {
-    height: unset;
+  .onebox img:not(.ytp-thumbnail-image),
+  img.onebox,
+  .chat-uploads img {
+    object-fit: contain;
+    max-height: 150px;
+    max-width: 100%;
+
     width: unset;
   }
 }

--- a/assets/stylesheets/common/chat-message.scss
+++ b/assets/stylesheets/common/chat-message.scss
@@ -454,14 +454,6 @@
   font-style: italic;
 }
 
-.chat-message-text {
-  img.animated.onebox,
-  img.chat-img-upload {
-    max-width: 100%;
-    height: unset;
-  }
-}
-
 .full-page-chat {
   .chat-message {
     background: var(--primary-very-low);
@@ -484,10 +476,6 @@
 
   img {
     grid-area: image;
-
-    &:not(.ytp-thumbnail-image) {
-      max-height: 150px;
-    }
   }
 
   h3 a,


### PR DESCRIPTION
This was tested also with twitter image embeds minimally. Maybe I'd get this right for reals. This was done with `object-fit: contain`. `width` needs to be `unset` because of the way our onebox engines are setting certain images.

One thing we may consider is a site setting for max-height. It's currently hardcoded to 150px.

Note that this fix cannot apply to youtube and we would have to change core because of the way lazyYT is dynamically calculating positions for the buttons and such.

<img width="1071" alt="Screenshot 2022-01-14 at 8 11 55 PM" src="https://user-images.githubusercontent.com/1555215/149514541-60dc6f1e-3aa4-43b0-a95b-4897d1250a99.png">

