### PR TITLE
UX: Chat composer changes, full page spacing adjustments

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer.hbs
@@ -60,7 +60,7 @@
     {{flat-button
       action=(action "sendClicked")
       class="mobile-send-btn"
-      icon="play"
+      icon="paper-plane"
       disabled=sendDisabled
       title=sendTitle
     }}

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -576,7 +576,7 @@ body.composer-open .topic-chat-float-container {
 
       .open-toolbar-btn {
         position: absolute;
-        right: 20px;
+        left: 16px;
         top: 50%;
         transform: translateY(-50%);
         padding: 0.3em;
@@ -607,7 +607,7 @@ body.composer-open .topic-chat-float-container {
       margin: 0;
       resize: none;
       max-height: 125px;
-      padding: 8px 40px 8px 8px;
+      padding: 8px 8px 8px 45px;
       border: 1px solid transparent;
       background-color: var(--primary-low);
       border-radius: 0.5em;
@@ -643,7 +643,7 @@ body.composer-open .topic-chat-float-container {
   .chat-composer-toolbar {
     position: absolute;
     top: -36px;
-    right: 0.75em;
+    left: 0.75em;
     border-radius: 5px;
     border: 1px solid var(--primary-low);
     background: var(--secondary);

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -43,12 +43,6 @@
       padding-left: 1em;
       padding-right: 1.5em;
     }
-
-    .chat-composer-row {
-      .chat-composer-toolbar {
-        right: 1em;
-      }
-    }
   }
 }
 

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -156,7 +156,7 @@
     }
 
     .chat-message {
-      padding-left: 2em;
+      padding-left: 1em;
 
       &:hover {
         background-color: var(--primary-very-low);
@@ -164,7 +164,7 @@
     }
 
     .chat-messages-container .chat-message-deleted {
-      padding: 0.25em 2em;
+      padding: 0.25em 1em;
     }
   }
 }

--- a/assets/stylesheets/mobile/mobile.scss
+++ b/assets/stylesheets/mobile/mobile.scss
@@ -90,7 +90,7 @@ body.has-full-page-chat {
   }
 
   .chat-composer {
-    background-color: var(--primary-very-low);
+    background-color: var(--secondary);
   }
 
   .chat-full-page-header {

--- a/assets/stylesheets/mobile/mobile.scss
+++ b/assets/stylesheets/mobile/mobile.scss
@@ -13,6 +13,9 @@
     right: 12px;
     top: 50%;
     transform: translateY(-50%);
+    .d-icon {
+      color: var(--primary-low-mid);
+    }
     &:not([disabled]) .d-icon {
       color: var(--tertiary);
     }


### PR DESCRIPTION
This PR changes placement of the uploads button, and changes the mobile icon used to "send" messages once typed. It also makes a minor adjustment to full page chat left padding.

**Widget**
<img width="406" alt="image" src="https://user-images.githubusercontent.com/30537603/150210843-8eb0d7f7-3954-4a24-818d-5ed2c4c7de7e.png">

**Full screen**
<img width="1346" alt="image" src="https://user-images.githubusercontent.com/30537603/150210877-1dfbde60-aae3-4e89-a30d-2b5a1ae70523.png">

**Mobile no text**
<img width="388" alt="image" src="https://user-images.githubusercontent.com/30537603/150210962-80fece80-8bf5-44aa-ae8c-4ac799aea7ff.png">

**Mobile with text**
<img width="392" alt="image" src="https://user-images.githubusercontent.com/30537603/150211007-8a311b72-a87d-4144-979f-ab9cb4d95144.png">
