### PR TITLE
FIX:  ProcessChatMessage when message deleted

### DIFF
--- a/app/jobs/regular/process_chat_message.rb
+++ b/app/jobs/regular/process_chat_message.rb
@@ -5,6 +5,7 @@ module Jobs
     def execute(args = {})
       DistributedMutex.synchronize("process_chat_message_#{args[:chat_message_id]}", validity: 10.minutes) do
         chat_message = ChatMessage.find_by(id: args[:chat_message_id])
+        return if !chat_message
         processor = DiscourseChat::ChatMessageProcessor.new(chat_message)
         processor.run!
         if processor.dirty?

--- a/spec/jobs/process_chat_message_spec.rb
+++ b/spec/jobs/process_chat_message_spec.rb
@@ -15,4 +15,9 @@ describe Jobs::ProcessChatMessage do
     described_class.new.execute(chat_message_id: chat_message.id)
     expect(chat_message.reload.cooked).to eq("<p><a href=\"https://discourse.org/team\" class=\"onebox\" target=\"_blank\" rel=\"noopener nofollow ugc\">https://discourse.org/team</a></p>")
   end
+
+  it "does not error when message is deleted" do
+    chat_message.destroy
+    expect { described_class.new.execute(chat_message_id: chat_message.id) }.not_to raise_exception
+  end
 end


### PR DESCRIPTION
Do not error when message is deleted before job execution