### PR TITLE
UX: Adjust padding + icon spacing in sidebar

### DIFF
--- a/assets/stylesheets/sidebar-extensions.scss
+++ b/assets/stylesheets/sidebar-extensions.scss
@@ -1,8 +1,32 @@
 // Styles to make channel list in sidebar match sidebar theme
 .has-sidebar {
+  .sidebar-header {
+    .d-header .menu-panel {
+      top: 3.22em !important;
+    }
+    .d-header-icons .icon {
+      width: 2em;
+      height: 2em;
+      img.avatar, #logo-small {
+        width: 2em;
+        height: 2em;
+      }
+    }
+  }
   .header-dropdown-toggle.open-chat {
     .chat-channel-unread-indicator {
       border-color: var(--primary-very-low);
+    }
+  }
+  .custom-nav-list .title {
+    padding: 0 0.5em 0 1.75em;
+  }
+  .sidebar-container {
+    .chat-channels .chat-channel-divider {
+      padding: 0 0.5em 0 1.75rem;
+    }
+    .chat-channels .chat-channel-row {
+      padding-right: 0.5em;
     }
   }
 }

--- a/assets/stylesheets/sidebar-extensions.scss
+++ b/assets/stylesheets/sidebar-extensions.scss
@@ -7,7 +7,8 @@
     .d-header-icons .icon {
       width: 2em;
       height: 2em;
-      img.avatar, #logo-small {
+      img.avatar,
+      #logo-small {
         width: 2em;
         height: 2em;
       }


### PR DESCRIPTION
This PR adjusts the padding of sidebar headers as well as the size and spacing of the header icons to make room for the chat icon being inserted into the header. 

### After
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30537603/149813599-7a807c34-06a7-4537-95c2-2828d0d4e169.png">

### Before
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30537603/149813641-b157ef5b-617d-4d76-9e78-0f32ea3204cb.png">

