### PR TITLE
FIX: moves calculateHeight after render

### DIFF
--- a/assets/javascripts/discourse/components/full-page-chat.js
+++ b/assets/javascripts/discourse/components/full-page-chat.js
@@ -2,6 +2,7 @@ import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
 import { action } from "@ember/object";
 import { reads } from "@ember/object/computed";
+import { schedule } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 
 export default Component.extend({
@@ -37,7 +38,7 @@ export default Component.extend({
     window.addEventListener("resize", this._calculateHeight, false);
     document.body.classList.add("has-full-page-chat");
     this.chat.set("fullScreenChatOpen", true);
-    this._calculateHeight();
+    schedule("afterRender", this._calculateHeight);
   },
 
   willDestroyElement() {


### PR DESCRIPTION
This will need more refactoring in the future, but it seems needs for now, most likely because of the previous line `chat.Set("fullScreenChatOpen", true)` which probably impacts other elements.

This commit is meant as a partial revert of https://github.com/discourse/discourse-chat/commit/19a57e043a1bac9016852d89f74c55559604e04f