### PR TITLE
FIX: Add missing markdown features

### DIFF
--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -43,6 +43,8 @@ class ChatMessage < ActiveRecord::Base
     censored
     discourse-local-dates
     emoji
+    emojiShortcuts
+    inlineEmoji
     html-img
     mentions
     onebox
@@ -50,9 +52,12 @@ class ChatMessage < ActiveRecord::Base
     upload-protocol
     watched-words
     table
+    spoiler-alert
   }
 
   MARKDOWN_IT_RULES = %w{
+    autolink
+    list
     backticks
     newline
     code

--- a/spec/models/chat_message_spec.rb
+++ b/spec/models/chat_message_spec.rb
@@ -133,5 +133,50 @@ describe ChatMessage do
 
       expect(cooked).to eq("<p>■■■■■</p>")
     end
+
+    it 'supports autolink with <>' do
+      cooked = ChatMessage.cook("<https://github.com/discourse/discourse-chat/pull/468>")
+
+      expect(cooked).to eq("<p><a href=\"https://github.com/discourse/discourse-chat/pull/468\" rel=\"noopener nofollow ugc\">https://github.com/discourse/discourse-chat/pull/468</a></p>")
+    end
+
+    it 'supports lists' do
+      cooked = ChatMessage.cook(<<~MSG)
+      wow look it's a list
+
+      * item 1
+      * item 2
+      MSG
+
+      expect(cooked).to eq(<<~HTML.chomp)
+      <p>wow look it's a list</p>
+      <ul>
+      <li>item 1</li>
+      <li>item 2</li>
+      </ul>
+      HTML
+    end
+
+    it 'supports inline emoji' do
+      cooked = ChatMessage.cook(":D")
+      expect(cooked).to eq(<<~HTML.chomp)
+      <p><img src="/images/emoji/twitter/smiley.png?v=12" title=":smiley:" class="emoji only-emoji" alt=":smiley:"></p>
+      HTML
+    end
+
+    it 'supports emoji shortcuts' do
+      cooked = ChatMessage.cook("this is a replace test :P :|")
+      expect(cooked).to eq(<<~HTML.chomp)
+        <p>this is a replace test <img src="/images/emoji/twitter/stuck_out_tongue.png?v=12" title=":stuck_out_tongue:" class="emoji" alt=":stuck_out_tongue:"> <img src="/images/emoji/twitter/expressionless.png?v=12" title=":expressionless:" class="emoji" alt=":expressionless:"></p>
+      HTML
+    end
+
+    it 'supports spoilers' do
+      if SiteSetting.respond_to?(:spoiler_enabled) && SiteSetting.spoiler_enabled
+        cooked = ChatMessage.cook("[spoiler]the planet of the apes was earth all along[/spoiler]")
+
+        expect(cooked).to eq("<div class=\"spoiler\">\n<p>the planet of the apes was earth all along</p>\n</div>")
+      end
+    end
   end
 end


### PR DESCRIPTION
In e0a4a48d3cba6457a593dd43e3d7f14577c6f3d0 we limited chat to a
few features of markdown, but we missed some commonly used ones.
This commit adds the following back in:

* `[spoiler]spoiler tags[/spoiler]` from discourse-spoiler-alert
* markdown lists
* autolink for links like `<https://somelink.com>` to avoid inline
  oneboxing those links
* emoji shortcuts (:P -> :stuck_out_tongue:) and inline emoji for
  one emoji making up the whole chat message

The test for spoilers will not run unless you have
discourse-spoiler-alert installed and enabled.