### PR TITLE
UX: Use more specific positioning

### DIFF
--- a/assets/stylesheets/sidebar-extensions.scss
+++ b/assets/stylesheets/sidebar-extensions.scss
@@ -3,7 +3,7 @@
   .has-sidebar {
     .sidebar-header {
       .d-header .menu-panel {
-        top: 3.22em !important;
+        top: calc(3.4em - 2px) !important;
       }
       .d-header-icons .icon {
         width: 2em;


### PR DESCRIPTION
This PR fixes an issue where the user-menu is placed a couple pixels shy of where it should be, which causes a border-line to show between the active icon and its menu. This is happening because in the chat plugin, we slightly decrease the size of these icons in order to make room for the chat icon.

### After Fix
![image](https://user-images.githubusercontent.com/30537603/150569553-eb663287-cf6c-4dd0-ba68-1e5eef18a932.png)

### Before Fix
![image](https://user-images.githubusercontent.com/30537603/150569662-8d7ad79b-0b49-4cb1-aa8d-817b0dd22ef2.png)

