### PR TITLE
UX: Instantly filter chat channels in quick select modal

### DIFF
--- a/assets/javascripts/discourse/components/chat-channel-selector-modal-inner.js
+++ b/assets/javascripts/discourse/components/chat-channel-selector-modal-inner.js
@@ -1,6 +1,5 @@
 import Component from "@ember/component";
 import { bind } from "discourse-common/utils/decorators";
-import discourseDebounce from "discourse-common/lib/debounce";
 import { schedule } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 import { action } from "@ember/object";
@@ -14,7 +13,7 @@ export default Component.extend({
   init() {
     this._super(...arguments);
     this.appEvents.on("chat-channel-selector-modal:close", this.close);
-    this._getFilteredChannels();
+    this.getFilteredChannels();
   },
 
   didInsertElement() {
@@ -24,6 +23,9 @@ export default Component.extend({
       .getElementById("chat-channel-selector-modal-inner")
       ?.addEventListener("mouseover", this.mouseover);
     document.getElementById("chat-channel-selector-modal-inner")?.focus();
+    document
+      .getElementById("chat-channel-selector-input")
+      ?.addEventListener("keyup", this.getFilteredChannels);
   },
 
   willDestroyElement() {
@@ -33,6 +35,9 @@ export default Component.extend({
     document
       .getElementById("chat-channel-selector-modal-inner")
       ?.removeEventListener("mouseover", this.mouseover);
+    document
+      .getElementById("chat-channel-selector-input")
+      ?.removeEventListener("keyup", this.getFilteredChannels);
     this.filteredChannels.forEach((c) => c.set("focused", false));
   },
 
@@ -90,16 +95,12 @@ export default Component.extend({
     this.close();
   },
 
-  _getFilteredChannels() {
+  @action
+  getFilteredChannels() {
     return this.chat.getChannelsWithFilter(this.filter).then((channels) => {
       channels.forEach((c) => c.set("focused", false));
       channels[0]?.set("focused", true);
       this.set("filteredChannels", channels);
     });
-  },
-
-  @action
-  onFilterChange() {
-    discourseDebounce(this, this._getFilteredChannels, 50);
   },
 });

--- a/assets/javascripts/discourse/templates/components/chat-channel-selector-modal-inner.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-selector-modal-inner.hbs
@@ -4,7 +4,7 @@
       <span class="search-icon">
         {{d-icon "search"}}
       </span>
-      {{input id="chat-channel-selector-input" type="text" value=filter onChange=onFilterChange autocomplete="off"}}
+      {{input id="chat-channel-selector-input" type="text" value=filter autocomplete="off"}}
     </div>
     <div class="channels">
       {{#each filteredChannels as |channel|}}


### PR DESCRIPTION
`{{input onChange=}}` has a built on delay for something like 500ms after the user stops typing.

Hooking into `keyup` for the `input` element causes the filter to trigger instantly and it makes this modal much better.