### PR TITLE
UX: Padding changes in sidebar

### DIFF
--- a/assets/stylesheets/sidebar-extensions.scss
+++ b/assets/stylesheets/sidebar-extensions.scss
@@ -22,7 +22,6 @@
     }
     .custom-nav-list {
       li > a {
-        padding: 0.35em 0.5em 0.35em 1.8rem;
         .badge-notification .sidebar-nav-item-callout {
           padding: 0;
           margin: 0;
@@ -117,7 +116,9 @@
       }
 
       .chat-channel-row {
-        padding-left: 1.8rem;
+        padding-left: calc(1.8rem / 2);
+        margin-left: calc(1.8rem / 2);
+        border-radius: 0.25em;
         padding-right: 1.8rem;
         min-height: 28px;
 

--- a/assets/stylesheets/sidebar-extensions.scss
+++ b/assets/stylesheets/sidebar-extensions.scss
@@ -20,17 +20,6 @@
         border-color: var(--primary-very-low);
       }
     }
-    .custom-nav-list {
-      li > a {
-        .badge-notification .sidebar-nav-item-callout {
-          padding: 0;
-          margin: 0;
-        }
-      }
-      .title {
-        padding: 0 0 0 1.75em;
-      }
-    }
     .sidebar-container {
       .chat-channels {
         .chat-channel-divider {


### PR DESCRIPTION
This PR changes the padding and margin for links in the sidebar to prevent the hover effect from extending to the edge of the sidebar.

### After
<img src="https://user-images.githubusercontent.com/30537603/150599420-a9d8cadb-b360-42e6-b704-54a65c696f4d.png" width="300" />

### Before
<img src="https://user-images.githubusercontent.com/30537603/150599523-24cd6f62-486e-45bb-b883-1d31222dea0d.png" width="300" />

