### PR TITLE
FEATURE: Chat message auto-deletion with site settings

### DIFF
--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -310,6 +310,18 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
     render json: success_json
   end
 
+  def dismiss_retention_reminder
+    params.require(:chatable_type)
+    guardian.ensure_can_chat!(current_user)
+    raise Discourse::InvalidParameters unless ChatChannel.chatable_types.include?(params[:chatable_type])
+
+    field = ChatChannel.public_channel_chatable_types.include?(params[:chatable_type]) ?
+      :dismissed_channel_retention_reminder :
+      :dismissed_dm_retention_reminder
+    current_user.user_option.update("#{field}": true)
+    render json: success_json
+  end
+
   private
 
   def set_user_last_read

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -318,7 +318,7 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
     field = ChatChannel.public_channel_chatable_types.include?(params[:chatable_type]) ?
       :dismissed_channel_retention_reminder :
       :dismissed_dm_retention_reminder
-    current_user.user_option.update("#{field}": true)
+    current_user.user_option.update(field => true)
     render json: success_json
   end
 

--- a/app/jobs/scheduled/delete_old_chat_messages.rb
+++ b/app/jobs/scheduled/delete_old_chat_messages.rb
@@ -28,10 +28,7 @@ module Jobs
     end
 
     def valid_day_value?(setting_name)
-      value = SiteSetting.public_send(setting_name)
-      return false if value.nil?
-      return false if value.zero?
-      true
+      (SiteSetting.public_send(setting_name) || 0).positive?
     end
   end
 end

--- a/app/jobs/scheduled/delete_old_chat_messages.rb
+++ b/app/jobs/scheduled/delete_old_chat_messages.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Jobs
+  class DeleteOldChatMessages < ::Jobs::Scheduled
+    daily at: 0.hours
+
+    def execute(args = {})
+      delete_public_channel_messages
+      delete_dm_channel_messages
+    end
+
+    def delete_public_channel_messages
+      return unless valid_day_value?(:chat_channel_retention_days)
+
+      ChatMessage
+        .in_public_channel
+        .created_before(SiteSetting.chat_channel_retention_days.days.ago)
+        .destroy_all
+    end
+
+    def delete_dm_channel_messages
+      return unless valid_day_value?(:chat_dm_retention_days)
+
+      ChatMessage
+        .in_dm_channel
+        .created_before(SiteSetting.chat_dm_retention_days.days.ago)
+        .destroy_all
+    end
+
+    def valid_day_value?(setting_name)
+      value = SiteSetting.public_send(setting_name)
+      return false if value.nil?
+      return false if value.zero?
+      true
+    end
+  end
+end

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -80,6 +80,10 @@ class ChatChannel < ActiveRecord::Base
     end
   end
 
+  def self.chatable_types
+    public_channel_chatable_types << "DirectMessageChannel"
+  end
+
   def self.public_channel_chatable_types
     ["Topic", "Category", "Tag"]
   end

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -80,8 +80,12 @@ class ChatChannel < ActiveRecord::Base
     end
   end
 
+  def self.public_channel_chatable_types
+    ["Topic", "Category", "Tag"]
+  end
+
   def self.public_channels
-    where(chatable_type: ["Topic", "Category", "Tag"])
+    where(chatable_type: public_channel_chatable_types)
   end
 
   def self.is_enabled?(t)

--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -18,6 +18,20 @@ class ChatMessage < ActiveRecord::Base
   has_many :uploads, through: :chat_uploads
   has_one :chat_webhook_event
 
+  scope :in_public_channel, -> {
+    joins(:chat_channel)
+      .where(chat_channel: { chatable_type: ChatChannel.public_channel_chatable_types })
+  }
+
+  scope :in_dm_channel, -> {
+    joins(:chat_channel)
+      .where(chat_channel: { chatable_type: "DirectMessageChannel" })
+  }
+
+  scope :created_before, -> (date) {
+    where("chat_messages.created_at < ?", date)
+  }
+
   def reviewable_flag
     raise NotImplementedError
     #ReviewableFlaggedChat.pending.find_by(target: self)

--- a/assets/javascripts/discourse/components/chat-retention-reminder.js
+++ b/assets/javascripts/discourse/components/chat-retention-reminder.js
@@ -3,6 +3,7 @@ import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "I18n";
 import { action } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
 
 export default Component.extend({
   tagName: "",
@@ -45,12 +46,14 @@ export default Component.extend({
     return ajax("/chat/dismiss-retention-reminder", {
       method: "POST",
       data: { chatable_type: this.chatChannel.chatable_type },
-    }).then(() => {
-      const field =
-        this.chatChannel.chatable_type === "DirectMessageChannel"
-          ? "needs_dm_retention_reminder"
-          : "needs_channel_retention_reminder";
-      this.currentUser.set(field, false);
-    });
+    })
+      .then(() => {
+        const field =
+          this.chatChannel.chatable_type === "DirectMessageChannel"
+            ? "needs_dm_retention_reminder"
+            : "needs_channel_retention_reminder";
+        this.currentUser.set(field, false);
+      })
+      .catch(popupAjaxError);
   },
 });

--- a/assets/javascripts/discourse/components/chat-retention-reminder.js
+++ b/assets/javascripts/discourse/components/chat-retention-reminder.js
@@ -3,6 +3,7 @@ import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "I18n";
 import { action } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
+import { CHATABLE_TYPES } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 
 export default Component.extend({
@@ -15,9 +16,9 @@ export default Component.extend({
   )
   show(chatableType) {
     return (
-      (chatableType === "DirectMessageChannel" &&
+      (chatableType === CHATABLE_TYPES.directMessageChannel &&
         this.currentUser.needs_dm_retention_reminder) ||
-      (chatableType !== "DirectMessageChannel" &&
+      (chatableType !== CHATABLE_TYPES.directMessageChannel &&
         this.currentUser.needs_channel_retention_reminder)
     );
   },
@@ -27,7 +28,7 @@ export default Component.extend({
     let days = this.siteSettings.chat_channel_retention_days;
     let translationKey = "chat.retention_reminders.public";
 
-    if (chatableType === "DirectMessageChannel") {
+    if (chatableType === CHATABLE_TYPES.directMessageChannel) {
       days = this.siteSettings.chat_dm_retention_days;
       translationKey = "chat.retention_reminders.dm";
     }
@@ -36,7 +37,7 @@ export default Component.extend({
 
   @discourseComputed("chatChannel.chatable_type")
   daysCount(chatableType) {
-    return chatableType === "DirectMessageChannel"
+    return chatableType === CHATABLE_TYPES.directMessageChannel
       ? this.siteSettings.chat_dm_retention_days
       : this.siteSettings.chat_channel_retention_days;
   },
@@ -49,7 +50,7 @@ export default Component.extend({
     })
       .then(() => {
         const field =
-          this.chatChannel.chatable_type === "DirectMessageChannel"
+          this.chatChannel.chatable_type === CHATABLE_TYPES.directMessageChannel
             ? "needs_dm_retention_reminder"
             : "needs_channel_retention_reminder";
         this.currentUser.set(field, false);

--- a/assets/javascripts/discourse/components/chat-retention-reminder.js
+++ b/assets/javascripts/discourse/components/chat-retention-reminder.js
@@ -1,0 +1,28 @@
+import Component from "@ember/component";
+import discourseComputed from "discourse-common/utils/decorators";
+import { action } from "@ember/object";
+
+export default Component.extend({
+  tagName: "",
+
+  @discourseComputed("chatChannel.chatable_type")
+  show(chatableType) {
+    return (
+      (chatableType === "DirectMessageChannel" &&
+        this.currentUser.needs_dm_retention_reminder) ||
+      this.currentUser.needs_channel_retention_reminder
+    );
+  },
+
+  @discourseComputed("chatChannel.chatable_type")
+  daysCount(chatableType) {
+    return chatableType === "DirectMessageChannel"
+      ? this.siteSettings.chat_channel_retention_days
+      : this.siteSettings.chat_dm_retention_days;
+  },
+
+  @action
+  dismiss() {
+
+  }
+});

--- a/assets/javascripts/discourse/components/chat-retention-reminder.js
+++ b/assets/javascripts/discourse/components/chat-retention-reminder.js
@@ -1,16 +1,22 @@
 import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
 import { action } from "@ember/object";
+import { ajax } from "discourse/lib/ajax";
 
 export default Component.extend({
   tagName: "",
+  loading: false,
 
-  @discourseComputed("chatChannel.chatable_type")
+  @discourseComputed(
+    "chatChannel.chatable_type",
+    "currentUser.{needs_dm_retention_reminder,needs_channel_retention_reminder}"
+  )
   show(chatableType) {
     return (
       (chatableType === "DirectMessageChannel" &&
         this.currentUser.needs_dm_retention_reminder) ||
-      this.currentUser.needs_channel_retention_reminder
+      (chatableType !== "DirectMessageChannel" &&
+        this.currentUser.needs_channel_retention_reminder)
     );
   },
 
@@ -23,6 +29,15 @@ export default Component.extend({
 
   @action
   dismiss() {
-
-  }
+    return ajax("/chat/dismiss-retention-reminder", {
+      method: "POST",
+      data: { chatable_type: this.chatChannel.chatable_type },
+    }).then(() => {
+      const field =
+        this.chatChannel.chatable_type === "DirectMessageChannel"
+          ? "needs_dm_retention_reminder"
+          : "needs_channel_retention_reminder";
+      this.currentUser.set(field, false);
+    });
+  },
 });

--- a/assets/javascripts/discourse/components/chat-retention-reminder.js
+++ b/assets/javascripts/discourse/components/chat-retention-reminder.js
@@ -1,5 +1,6 @@
 import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
+import I18n from "I18n";
 import { action } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 

--- a/assets/javascripts/discourse/components/chat-retention-reminder.js
+++ b/assets/javascripts/discourse/components/chat-retention-reminder.js
@@ -21,10 +21,22 @@ export default Component.extend({
   },
 
   @discourseComputed("chatChannel.chatable_type")
+  text(chatableType) {
+    let days = this.siteSettings.chat_channel_retention_days;
+    let translationKey = "chat.retention_reminders.public";
+
+    if (chatableType === "DirectMessageChannel") {
+      days = this.siteSettings.chat_dm_retention_days;
+      translationKey = "chat.retention_reminders.dm";
+    }
+    return I18n.t(translationKey, { days });
+  },
+
+  @discourseComputed("chatChannel.chatable_type")
   daysCount(chatableType) {
     return chatableType === "DirectMessageChannel"
-      ? this.siteSettings.chat_channel_retention_days
-      : this.siteSettings.chat_dm_retention_days;
+      ? this.siteSettings.chat_dm_retention_days
+      : this.siteSettings.chat_channel_retention_days;
   },
 
   @action

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -30,6 +30,7 @@
 
 <div class="chat-messages-scroll chat-messages-container">
   {{#conditional-loading-spinner condition=this.loading}}
+    {{chat-retention-reminder chatChannel=chatChannel}}
     {{#each this.messages as |message|}}
       {{chat-message
         message=message

--- a/assets/javascripts/discourse/templates/components/chat-retention-reminder.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-retention-reminder.hbs
@@ -1,0 +1,10 @@
+{{#if show}}
+  <div class="chat-retention-reminder">
+    <span>{{i18n "chat.retention_reminder" days=daysCount}}</span>
+    {{d-button
+      class="btn-flat dismiss-btn"
+      action=(action "dismiss")
+      icon="times"
+    }}
+  </div>
+{{/if}}

--- a/assets/javascripts/discourse/templates/components/chat-retention-reminder.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-retention-reminder.hbs
@@ -1,6 +1,6 @@
 {{#if show}}
   <div class="chat-retention-reminder">
-    <span>{{i18n "chat.retention_reminder" days=daysCount}}</span>
+    <span class="chat-retention-reminder-text">{{text}}</span>
     {{d-button
       class="btn-flat dismiss-btn"
       action=(action "dismiss")

--- a/assets/stylesheets/common/chat-retention-reminder.scss
+++ b/assets/stylesheets/common/chat-retention-reminder.scss
@@ -1,31 +1,33 @@
 .chat-retention-reminder {
   display: flex;
   position: absolute;
-  top: 25px;
+  top: 15px;
   left: 50%;
   transform: translateX(-50%);
   align-items: center;
   background: var(--tertiary);
   border-radius: 16px;
-  padding: 0.25em 1em;
+  padding: 0.5em 1em;
   font-size: var(--font-down-1);
   border: 1px solid var(--tertiary-hover);
   color: var(--secondary);
-  z-index: 1;
-  min-width: 300px;
+  z-index: 10;
+  min-width: 260px;
 
-  .dismiss-btn {
+  .btn-flat.dismiss-btn {
     margin-left: 0.75em;
+    color: var(--secondary);
 
-    &:hover {
+    &:hover,
+    &:focus {
       background: var(--tertiary-hover);
     }
     .d-icon {
       color: var(--secondary);
-
-      &:hover {
-        color: var(--secondary);
-      }
     }
   }
+}
+
+.full-page-chat .chat-retention-reminder {
+  top: 60px;
 }

--- a/assets/stylesheets/common/chat-retention-reminder.scss
+++ b/assets/stylesheets/common/chat-retention-reminder.scss
@@ -5,6 +5,7 @@
   left: 50%;
   transform: translateX(-50%);
   align-items: center;
+  justify-content: space-between;
   background: var(--tertiary);
   border-radius: 16px;
   padding: 0.5em 1em;
@@ -12,10 +13,10 @@
   border: 1px solid var(--tertiary-hover);
   color: var(--secondary);
   z-index: 10;
-  min-width: 260px;
+  min-width: 280px;
 
   .btn-flat.dismiss-btn {
-    margin-left: 0.75em;
+    margin-left: 0.25em;
     color: var(--secondary);
 
     &:hover,

--- a/assets/stylesheets/common/chat-retention-reminder.scss
+++ b/assets/stylesheets/common/chat-retention-reminder.scss
@@ -1,0 +1,31 @@
+.chat-retention-reminder {
+  display: flex;
+  position: absolute;
+  top: 25px;
+  left: 50%;
+  transform: translateX(-50%);
+  align-items: center;
+  background: var(--tertiary);
+  border-radius: 16px;
+  padding: 0.25em 1em;
+  font-size: var(--font-down-1);
+  border: 1px solid var(--tertiary-hover);
+  color: var(--secondary);
+  z-index: 1;
+  min-width: 300px;
+
+  .dismiss-btn {
+    margin-left: 0.75em;
+
+    &:hover {
+      background: var(--tertiary-hover);
+    }
+    .d-icon {
+      color: var(--secondary);
+
+      &:hover {
+        color: var(--secondary);
+      }
+    }
+  }
+}

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -486,6 +486,7 @@ body.composer-open .topic-chat-float-container {
 
 .chat-live-pane {
   display: flex;
+  position: relative;
   flex-direction: column;
   align-items: stretch;
   width: 100%;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -194,8 +194,8 @@ en:
           other: "%{commaSeparatedUsernames} and %{count} others are typing"
 
       retention_reminders:
-        public: "Remember, all messages in this channel older than %{days} days will be deleted!"
-        dm: "Remember, all personal chat messages older than %{days} days will be deleted!"
+        public: "Channel history is retained for %{days} days."
+        dm: "Personal chat history is retained for %{days} days."
 
     notifications:
       popup:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -193,6 +193,8 @@ en:
           one: "%{commaSeparatedUsernames} and %{count} other are typing"
           other: "%{commaSeparatedUsernames} and %{count} others are typing"
 
+      retention_reminder: "Remember, all messages older than %{days} will be deleted!"
+
     notifications:
       popup:
         chat_mention: "%{username} mentioned you in chat"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -193,7 +193,7 @@ en:
           one: "%{commaSeparatedUsernames} and %{count} other are typing"
           other: "%{commaSeparatedUsernames} and %{count} others are typing"
 
-      retention_reminder: "Remember, all messages older than %{days} will be deleted!"
+      retention_reminder: "Remember, all messages older than %{days} days will be deleted!"
 
     notifications:
       popup:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -193,7 +193,9 @@ en:
           one: "%{commaSeparatedUsernames} and %{count} other are typing"
           other: "%{commaSeparatedUsernames} and %{count} others are typing"
 
-      retention_reminder: "Remember, all messages older than %{days} days will be deleted!"
+      retention_reminders:
+        public: "Remember, all messages in this channel older than %{days} days will be deleted!"
+        dm: "Remember, all personal chat messages older than %{days} days will be deleted!"
 
     notifications:
       popup:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,6 +2,8 @@ en:
   site_settings:
     chat_enabled: "Enable the discourse-chat plugin. Use the per-topic 'Enable Chat' action to set up."
     chat_allowed_groups: "Users in these groups can chat."
+    chat_channel_retention_days: "Chat messages in reguar channels will be retained for this many days. Set to 0 to retain messages forever."
+    chat_dm_retention_days: "Chat messages in personal chat channels will be retained for this many days. Set to 0 to retain messages forever."
   chat:
     errors:
      channel_exists_for_category: "A channel already exists for this category and name"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,3 +15,13 @@ plugins:
   chat_debug_webhook_payloads:
     default: false
     hidden: true
+  chat_channel_retention_days:
+    default: 90
+    client: true
+    max: 3652 # 10 years
+    min: 0
+  chat_dm_retention_days:
+    default: 0
+    client: true
+    max: 3652 # 10 years
+    min: 0

--- a/db/migrate/20220119170535_add_chat_retention_fields_to_user_options.rb
+++ b/db/migrate/20220119170535_add_chat_retention_fields_to_user_options.rb
@@ -1,0 +1,6 @@
+class AddChatRetentionFieldsToUserOptions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :user_options, :dismissed_channel_retention_reminder, :boolean, null: true
+    add_column :user_options, :dismissed_dm_retention_reminder, :boolean, null: true
+  end
+end

--- a/db/migrate/20220119170535_add_chat_retention_fields_to_user_options.rb
+++ b/db/migrate/20220119170535_add_chat_retention_fields_to_user_options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class AddChatRetentionFieldsToUserOptions < ActiveRecord::Migration[6.1]
   def change
     add_column :user_options, :dismissed_channel_retention_reminder, :boolean, null: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -209,12 +209,18 @@ after_initialize do
     true
   end
 
-  add_to_serializer(:current_user, :include_dismissed_channel_retention_reminder?) do
-    include_has_chat_enabled? && object.staff? && !object.user_option.dismissed_channel_retention_reminder
+  add_to_serializer(:current_user, :include_needs_channel_retention_reminder?) do
+    include_has_chat_enabled? &&
+      object.staff? &&
+      !object.user_option.dismissed_channel_retention_reminder &&
+      SiteSetting.chat_channel_retention_days
+
   end
 
-  add_to_serializer(:current_user, :include_dismissed_dm_retention_reminder?) do
-    include_has_chat_enabled? && !object.user_option.dismissed_dm_retention_reminder
+  add_to_serializer(:current_user, :include_needs_dm_retention_reminder?) do
+    include_has_chat_enabled? &&
+      !object.user_option.dismissed_dm_retention_reminder &&
+      SiteSetting.chat_channel_retention_days
   end
 
   add_to_serializer(:current_user, :chat_drafts) do
@@ -326,6 +332,7 @@ after_initialize do
     get '/channel/:channel_id/:channel_title' => 'chat#respond'
     post '/enable' => 'chat#enable_chat'
     post '/disable' => 'chat#disable_chat'
+    post '/dismiss-retention-reminder' => 'chat#dismiss_retention_reminder'
     get '/:chat_channel_id/messages' => 'chat#messages'
     put ':chat_channel_id/edit/:message_id' => 'chat#edit_message'
     put ':chat_channel_id/react/:message_id' => 'chat#react'

--- a/plugin.rb
+++ b/plugin.rb
@@ -13,6 +13,7 @@ register_asset 'stylesheets/common/common.scss'
 register_asset 'stylesheets/common/incoming-chat-webhooks.scss'
 register_asset 'stylesheets/common/chat-message.scss'
 register_asset 'stylesheets/common/chat-message-collapser.scss'
+register_asset 'stylesheets/common/chat-retention-reminder.scss'
 register_asset 'stylesheets/mobile/mobile.scss', :mobile
 register_asset 'stylesheets/desktop/desktop.scss', :desktop
 register_asset 'stylesheets/sidebar-extensions.scss'
@@ -85,6 +86,7 @@ after_initialize do
   load File.expand_path('../app/jobs/regular/process_chat_message.rb', __FILE__)
   load File.expand_path('../app/jobs/regular/create_chat_mention_notifications.rb', __FILE__)
   load File.expand_path('../app/jobs/regular/notify_users_watching_chat.rb', __FILE__)
+  load File.expand_path('../app/jobs/scheduled/delete_old_chat_messages.rb', __FILE__)
   load File.expand_path('../app/services/chat_publisher.rb', __FILE__)
 
   register_topic_custom_field_type(DiscourseChat::HAS_CHAT_ENABLED, :boolean)
@@ -197,6 +199,22 @@ after_initialize do
 
   add_to_serializer(:current_user, :include_chat_sound?) do
     include_has_chat_enabled? && object.user_option.chat_sound
+  end
+
+  add_to_serializer(:current_user, :needs_channel_retention_reminder) do
+    true
+  end
+
+  add_to_serializer(:current_user, :needs_dm_retention_reminder) do
+    true
+  end
+
+  add_to_serializer(:current_user, :include_dismissed_channel_retention_reminder?) do
+    include_has_chat_enabled? && object.staff? && !object.user_option.dismissed_channel_retention_reminder
+  end
+
+  add_to_serializer(:current_user, :include_dismissed_dm_retention_reminder?) do
+    include_has_chat_enabled? && !object.user_option.dismissed_dm_retention_reminder
   end
 
   add_to_serializer(:current_user, :chat_drafts) do

--- a/spec/jobs/delete_old_chat_messages_spec.rb
+++ b/spec/jobs/delete_old_chat_messages_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Jobs::DeleteOldChatMessages do
+  base_date = DateTime.parse('2020-12-01 00:00 UTC')
+
+  fab!(:public_channel) { Fabricate(:chat_channel) }
+  fab!(:public_days_old_0) {
+    Fabricate(:chat_message, chat_channel: public_channel, message: "hi", created_at: base_date)
+  }
+  fab!(:public_days_old_10) {
+    Fabricate(:chat_message, chat_channel: public_channel, message: "hi", created_at: base_date - 10.days - 1.second)
+  }
+  fab!(:public_days_old_20) {
+    Fabricate(:chat_message, chat_channel: public_channel, message: "hi", created_at: base_date - 20.days - 1.second)
+  }
+  fab!(:public_days_old_30) {
+    Fabricate(:chat_message, chat_channel: public_channel, message: "hi", created_at: base_date - 30.days - 1.second)
+  }
+
+  fab!(:dm_channel) { Fabricate(:chat_channel, chatable: Fabricate(:direct_message_channel, users: [Fabricate(:user)])) }
+  fab!(:dm_days_old_0) {
+    Fabricate(:chat_message, chat_channel: dm_channel, message: "hi", created_at: base_date)
+  }
+  fab!(:dm_days_old_10) {
+    Fabricate(:chat_message, chat_channel: dm_channel, message: "hi", created_at: base_date - 10.days - 1.second)
+  }
+  fab!(:dm_days_old_20) {
+    Fabricate(:chat_message, chat_channel: dm_channel, message: "hi", created_at: base_date - 20.days - 1.second)
+  }
+  fab!(:dm_days_old_30) {
+    Fabricate(:chat_message, chat_channel: dm_channel, message: "hi", created_at: base_date - 30.days - 1.second)
+  }
+
+  before do
+    freeze_time(base_date)
+  end
+
+  it "doesn't delete messages when settings are 0" do
+    SiteSetting.chat_channel_retention_days = 0
+    SiteSetting.chat_dm_retention_days = 0
+
+    expect { described_class.new.execute }.to change { ChatMessage.count }.by(0)
+  end
+
+  describe "public channels" do
+    it "deletes public messages correctly" do
+      SiteSetting.chat_channel_retention_days = 20
+      described_class.new.execute
+      expect(public_days_old_0.deleted_at).to be_nil
+      expect(public_days_old_10.deleted_at).to be_nil
+      expect { public_days_old_20 }.to raise_exception(ActiveRecord::RecordNotFound)
+      expect { public_days_old_30 }.to raise_exception(ActiveRecord::RecordNotFound)
+    end
+
+    it "does nothing when no messages fall in the time range" do
+      SiteSetting.chat_channel_retention_days = 800
+      expect { described_class.new.execute }.to change { ChatMessage.in_public_channel.count }.by(0)
+    end
+  end
+
+  describe "dm channels" do
+    it "deletes public messages correctly" do
+      SiteSetting.chat_dm_retention_days = 20
+      described_class.new.execute
+      expect(dm_days_old_0.deleted_at).to be_nil
+      expect(dm_days_old_10.deleted_at).to be_nil
+      expect { dm_days_old_20 }.to raise_exception(ActiveRecord::RecordNotFound)
+      expect { dm_days_old_30 }.to raise_exception(ActiveRecord::RecordNotFound)
+    end
+
+    it "does nothing when no messages fall in the time range" do
+      SiteSetting.chat_dm_retention_days = 800
+      expect { described_class.new.execute }.to change { ChatMessage.in_dm_channel.count }.by(0)
+    end
+  end
+end

--- a/test/javascripts/components/chat-retention-reminder-test.js
+++ b/test/javascripts/components/chat-retention-reminder-test.js
@@ -10,15 +10,6 @@ import {
 import hbs from "htmlbars-inline-precompile";
 import I18n from "I18n";
 
-const user = {
-  id: 1,
-  username: "markvanlan",
-  name: null,
-  avatar_template: "/letter_avatar_proxy/v4/letter/m/48db29/{size}.png",
-  needs_dm_retention_reminder: true,
-  needs_channel_retention_reminder: true,
-};
-
 discourseModule(
   "Discourse Chat | Component | chat-retention-reminder",
   function (hooks) {

--- a/test/javascripts/components/chat-retention-reminder-test.js
+++ b/test/javascripts/components/chat-retention-reminder-test.js
@@ -1,0 +1,92 @@
+import { set } from "@ember/object";
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import {
+  discourseModule,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+import hbs from "htmlbars-inline-precompile";
+import I18n from "I18n";
+
+const user = {
+  id: 1,
+  username: "markvanlan",
+  name: null,
+  avatar_template: "/letter_avatar_proxy/v4/letter/m/48db29/{size}.png",
+  needs_dm_retention_reminder: true,
+  needs_channel_retention_reminder: true,
+};
+
+discourseModule(
+  "Discourse Chat | Component | chat-retention-reminder",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    componentTest("Shows for public channels when user needs it", {
+      template: hbs`{{chat-retention-reminder chatChannel=chatChannel}}`,
+
+      async beforeEach() {
+        this.set("chatChannel", { chatable_type: "Category" });
+        set(this.currentUser, "needs_channel_retention_reminder", true);
+        set(this.siteSettings, "chat_channel_retention_days", 100);
+      },
+
+      async test(assert) {
+        assert.equal(
+          query(".chat-retention-reminder-text").innerText.trim(),
+          I18n.t("chat.retention_reminders.public", { days: 100 })
+        );
+      },
+    });
+
+    componentTest(
+      "Doesn't show for public channels when user has dismissed it",
+      {
+        template: hbs`{{chat-retention-reminder chatChannel=chatChannel}}`,
+
+        async beforeEach() {
+          this.set("chatChannel", { chatable_type: "Category" });
+          set(this.currentUser, "needs_channel_retention_reminder", false);
+          set(this.siteSettings, "chat_channel_retention_days", 100);
+        },
+
+        async test(assert) {
+          assert.notOk(exists(".chat-retention-reminder"));
+        },
+      }
+    );
+
+    componentTest("Shows for direct message channels when user needs it", {
+      template: hbs`{{chat-retention-reminder chatChannel=chatChannel}}`,
+
+      async beforeEach() {
+        this.set("chatChannel", { chatable_type: "DirectMessageChannel" });
+        set(this.currentUser, "needs_dm_retention_reminder", true);
+        set(this.siteSettings, "chat_dm_retention_days", 100);
+      },
+
+      async test(assert) {
+        assert.equal(
+          query(".chat-retention-reminder-text").innerText.trim(),
+          I18n.t("chat.retention_reminders.dm", { days: 100 })
+        );
+      },
+    });
+
+    componentTest("Doesn't show for dm channels when user has dismissed it", {
+      template: hbs`{{chat-retention-reminder chatChannel=chatChannel}}`,
+
+      async beforeEach() {
+        this.set("chatChannel", { chatable_type: "DirectMessageChannel" });
+        set(this.currentUser, "needs_dm_retention_reminder", false);
+        set(this.siteSettings, "chat_dm_retention_days", 100);
+      },
+
+      async test(assert) {
+        assert.notOk(exists(".chat-retention-reminder"));
+      },
+    });
+  }
+);


### PR DESCRIPTION
Note: The serializer only serializes if the user HAS NOT cleared the reminder before. This will cut down on the current_user payload as most users who can chat will clear it.

The reminder also comes back if the site settings change, so that users stay up-to-date on how frequently old messages are removed. 

Site settings
<img width="1138" alt="Screen Shot 2022-01-20 at 11 00 22 AM" src="https://user-images.githubusercontent.com/16214023/150386457-a9f0a182-2c03-4ae4-a16e-1d292c106944.png">

Public channel channel (only staff will see this)
<img width="443" alt="Screen Shot 2022-01-20 at 11 01 06 AM" src="https://user-images.githubusercontent.com/16214023/150386489-441ea19e-1d94-4b55-8ae1-a640d3845b55.png">
<img width="1216" alt="Screen Shot 2022-01-20 at 11 01 17 AM" src="https://user-images.githubusercontent.com/16214023/150386503-c229cb48-bf31-4b4c-acfa-3f2a2eb876a2.png">

Personal chat channel (Everyone will see this)
<img width="442" alt="Screen Shot 2022-01-20 at 11 01 36 AM" src="https://user-images.githubusercontent.com/16214023/150386518-53d4daec-5aed-4997-b7de-a1c9de0355c1.png">
<img width="1212" alt="Screen Shot 2022-01-20 at 11 01 28 AM" src="https://user-images.githubusercontent.com/16214023/150386529-d3313590-bfb7-43c3-8377-1b79307f3bf7.png">

