### PR TITLE
FIX: Show lightbox after collapse and expand

### DIFF
--- a/assets/javascripts/discourse/templates/components/collapser.hbs
+++ b/assets/javascripts/discourse/templates/components/collapser.hbs
@@ -16,6 +16,6 @@
   {{/if}}
 </div>
 
-{{#unless collapsed}}
+<div class={{if collapsed "hidden" ""}}>
   {{yield}}
-{{/unless}}
+</div>

--- a/assets/stylesheets/common/chat-message-collapser.scss
+++ b/assets/stylesheets/common/chat-message-collapser.scss
@@ -4,9 +4,15 @@
     align-items: center;
   }
 
-  .chat-message-collapser-header + p,
-  .chat-message-collapser-header + p img.onebox {
+  .chat-message-collapser-header + div p {
+    margin: 0;
+  }
+
+  .chat-img-upload,
+  .chat-other-upload,
+  .chat-message-collapser-header + div p img {
     margin-top: 0.25em;
+    margin-bottom: 0.5em;
   }
 
   .chat-message-collapser-link-small {
@@ -27,15 +33,6 @@
       .d-icon {
         color: var(--primary);
       }
-    }
-  }
-
-  .chat-uploads {
-    margin-top: 0.25em;
-
-    .chat-img-upload,
-    .chat-other-upload {
-      margin-bottom: 1em;
     }
   }
 

--- a/assets/stylesheets/common/chat-message.scss
+++ b/assets/stylesheets/common/chat-message.scss
@@ -461,7 +461,7 @@
   }
 }
 
-.has-full-page-chat .chat-message .onebox,
+.has-full-page-chat .chat-message .onebox:not(img),
 .topic-chat-float-container .chat-message .onebox {
   margin: 0.5em 0;
   border-width: 2px;

--- a/test/javascripts/acceptance/chat-live-pane-collapse-test.js
+++ b/test/javascripts/acceptance/chat-live-pane-collapse-test.js
@@ -95,7 +95,7 @@ acceptance("Discourse Chat - Chat live pane", function (needs) {
   });
 
   test("can collapse and expand youtube chat", async function (assert) {
-    const youtubeContainerSelector = ".chat-message-container-1 .lazyYT";
+    const youtubeContainer = ".chat-message-container-1 .lazyYT";
     const expandImage =
       ".chat-message-container-1 .chat-message-collapser-closed";
     const collapseImage =
@@ -103,19 +103,19 @@ acceptance("Discourse Chat - Chat live pane", function (needs) {
 
     await visit("/chat/channel/1/cat");
 
-    assert.ok(visible(youtubeContainerSelector));
+    assert.ok(visible(youtubeContainer));
     assert.ok(visible(collapseImage), "the open arrow is shown");
     assert.notOk(exists(expandImage), "the close arrow is hidden");
 
     await click(collapseImage);
 
-    assert.notOk(visible(youtubeContainerSelector));
+    assert.notOk(visible(youtubeContainer));
     assert.ok(visible(expandImage), "the close arrow is shown");
     assert.notOk(exists(collapseImage), "the open arrow is hidden");
 
     await click(expandImage);
 
-    assert.ok(visible(youtubeContainerSelector));
+    assert.ok(visible(youtubeContainer));
     assert.ok(visible(collapseImage), "the open arrow is shown again");
     assert.notOk(exists(expandImage), "the close arrow is hidden again");
   });

--- a/test/javascripts/acceptance/chat-live-pane-collapse-test.js
+++ b/test/javascripts/acceptance/chat-live-pane-collapse-test.js
@@ -38,6 +38,34 @@ acceptance("Discourse Chat - Chat live pane", function (needs) {
               username: "tomtom",
             },
           },
+          {
+            id: 2,
+            message: "",
+            cooked: "",
+            excerpt: "",
+            uploads: [
+              {
+                id: 4,
+                url: "/images/avatar.png",
+                original_filename: "tomtom.jpeg",
+                filesize: 93815,
+                width: 480,
+                height: 640,
+                thumbnail_width: 375,
+                thumbnail_height: 500,
+                extension: "jpeg",
+                retain_hours: null,
+                human_filesize: "91.6 KB",
+              },
+            ],
+            user: {
+              avatar_template:
+                "/letter_avatar_proxy/v4/letter/t/a9a28c/{size}.png",
+              id: 1,
+              name: "Tomtom",
+              username: "tomtom",
+            },
+          },
         ],
       })
     );
@@ -52,29 +80,72 @@ acceptance("Discourse Chat - Chat live pane", function (needs) {
     server.get("/chat/chat_channels/:chatChannelId", () =>
       helper.response({ chat_channel: { id: 1 } })
     );
+
+    server.post("/uploads/lookup-urls", () =>
+      helper.response([
+        200,
+        { "Content-Type": "application/json" },
+        [
+          {
+            url: "/images/avatar.png",
+          },
+        ],
+      ])
+    );
   });
 
   test("can collapse and expand youtube chat", async function (assert) {
-    const youtubeContainerSelector = ".lazyYT";
-    const close = ".chat-message-collapser-closed";
-    const open = ".chat-message-collapser-opened";
+    const youtubeContainerSelector = ".chat-message-container-1 .lazyYT";
+    const expandImage =
+      ".chat-message-container-1 .chat-message-collapser-closed";
+    const collapseImage =
+      ".chat-message-container-1 .chat-message-collapser-opened";
 
     await visit("/chat/channel/1/cat");
 
     assert.ok(visible(youtubeContainerSelector));
-    assert.ok(visible(open), "the open arrow is shown");
-    assert.notOk(exists(close), "the close arrow is hidden");
+    assert.ok(visible(collapseImage), "the open arrow is shown");
+    assert.notOk(exists(expandImage), "the close arrow is hidden");
 
-    await click(open);
+    await click(collapseImage);
 
-    assert.notOk(exists(youtubeContainerSelector));
-    assert.ok(visible(close), "the close arrow is shown");
-    assert.notOk(exists(open), "the open arrow is hidden");
+    assert.notOk(visible(youtubeContainerSelector));
+    assert.ok(visible(expandImage), "the close arrow is shown");
+    assert.notOk(exists(collapseImage), "the open arrow is hidden");
 
-    await click(close);
+    await click(expandImage);
 
     assert.ok(visible(youtubeContainerSelector));
-    assert.ok(visible(open), "the open arrow is shown again");
-    assert.notOk(exists(close), "the close arrow is hidden again");
+    assert.ok(visible(collapseImage), "the open arrow is shown again");
+    assert.notOk(exists(expandImage), "the close arrow is hidden again");
+  });
+
+  test("lightbox shows up before and after expand and collapse", async function (assert) {
+    const lightboxImage = ".mfp-img";
+    const image = ".chat-message-container-2 .chat-img-upload";
+    const expandImage =
+      ".chat-message-container-2 .chat-message-collapser-closed";
+    const collapseImage =
+      ".chat-message-container-2 .chat-message-collapser-opened";
+
+    await visit("/chat/channel/1/cat");
+
+    await click(image);
+
+    assert.ok(
+      exists(document.querySelector(lightboxImage)),
+      "can see lightbox"
+    );
+    await click(document.querySelector(".mfp-container"));
+
+    await click(collapseImage);
+    await click(expandImage);
+
+    await click(image);
+    assert.ok(
+      exists(document.querySelector(lightboxImage)),
+      "can see lightbox after collapse expand"
+    );
+    await click(document.querySelector(".mfp-container"));
   });
 });

--- a/test/javascripts/components/chat-message-collapser-test.js
+++ b/test/javascripts/components/chat-message-collapser-test.js
@@ -4,8 +4,8 @@ import componentTest, {
 import hbs from "htmlbars-inline-precompile";
 import {
   discourseModule,
-  exists,
   query,
+  visible,
 } from "discourse/tests/helpers/qunit-helpers";
 
 const youtubeCooked =
@@ -103,11 +103,11 @@ discourseModule(
         );
 
         assert.notOk(
-          exists(".onebox[data-youtube-id='ytId1']"),
+          visible(".onebox[data-youtube-id='ytId1']"),
           "first youtube preview hidden"
         );
         assert.ok(
-          exists(".onebox[data-youtube-id='ytId2']"),
+          visible(".onebox[data-youtube-id='ytId2']"),
           "second youtube preview still visible"
         );
 
@@ -121,11 +121,11 @@ discourseModule(
         );
 
         assert.ok(
-          exists(".onebox[data-youtube-id='ytId1']"),
+          visible(".onebox[data-youtube-id='ytId1']"),
           "first youtube preview still visible"
         );
         assert.notOk(
-          exists(".onebox[data-youtube-id='ytId2']"),
+          visible(".onebox[data-youtube-id='ytId2']"),
           "second youtube preview hidden"
         );
 
@@ -189,18 +189,18 @@ discourseModule(
         const uploads = ".chat-uploads";
         const chatImageUpload = ".chat-img-upload";
 
-        assert.ok(exists(uploads));
-        assert.ok(exists(chatImageUpload));
+        assert.ok(visible(uploads));
+        assert.ok(visible(chatImageUpload));
 
         await click(".chat-message-collapser-opened");
 
-        assert.notOk(exists(uploads));
-        assert.notOk(exists(chatImageUpload));
+        assert.notOk(visible(uploads));
+        assert.notOk(visible(chatImageUpload));
 
         await click(".chat-message-collapser-closed");
 
-        assert.ok(exists(uploads));
-        assert.ok(exists(chatImageUpload));
+        assert.ok(visible(uploads));
+        assert.ok(visible(chatImageUpload));
       },
     });
   }
@@ -265,9 +265,12 @@ discourseModule(
           "close first preview"
         );
 
-        assert.notOk(exists(".onebox[src='lesource1']"), "first onebox hidden");
+        assert.notOk(
+          visible(".onebox[src='lesource1']"),
+          "first onebox hidden"
+        );
         assert.ok(
-          exists(".onebox[src='lesource2']"),
+          visible(".onebox[src='lesource2']"),
           "second onebox still visible"
         );
 
@@ -281,11 +284,11 @@ discourseModule(
         );
 
         assert.ok(
-          exists(".onebox[src='lesource1']"),
+          visible(".onebox[src='lesource1']"),
           "first onebox still visible"
         );
         assert.notOk(
-          exists(".onebox[src='lesource2']"),
+          visible(".onebox[src='lesource2']"),
           "second onebox hidden"
         );
 
@@ -357,11 +360,11 @@ discourseModule(
         );
 
         assert.notOk(
-          exists(".onebox[href='http://cat1.com']"),
+          visible(".onebox[href='http://cat1.com']"),
           "first onebox hidden"
         );
         assert.ok(
-          exists(".onebox[href='http://cat2.com']"),
+          visible(".onebox[href='http://cat2.com']"),
           "second onebox still visible"
         );
 
@@ -375,11 +378,11 @@ discourseModule(
         );
 
         assert.ok(
-          exists(".onebox[href='http://cat1.com']"),
+          visible(".onebox[href='http://cat1.com']"),
           "first onebox still visible"
         );
         assert.notOk(
-          exists(".onebox[href='http://cat2.com']"),
+          visible(".onebox[href='http://cat2.com']"),
           "second onebox hidden"
         );
 

--- a/test/javascripts/components/collapser-test.js
+++ b/test/javascripts/components/collapser-test.js
@@ -6,6 +6,7 @@ import {
   discourseModule,
   exists,
   query,
+  visible,
 } from "discourse/tests/helpers/qunit-helpers";
 
 discourseModule("Discourse chat | Component | collapser", function (hooks) {
@@ -33,14 +34,14 @@ discourseModule("Discourse chat | Component | collapser", function (hooks) {
       const closeButton = ".chat-message-collapser-opened";
       const body = ".cat";
 
-      assert.ok(exists(body));
+      assert.ok(visible(body));
       await click(closeButton);
 
-      assert.notOk(exists(body));
+      assert.notOk(visible(body));
 
       await click(openButton);
 
-      assert.ok(exists(body));
+      assert.ok(visible(body));
     },
   });
 });


### PR DESCRIPTION
The lightboxing function is applied once when [messages are loaded](https://github.com/discourse/discourse-chat/blob/3eabe03afa73418565d7f336f207ca3b2702ed07/assets/javascripts/discourse/components/chat-live-pane.js#L477). Since collapsing an image removed it from the document entirely, the lightboxing feature wasn't working after a user collapses and expands the image. 

To prevent this we could either A: reapply the lightboxing function every time after expand, or B: just skip removing the image when it's collapsed and just hide it. I chose B.