### PR TITLE
FIX: Unread indicator styling in channel selector

### DIFF
--- a/assets/stylesheets/common/chat-channel-selector-modal.scss
+++ b/assets/stylesheets/common/chat-channel-selector-modal.scss
@@ -39,6 +39,13 @@
         color: var(--primary-high);
         padding-left: 0.5em;
       }
+
+      .chat-channel-unread-indicator {
+        border: none;
+        margin-left: 0.5em;
+        height: 12px;
+        width: 12px;
+      }
     }
   }
 }


### PR DESCRIPTION
# OLD
<img width="621" alt="Screen Shot 2022-01-26 at 10 10 39 AM" src="https://user-images.githubusercontent.com/16214023/151201067-e23affa9-bc89-4454-b69a-c53fb91060ad.png">

# NEW
<img width="652" alt="Screen Shot 2022-01-26 at 10 10 02 AM" src="https://user-images.githubusercontent.com/16214023/151201078-1d164548-34ff-4373-9796-ed2b64bb0287.png">

