### PR TITLE
FIX: ensures textarea is resized upon entering a new channel

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -239,6 +239,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
 
   didReceiveAttrs() {
     this._super(...arguments);
+
     if (
       this.chatChannel.id === this.lastChatChannelId &&
       !this.editingMessage
@@ -259,9 +260,10 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
           ? cloneJSON(this.editingMessage.uploads)
           : [],
       });
-      this._focusTextArea({ ensureAtEnd: true, resizeTextArea: true });
+      this._focusTextArea({ ensureAtEnd: true, resizeTextArea: false });
     }
     this.set("lastChatChannelId", this.chatChannel.id);
+    this._resizeTextArea();
   },
 
   _replyToMsgChanged(replyToMsg) {
@@ -478,11 +480,14 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   },
 
   _resizeTextArea() {
-    this._textarea.parentNode.dataset.replicatedValue = this._textarea.value;
+    schedule("afterRender", () => {
+      if (!this._textarea) {
+        return;
+      }
 
-    if (this.onChangeHeight) {
-      this.onChangeHeight();
-    }
+      this._textarea.parentNode.dataset.replicatedValue = this._textarea.value;
+      this.onChangeHeight?.();
+    });
   },
 
   _uploadDropTargetOptions() {


### PR DESCRIPTION
Before this change the textarea was only resized on initial insert of the element or typing, which would mean that typing multiple lines in one channel would increase height of composer, and switching to another channel would keep this height.

Note: this behavior was only visible with the https://meta.discourse.org/t/experiment-on-meta-horizontal-loading-slider/177939 theme component