### PR TITLE
UX: Sidebar rows 'active' when float is open

### DIFF
--- a/assets/javascripts/discourse/components/chat-channel-row.js
+++ b/assets/javascripts/discourse/components/chat-channel-row.js
@@ -1,18 +1,20 @@
 import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
 import getURL from "discourse-common/lib/get-url";
+import { action } from "@ember/object";
 import { equal } from "@ember/object/computed";
 import { inject as service } from "@ember/service";
-import { action } from "@ember/object";
+import { propertyEqual } from "discourse/lib/computed";
 
 export default Component.extend({
   tagName: "",
+  router: service(),
+  chat: service(),
   channel: null,
   switchChannel: null,
   isUnfollowing: false,
   isDirectMessageRow: equal("channel.chatable_type", "DirectMessageChannel"),
-  router: service(),
-  chat: service(),
+  active: propertyEqual("channel.id", "chat.activeChannel.id"),
   options: null,
 
   @discourseComputed("active", "channel.{id,muted}", "channel.focused")
@@ -73,10 +75,5 @@ export default Component.extend({
   onLeaveChannel() {
     this.set("isUnfollowing", true);
     this.chat.unfollowChannel(this.channel);
-  },
-
-  @discourseComputed("channel", "chat.activeChannel")
-  active(channel, activeChannel) {
-    return channel.id === activeChannel?.id;
   },
 });

--- a/assets/javascripts/discourse/components/chat-channel-row.js
+++ b/assets/javascripts/discourse/components/chat-channel-row.js
@@ -75,11 +75,8 @@ export default Component.extend({
     this.chat.unfollowChannel(this.channel);
   },
 
-  @discourseComputed("channel", "router.currentRoute")
-  active(channel, currentRoute) {
-    return (
-      currentRoute?.name === "chat.channel" &&
-      currentRoute?.params?.channelId === channel.id.toString(10)
-    );
+  @discourseComputed("channel", "chat.activeChannel")
+  active(channel, activeChannel) {
+    return channel.id === activeChannel?.id;
   },
 });

--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -295,6 +295,7 @@ export default Component.extend({
       hidden: true,
       expanded: true,
     });
+    this.chat.setActiveChannel(null);
     this.appEvents.trigger("chat:float-toggled", this.hidden);
   },
 
@@ -303,13 +304,13 @@ export default Component.extend({
     this.set("hidden", !this.hidden);
     this.appEvents.trigger("chat:float-toggled", this.hidden);
     if (this.hidden) {
-      return;
+      return this.chat.setActiveChannel(null);
     } else {
       this.set("expanded", true);
       this.appEvents.trigger("chat:toggle-expand", this.expanded);
       if (this.activeChannel) {
         // Channel was previously open, so after expand we are done.
-        return;
+        return this.chat.setActiveChannel(null);
       }
     }
 
@@ -373,6 +374,7 @@ export default Component.extend({
       expectPageChange: false,
       view: CHAT_VIEW,
     };
+    this.chat.setActiveChannel(channel);
     this.setProperties(channelInfo);
   },
 

--- a/assets/javascripts/discourse/routes/chat-channel.js
+++ b/assets/javascripts/discourse/routes/chat-channel.js
@@ -34,8 +34,9 @@ export default DiscourseRoute.extend({
       .catch(() => this.replaceWith("/404"));
   },
 
-  afterModel() {
+  afterModel(model) {
     this.appEvents.trigger("chat:navigated-to-full-page");
+    this.chat.setActiveChannel(model?.chatChannel);
   },
 
   setupController(controller) {
@@ -45,6 +46,12 @@ export default DiscourseRoute.extend({
       this.chat.set("messageId", controller.messageId);
       this.controller.set("messageId", null);
     }
+  },
+
+  @action
+  willTransition() {
+    this._super(...arguments);
+    this.chat.setActiveChannel(null);
   },
 
   @action

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -29,6 +29,7 @@ const PUBLIC_CHANNEL_SORT_PRIOS = {
 };
 
 export default Service.extend({
+  activeChannel: null,
   allChannels: null,
   appEvents: service(),
   chatNotificationManager: service(),
@@ -113,17 +114,8 @@ export default Service.extend({
     return this.router.currentRouteName === "chat.browse";
   },
 
-  get activeChannel() {
-    let channelId;
-    if (this.router.currentRouteName === "chat.channel") {
-      channelId = this.router.currentRoute.params.channelId;
-    } else {
-      channelId = document.querySelector(".topic-chat-container.visible")
-        ?.dataset?.chatChannelId;
-    }
-    return channelId
-      ? this.allChannels.findBy("id", parseInt(channelId, 10))
-      : null;
+  setActiveChannel(channel) {
+    this.set("activeChannel", channel);
   },
 
   loadCookFunction(categories) {


### PR DESCRIPTION
This is a major improvement on how `activeChannel` is calc'd everywhere, by being manually set at the correct spots. The largest benefit of this is that channel-rows can hook into the chat services' `activeChannel` and highlight even when the float is open :)

<img width="1049" alt="Screen Shot 2022-01-28 at 2 16 09 PM" src="https://user-images.githubusercontent.com/16214023/151615677-bd9dc615-824f-4d0e-9922-fdb36df88319.png">
