### PR TITLE
FIX: Use Page Visibility API for determining whether to read

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -699,7 +699,12 @@ export default Component.extend({
   },
 
   _floatOpenAndFocused() {
-    return document.hasFocus() && this.expanded && !this.floatHidden;
+    console.log(document.visibilityState);
+    return (
+      document.visibilityState === "visible" &&
+      this.expanded &&
+      !this.floatHidden
+    );
   },
 
   _stopLastReadRunner() {

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -10,6 +10,7 @@ import EmberObject, { action } from "@ember/object";
 import I18n from "I18n";
 import loadScript from "discourse/lib/load-script";
 import showModal from "discourse/lib/show-modal";
+import userPresent from "discourse/lib/user-presence";
 import { A } from "@ember/array";
 import { ajax } from "discourse/lib/ajax";
 import { isTesting } from "discourse-common/config/environment";
@@ -699,11 +700,7 @@ export default Component.extend({
   },
 
   _floatOpenAndFocused() {
-    return (
-      document.visibilityState === "visible" &&
-      this.expanded &&
-      !this.floatHidden
-    );
+    return userPresent() && this.expanded && !this.floatHidden;
   },
 
   _stopLastReadRunner() {

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -699,7 +699,6 @@ export default Component.extend({
   },
 
   _floatOpenAndFocused() {
-    console.log(document.visibilityState);
     return (
       document.visibilityState === "visible" &&
       this.expanded &&


### PR DESCRIPTION
Using this api https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API solves the issue of switching tabs and messages not being marked as read, because `document.hasFocus` is still false.
