### PR TITLE
DEV: Don't manually calc full chat height

### DIFF
--- a/assets/javascripts/discourse/components/full-page-chat.js
+++ b/assets/javascripts/discourse/components/full-page-chat.js
@@ -2,7 +2,6 @@ import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
 import { action } from "@ember/object";
 import { reads } from "@ember/object/computed";
-import { schedule } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 
 export default Component.extend({
@@ -25,27 +24,19 @@ export default Component.extend({
     return !mobileView && !sidebarOn;
   },
 
-  init() {
-    this._super(...arguments);
-
-    this.appEvents.on("chat:refresh-channels", this, "refreshModel");
-  },
-
   didInsertElement() {
     this._super(...arguments);
 
+    this.appEvents.on("chat:refresh-channels", this, "refreshModel");
     this._scrollSidebarToBottom();
-    window.addEventListener("resize", this._calculateHeight, false);
     document.body.classList.add("has-full-page-chat");
     this.chat.set("fullScreenChatOpen", true);
-    schedule("afterRender", this._calculateHeight);
   },
 
   willDestroyElement() {
     this._super(...arguments);
 
     this.appEvents.off("chat:refresh-channels", this, "refreshModel");
-    window.removeEventListener("resize", this._calculateHeight, false);
     document.body.classList.remove("has-full-page-chat");
     this.chat.set("fullScreenChatOpen", false);
   },
@@ -61,24 +52,6 @@ export default Component.extend({
     if (sidebarScroll) {
       sidebarScroll.scrollTop = sidebarScroll.scrollHeight;
     }
-  },
-
-  _calculateHeight() {
-    const main = document.getElementById("main-outlet"),
-      padBottom = window
-        .getComputedStyle(main, null)
-        .getPropertyValue("padding-bottom"),
-      chatContainerCoords = document
-        .querySelector(".full-page-chat")
-        .getBoundingClientRect();
-
-    const elHeight =
-      window.innerHeight -
-      chatContainerCoords.y -
-      window.pageYOffset -
-      parseInt(padBottom, 10);
-
-    document.body.style.setProperty("--full-page-chat-height", `${elHeight}px`);
   },
 
   @action

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1138,6 +1138,7 @@ body.has-full-page-chat {
   display: grid;
   flex-grow: 1;
   grid-template-columns: var(--full-page-sidebar-width) 1fr;
+  overflow: hidden;
 
   .chat-channels {
     background: var(--primary-very-low);

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1120,6 +1120,12 @@ body.composer-open .topic-chat-float-container {
 }
 
 body.has-full-page-chat {
+  #main-outlet {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - var(--header-offset));
+  }
+
   .alert-info:last-of-type {
     margin-bottom: 0;
     border-bottom: 1px solid var(--primary-low);
@@ -1130,8 +1136,8 @@ body.has-full-page-chat {
   font-family: "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   display: grid;
+  flex-grow: 1;
   grid-template-columns: var(--full-page-sidebar-width) 1fr;
-  grid-template-rows: var(--full-page-chat-height);
 
   .chat-channels {
     background: var(--primary-very-low);

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -134,7 +134,9 @@
 // Full page styling with sidebar enabled
 .discourse-sidebar.has-full-page-chat {
   #main-outlet {
-    padding: 2em 0 0 0;
+    box-sizing: border-box;
+    height: calc(100vh - 4rem); // 4rem: sidebar header
+    padding: 1.5rem 0 0 0;
   }
 
   .full-page-chat.teams-sidebar-on {

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -135,7 +135,8 @@
 .discourse-sidebar.has-full-page-chat {
   #main-outlet {
     box-sizing: border-box;
-    height: calc(100vh - 4rem); // 4rem: sidebar header
+    // 4rem: sidebar header
+    height: calc(var(--ipad-viewport-height, 100vh) - 4rem);
     padding: 1.5rem 0 0 0;
   }
 


### PR DESCRIPTION
That method was error-prone, because if something were to be added/removed above the chat (e.g. an alert) it would not recalc the height.