### PR TITLE
FIX: attempts to make scrolling github more resilient

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1030,34 +1030,38 @@ export default Component.extend({
     decorateGithubOneboxBody(this.element);
   },
 
+  _getScrollParent(node, maxParentSelector) {
+    if (node === null || node.classList.contains(maxParentSelector)) {
+      return null;
+    }
+
+    if (node.scrollHeight > node.clientHeight) {
+      return node;
+    } else {
+      return this._getScrollParent(node.parentNode, maxParentSelector);
+    }
+  },
+
   _scrollGithubOneboxes() {
     this.element
       .querySelectorAll(".onebox.githubblob li.selected")
       .forEach((line) => {
-        const scrollingElementSelector = ".onebox .onebox-body";
+        const scrollingElement = this._getScrollParent(line, "onebox");
 
-        let linePosition = line.offsetTop + line.offsetHeight / 2;
-
-        // offsetTop is relative to the offsetParent (i.e. a position: relative element)
-        // Keep iterating up them until we reach the topmost one within the onebox
-        // Sum up the offsetTop values as we go
-        let offsetParent = line.offsetParent;
-        while (true) {
-          linePosition += offsetParent.offsetTop;
-          if (!offsetParent.offsetParent?.closest(scrollingElementSelector)) {
-            // The next offsetParent would be outside the onebox
-            break;
-          }
-        }
-        let onebox = line.closest(scrollingElementSelector);
-        if (onebox !== offsetParent) {
-          // The onebox body itself is not position: relative, so we need to subtract it's offsetTop
-          linePosition -= onebox.offsetTop;
+        // most likely a very small file which doesn’t need scrolling
+        if (!scrollingElement) {
+          return;
         }
 
-        onebox.scroll({
-          // Scroll so the selected line is in the middle of the div
-          top: linePosition - onebox.offsetHeight / 2,
+        const scrollBarWidth =
+          scrollingElement.offsetHeight - scrollingElement.clientHeight;
+
+        scrollingElement.scroll({
+          top:
+            line.offsetTop +
+            scrollBarWidth -
+            scrollingElement.offsetHeight / 2 +
+            line.offsetHeight / 2,
         });
       });
   },


### PR DESCRIPTION
It now tries to find the first parent scrollable element from a selected line.

It works nicely in my tests:
<img width="501" alt="Screenshot 2022-01-16 at 22 16 00" src="https://user-images.githubusercontent.com/339945/149678434-dd9a8f54-84c7-4cb7-8e29-3395eb7e7244.png">


