### PR TITLE
FEATURE: Server-side filter and new DM creation from ctrl+k

### DIFF
--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -151,6 +151,9 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
     end
 
     users = users.uniq
+    # Need to filter out current user for chat channel query
+    users.reject! { |user| user.id === current_user.id }
+
     direct_message_channels = users.count > 0 ?
       ChatChannel
         .includes(chatable: :users)
@@ -167,6 +170,12 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
     end
 
     users_without_channel = users.filter { |u| !user_ids_with_channel.include?(u.id) }
+
+    if current_user.username.downcase.start_with?(filter)
+      # We filtered out the current user for the query earlier, but check to see
+      # if they should be included, and add.
+      users_without_channel << current_user
+    end
 
     render_serialized({
       public_channels: public_channels,

--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -150,7 +150,7 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
       users = users.where("LOWER(users.username) LIKE ?", like_filter)
     end
 
-    users = users.uniq
+    users = users.limit(25).uniq
     # Need to filter out current user for chat channel query
     users.reject! { |user| user.id === current_user.id }
 

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -11,6 +11,8 @@ class ChatChannel < ActiveRecord::Base
   attribute :last_read_message_id, default: nil
 
   belongs_to :chatable, polymorphic: true
+  belongs_to :direct_message_channel, -> { where(chat_channels: { chatable_type: 'DirectMessageChannel' }) }, foreign_key: 'chatable_id'
+
   has_many :chat_messages
   has_many :user_chat_channel_memberships
 

--- a/app/serializers/chat_channel_search_serializer.rb
+++ b/app/serializers/chat_channel_search_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ChatChannelSearchSerializer < ApplicationSerializer
+  has_many :public_channels, serializer: ChatChannelSerializer, embed: :objects
+  has_many :direct_message_channels, serializer: ChatChannelSerializer, embed: :objects
+  has_many :users, serializer: BasicUserSerializer, embed: :objects
+
+  def public_channels
+    object[:public_channels]
+  end
+
+  def direct_message_channels
+    object[:direct_message_channels]
+  end
+
+  def users
+    object[:users]
+  end
+end

--- a/assets/javascripts/discourse/components/chat-channel-selection-row.js
+++ b/assets/javascripts/discourse/components/chat-channel-selection-row.js
@@ -1,0 +1,22 @@
+import Component from "@ember/component";
+import discourseComputed from "discourse-common/utils/decorators";
+import { action } from "@ember/object";
+
+export default Component.extend({
+  tagName: "",
+
+  @discourseComputed("model", "model.focused")
+  rowClassNames(model, focused) {
+    return `chat-channel-selection-row ${focused ? "focused" : ""} ${
+      this.model.user ? "user-row" : "channel-row"
+    }`;
+  },
+
+  @action
+  handleClick(event) {
+    if (this.onClick) {
+      this.onClick(this.model);
+      event.preventDefault();
+    }
+  },
+});

--- a/assets/javascripts/discourse/components/chat-channel-selector-modal-inner.js
+++ b/assets/javascripts/discourse/components/chat-channel-selector-modal-inner.js
@@ -13,6 +13,7 @@ export default Component.extend({
   filter: "",
   channels: null,
   searchIndex: 0,
+  loading: false,
 
   init() {
     this._super(...arguments);
@@ -121,10 +122,13 @@ export default Component.extend({
 
   @action
   fetchChannelsFromServer() {
-    this.set("searchIndex", this.searchIndex + 1); // This is used to 'cancel' old search requests
+    this.setProperties({
+      loading: true,
+      searchIndex: this.searchIndex + 1,
+    });
     const thisSearchIndex = this.searchIndex;
-    ajax("/chat/chat_channels/search", { data: { filter: this.filter } }).then(
-      (searchModel) => {
+    ajax("/chat/chat_channels/search", { data: { filter: this.filter } })
+      .then((searchModel) => {
         if (this.searchIndex === thisSearchIndex) {
           this.set("searchModel", searchModel);
           const channels = searchModel.public_channels.concat(
@@ -136,14 +140,14 @@ export default Component.extend({
               c.user = true; // This is used by the `chat-channel-selection-row` component
             }
           });
-          this.set(
-            "channels",
-            channels.map((c) => EmberObject.create(c))
-          );
+          this.setProperties({
+            channels: channels.map((c) => EmberObject.create(c)),
+            loading: false,
+          });
           this.focusFirstChannel(this.channels);
         }
-      }
-    ).catch(popupAjaxError);
+      })
+      .catch(popupAjaxError);
   },
 
   @action

--- a/assets/javascripts/discourse/components/chat-channel-selector-modal-inner.js
+++ b/assets/javascripts/discourse/components/chat-channel-selector-modal-inner.js
@@ -1,6 +1,5 @@
 import Component from "@ember/component";
-import EmberObject from "@ember/object";
-import { action } from "@ember/object";
+import EmberObject, { action } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 import { bind } from "discourse-common/utils/decorators";
 import { schedule } from "@ember/runloop";
@@ -27,7 +26,7 @@ export default Component.extend({
     document
       .getElementById("chat-channel-selector-modal-inner")
       ?.addEventListener("mouseover", this.mouseover);
-    document.getElementById("chat-channel-selector-modal-inner")?.focus();
+    document.getElementById("chat-channel-selector-input")?.focus();
   },
 
   willDestroyElement() {

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -232,13 +232,6 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   didReceiveAttrs() {
     this._super(...arguments);
 
-    if (
-      this.chatChannel.id === this.lastChatChannelId &&
-      !this.editingMessage
-    ) {
-      return;
-    }
-
     if (!this.editingMessage && this.draft) {
       this.setProperties(this.draft);
       this.setInReplyToMsg(this.draft.replyToMsg);
@@ -254,6 +247,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
       });
       this._focusTextArea({ ensureAtEnd: true, resizeTextArea: false });
     }
+
     this.set("lastChatChannelId", this.chatChannel.id);
     this._resizeTextArea();
   },

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -795,7 +795,7 @@ export default Component.extend({
       this.setProperties({
         id: null,
       });
-      this.chat.forceRefreshChannels().then(() => {
+      return this.chat.forceRefreshChannels().then(() => {
         if (this._selfDeleted()) {
           return;
         }

--- a/assets/javascripts/discourse/controllers/chat-channel.js
+++ b/assets/javascripts/discourse/controllers/chat-channel.js
@@ -1,9 +1,5 @@
 import Controller from "@ember/controller";
-import { action } from "@ember/object";
-import { ajax } from "discourse/lib/ajax";
-import { inject as service } from "@ember/service";
 
 export default Controller.extend({
   queryParams: ["messageId"],
-  chat: service(),
 });

--- a/assets/javascripts/discourse/controllers/chat-channel.js
+++ b/assets/javascripts/discourse/controllers/chat-channel.js
@@ -6,20 +6,4 @@ import { inject as service } from "@ember/service";
 export default Controller.extend({
   queryParams: ["messageId"],
   chat: service(),
-
-  @action
-  joinChannel() {
-    return ajax(`/chat/chat_channels/${this.model.chatChannel.id}/follow`, {
-      method: "POST",
-    }).then(() => {
-      this.setProperties({
-        id: null,
-      });
-      this.model.set("previewing", false);
-      this.chat.forceRefreshChannels().then(() => {
-        this.send("refreshModel");
-        this.appEvents.trigger("chat:refresh-channels");
-      });
-    });
-  },
 });

--- a/assets/javascripts/discourse/routes/chat-channel.js
+++ b/assets/javascripts/discourse/routes/chat-channel.js
@@ -8,22 +8,20 @@ export default DiscourseRoute.extend({
   chat: service(),
 
   async model(params) {
-    let [[chatChannel, previewing], channels] = await Promise.all([
+    let [chatChannel, channels] = await Promise.all([
       this.getChannel(params.channelId),
       this.chat.getChannels(),
     ]);
 
-    return EmberObject.create({ chatChannel, channels, previewing });
+    return EmberObject.create({ chatChannel, channels });
   },
 
   async getChannel(id) {
     let channel = await this.chat.getChannelBy("id", id);
-    let previewing = false;
     if (!channel) {
       channel = await this.getChannelFromServer(id);
-      previewing = true;
     }
-    return [channel, previewing];
+    return channel;
   },
 
   async getChannelFromServer(id) {

--- a/assets/javascripts/discourse/templates/chat-channel.hbs
+++ b/assets/javascripts/discourse/templates/chat-channel.hbs
@@ -3,6 +3,5 @@
   directMessageChannels=model.channels.directMessageChannels
   chatChannel=model.chatChannel
   previewing=model.previewing
-  joinChannel=(action "joinChannel")
   refreshModel=(route-action "refreshModel")
 }}

--- a/assets/javascripts/discourse/templates/components/chat-channel-selection-row.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-selection-row.hbs
@@ -1,5 +1,7 @@
 <div
   class="{{rowClassNames}} {{if isUnfollowing "unfollowing"}}"
+  role="button"
+  tabindex="0"
   {{on "click" (fn this.handleClick)}}
   data-id={{model.id}}
   >

--- a/assets/javascripts/discourse/templates/components/chat-channel-selection-row.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-selection-row.hbs
@@ -1,0 +1,16 @@
+<div
+  class="{{rowClassNames}} {{if isUnfollowing "unfollowing"}}"
+  {{on "click" (fn this.handleClick)}}
+  data-id={{model.id}}
+  >
+
+  {{#if model.user}}
+    {{avatar model imageSize="tiny"}}
+    <span class="username">
+      {{model.username}}
+    </span>
+  {{else}}
+    {{chat-channel-title channel=model}}
+    {{chat-channel-unread-indicator channel=channel}}
+  {{/if}}
+</div>

--- a/assets/javascripts/discourse/templates/components/chat-channel-selection-row.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-selection-row.hbs
@@ -2,9 +2,9 @@
   class="{{rowClassNames}} {{if isUnfollowing "unfollowing"}}"
   role="button"
   tabindex="0"
-  {{on "click" (fn this.handleClick)}}
+  {{on "click" this.handleClick}}
   data-id={{model.id}}
-  >
+>
 
   {{#if model.user}}
     {{avatar model imageSize="tiny"}}

--- a/assets/javascripts/discourse/templates/components/chat-channel-selector-modal-inner.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-selector-modal-inner.hbs
@@ -4,11 +4,11 @@
       <span class="search-icon">
         {{d-icon "search"}}
       </span>
-      {{input id="chat-channel-selector-input" type="text" value=filter autocomplete="off"}}
+      {{input id="chat-channel-selector-input" type="text" onChange=(action "search") value=filter autocomplete="off"}}
     </div>
     <div class="channels">
-      {{#each filteredChannels as |channel|}}
-        {{chat-channel-row channel=channel switchChannel=switchChannel}}
+      {{#each channels as |channel|}}
+        {{chat-channel-selection-row model=channel onClick=switchChannel}}
       {{/each}}
     </div>
   </div>

--- a/assets/javascripts/discourse/templates/components/chat-channel-selector-modal-inner.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-selector-modal-inner.hbs
@@ -7,9 +7,11 @@
       {{input id="chat-channel-selector-input" type="text" onChange=(action "search") value=filter autocomplete="off"}}
     </div>
     <div class="channels">
-      {{#each channels as |channel|}}
-        {{chat-channel-selection-row model=channel onClick=switchChannel}}
-      {{/each}}
+      {{#conditional-loading-spinner condition=this.loading}}
+        {{#each channels as |channel|}}
+          {{chat-channel-selection-row model=channel onClick=switchChannel}}
+        {{/each}}
+      {{/conditional-loading-spinner}}
     </div>
   </div>
 {{/d-modal-body}}

--- a/assets/javascripts/discourse/templates/components/chat-channel-selector-modal-inner.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-selector-modal-inner.hbs
@@ -10,6 +10,8 @@
       {{#conditional-loading-spinner condition=this.loading}}
         {{#each channels as |channel|}}
           {{chat-channel-selection-row model=channel onClick=switchChannel}}
+        {{else}}
+          <div class="no-channels-notice">{{i18n "chat.channel_selector.no_channels"}}</div>
         {{/each}}
       {{/conditional-loading-spinner}}
     </div>

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -13,7 +13,7 @@
     {{#if previewing}}
       {{d-button
         class="btn-primary join-channel-btn"
-        action=joinChannel
+        action=(action "joinChannel")
         label="chat.join_channel"
       }}
     {{/if}}
@@ -30,6 +30,15 @@
 
 <div class="chat-messages-scroll chat-messages-container">
   {{#conditional-loading-spinner condition=this.loading}}
+
+    {{#if (and previewing (not fullPage))}}
+      {{d-button
+        class="btn-primary join-channel-btn in-float"
+        action=(action "joinChannel")
+        label="chat.join_channel"
+      }}
+    {{/if}}
+
     {{chat-retention-reminder chatChannel=chatChannel}}
     {{#each this.messages as |message|}}
       {{chat-message

--- a/assets/javascripts/discourse/templates/components/full-page-chat.hbs
+++ b/assets/javascripts/discourse/templates/components/full-page-chat.hbs
@@ -11,8 +11,6 @@
     expanded=true
     floatHidden=false
     fullPage=true
-    previewing=previewing
-    joinChannel=joinChannel
     onBackClick=(action "navigateToIndex")
   }}
 </div>

--- a/assets/stylesheets/common/chat-channel-selector-modal.scss
+++ b/assets/stylesheets/common/chat-channel-selector-modal.scss
@@ -32,19 +32,20 @@
     height: calc(100% - var(--chat-channel-selector-input-height));
     overflow: auto;
 
-    .chat-channel-row {
-      &.active {
-        background: none;
-      }
-      &:hover {
-        background: none;
-      }
+    .chat-channel-selection-row {
+      display: flex;
+      align-items: center;
+      height: 2.5em;
+      padding-left: 0.5em;
+
       &.focused {
         background: var(--primary-low);
       }
+      .username {
+        margin-left: 0.5em;
+      }
       .chat-channel-title {
         color: var(--primary-high);
-        padding-left: 0.5em;
       }
 
       .chat-channel-unread-indicator {

--- a/assets/stylesheets/common/chat-channel-selector-modal.scss
+++ b/assets/stylesheets/common/chat-channel-selector-modal.scss
@@ -32,6 +32,10 @@
     height: calc(100% - var(--chat-channel-selector-input-height));
     overflow: auto;
 
+    .no-channels-notice {
+      padding: 0.5em;
+    }
+
     .chat-channel-selection-row {
       display: flex;
       align-items: center;

--- a/assets/stylesheets/common/chat-retention-reminder.scss
+++ b/assets/stylesheets/common/chat-retention-reminder.scss
@@ -1,7 +1,7 @@
 .chat-retention-reminder {
   display: flex;
   position: absolute;
-  top: 15px;
+  top: 0;
   left: 50%;
   transform: translateX(-50%);
   align-items: center;

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -523,6 +523,14 @@ body.composer-open .topic-chat-float-container {
       }
     }
 
+    .join-channel-btn.in-float {
+      position: absolute;
+      transform: translateX(-50%);
+      left: 50%;
+      top: 10px;
+      z-index: 10;
+    }
+
     .all-loaded-message {
       text-align: center;
       color: var(--primary-medium);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -90,6 +90,7 @@ en:
 
       channel_selector:
         title: "Jump to channel"
+        no_channels: "No channels match your search"
 
       create_channel:
         choose_category:

--- a/plugin.rb
+++ b/plugin.rb
@@ -69,6 +69,7 @@ after_initialize do
   load File.expand_path('../app/serializers/chat_channel_serializer.rb', __FILE__)
   load File.expand_path('../app/serializers/chat_channel_settings_serializer.rb', __FILE__)
   load File.expand_path('../app/serializers/chat_channel_index_serializer.rb', __FILE__)
+  load File.expand_path('../app/serializers/chat_channel_search_serializer.rb', __FILE__)
   load File.expand_path('../app/serializers/direct_message_channel_serializer.rb', __FILE__)
   load File.expand_path('../app/serializers/incoming_chat_webhook_serializer.rb', __FILE__)
   load File.expand_path('../app/serializers/admin_chat_index_serializer.rb', __FILE__)
@@ -337,6 +338,7 @@ after_initialize do
     get '/chat_channels' => 'chat_channels#index'
     put '/chat_channels' => 'chat_channels#create'
     get '/chat_channels/all' => 'chat_channels#all'
+    get '/chat_channels/search' => 'chat_channels#search'
     post '/chat_channels/:chat_channel_id' => 'chat_channels#edit'
     post '/chat_channels/:chat_channel_id/notification_settings' => 'chat_channels#notification_settings'
     post '/chat_channels/:chat_channel_id/follow' => 'chat_channels#follow'

--- a/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
+++ b/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
@@ -43,6 +43,19 @@ if (!isLegacyEmber()) {
       server.post("/uploads/lookup-urls", () => {
         return helper.response([]);
       });
+
+      server.get("/chat/chat_channels/search", () => {
+        return helper.response({
+          public_channels: [{ id: 3, name: "seventeen" }],
+          direct_message_channels: [
+            { id: 4, users: [{ id: 10, username: "someone" }] },
+          ],
+          users: [
+            { id: 11, username: "smoothies" },
+            { id: 12, username: "server" },
+          ],
+        });
+      });
     });
 
     needs.settings({
@@ -65,20 +78,24 @@ if (!isLegacyEmber()) {
 
       // All 6 channels should show because the input is blank
       assert.equal(
-        queryAll("#chat-channel-selector-modal-inner .chat-channel-row").length,
+        queryAll(
+          "#chat-channel-selector-modal-inner .chat-channel-selection-row"
+        ).length,
         6
       );
 
       // Freaking keydown event isn't triggered by fillIn...
       // Next line manually keyup's "r" to make the keyup event run.
       // Fillin is needed for `this.filter` but triggerKeyEvent is needed to fire the JS event.
-      await fillIn("#chat-channel-selector-input", "mar");
-      await triggerKeyEvent("#chat-channel-selector-input", "keyup", 82);
+      await fillIn("#chat-channel-selector-input", "s");
+      await triggerKeyEvent("#chat-channel-selector-input", "keyup", 83);
       await settled();
-      // Only 2 channels match this filter now!
+      // Only 4 channels match this filter now!
       assert.equal(
-        queryAll("#chat-channel-selector-modal-inner .chat-channel-row").length,
-        2
+        queryAll(
+          "#chat-channel-selector-modal-inner .chat-channel-selection-row"
+        ).length,
+        4
       );
 
       await triggerKeyEvent(document.body, "keydown", 13); // Enter key
@@ -93,7 +110,7 @@ if (!isLegacyEmber()) {
       await showModal("chat-channel-selector-modal");
       await settled();
       await click(
-        "#chat-channel-selector-modal-inner .chat-channel-row.chat-channel-75"
+        "#chat-channel-selector-modal-inner .chat-channel-selection-row.channel-row[data-id='75']"
       );
       assert.notOk(exists("#chat-channel-selector-modal-inner"));
       assert.equal(currentURL(), "/chat/channel/75/@hawk");
@@ -106,12 +123,14 @@ if (!isLegacyEmber()) {
 
       // Only 5 channels now instead of 6.
       assert.equal(
-        queryAll("#chat-channel-selector-modal-inner .chat-channel-row").length,
+        queryAll(
+          "#chat-channel-selector-modal-inner .chat-channel-selection-row"
+        ).length,
         5
       );
       assert.notOk(
         exists(
-          "#chat-channel-selector-modal-inner .chat-channel-row.chat-channel-75"
+          "#chat-channel-selector-modal-inner .chat-channel-selection-row.chat-channel-75"
         )
       );
     });

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -1107,6 +1107,14 @@ acceptance(
       server.get("/chat/chat_channels/:chatChannelId", () => {
         return helper.response(siteChannel);
       });
+      server.get("/chat/chat_channels/70", () => {
+        return helper.response({
+          chat_channel: {
+            id: 70,
+            name: "preview-me",
+          },
+        });
+      });
       server.put("/chat/chat_channels", () => {
         return helper.response({
           chat_channel: {


### PR DESCRIPTION
This PR implements server-side filtering of results in the quick channel selection modal. The purpose of this, is that you can now start new DMs with user's who you haven't chatted with yet.

The search endpoint/response handling is quite complex. Some records are users, some are chat channels, so I created a new frontend component `chat-channel-selection-row` to handle these cases.

Other thing that is changed: Calculate `previewing` in chat-live-pane so that we can open previewed channels in the float. Add join channel btw to the float for previewed channels.


![Screen Shot 2022-02-01 at 11 34 16 AM](https://user-images.githubusercontent.com/16214023/152020173-15d74178-d64d-4b77-8cb4-2d0e705238ff.png)