### PR TITLE
UX: Make edited indicator subtler

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-message-text.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message-text.hbs
@@ -4,10 +4,4 @@
   {{html-safe cooked}}
 {{/if}}
 
-{{#if edited}}
-  <div class="chat-message-edited">
-    {{i18n "chat.edited"}}
-  </div>
-{{/if}}
-
 {{yield}}

--- a/assets/javascripts/discourse/templates/components/chat-message.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message.hbs
@@ -79,7 +79,14 @@
         {{/if}}
 
         {{#if hideUserInfo}}
-          {{format-chat-date message details "tiny"}}
+          <div class="chat-message-left-gutter">
+            {{format-chat-date message details "tiny"}}
+            {{#if message.edited}}
+              <div class="chat-message-edited">
+                {{d-icon "pencil-alt" title=(i18n "chat.edited")}}
+              </div>
+            {{/if}}
+          </div>
         {{else}}
           {{#if message.chat_webhook_event.emoji}}
             {{chat-emoji-avatar emoji=message.chat_webhook_event.emoji}}
@@ -106,6 +113,11 @@
               {{/if}}
 
               {{format-chat-date message details}}
+              {{#if message.edited}}
+                <div class="chat-message-edited">
+                  {{d-icon "pencil-alt" title=(i18n "chat.edited")}}
+                </div>
+              {{/if}}
             </div>
           {{/unless}}
 

--- a/assets/stylesheets/common/chat-message.scss
+++ b/assets/stylesheets/common/chat-message.scss
@@ -62,6 +62,13 @@
     }
   }
 
+  .chat-message-left-gutter {
+    width: var(--message-left-width);
+    .chat-message-edited {
+      padding-left: 0.6em;
+    }
+  }
+
   &.chat-action {
     background-color: var(--highlight-medium);
   }
@@ -88,7 +95,7 @@
       flex-shrink: 0;
       font-size: var(--font-down-2);
       margin-top: 0.4em;
-      visibility: hidden;
+      display: none;
       width: var(--message-left-width);
     }
 
@@ -174,7 +181,7 @@
   .chat-message-edited {
     display: inline-block;
     color: var(--primary-medium);
-    font-size: var(--font-down-1);
+    font-size: var(--font-down-2);
   }
 
   .chat-message-reaction-list {
@@ -438,7 +445,10 @@
   .not-mobile-device & .user-info-hidden:hover,
   .user-info-hidden.chat-message-selected {
     .chat-time {
-      visibility: visible;
+      display: inline-block;
+    }
+    .chat-message-edited {
+      display: none;
     }
   }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -21,7 +21,7 @@ en:
       collapse: "Collapse Chat Drawer"
       deleted: "A message was deleted. [view]"
       delete: "Delete"
-      edited: "(edited)"
+      edited: "edited"
       empty_state:
         create_personal_chat: "Start a Personal Chat"
         no_public_available: "There are no public channels available for you to follow at this time."

--- a/test/javascripts/components/chat-message-text-test.js
+++ b/test/javascripts/components/chat-message-text-test.js
@@ -10,7 +10,7 @@ discourseModule(
     setupRenderingTest(hooks);
 
     componentTest("yields", {
-      template: hbs`{{#chat-message-text cooked=cooked uploads=uploads edited=edited}} <div class="yield-me"></div> {{/chat-message-text}}`,
+      template: hbs`{{#chat-message-text cooked=cooked uploads=uploads}} <div class="yield-me"></div> {{/chat-message-text}}`,
 
       beforeEach() {
         this.set("cooked", "<p></p>");
@@ -22,7 +22,7 @@ discourseModule(
     });
 
     componentTest("shows collapsed", {
-      template: hbs`{{chat-message-text cooked=cooked uploads=uploads edited=edited}}`,
+      template: hbs`{{chat-message-text cooked=cooked uploads=uploads}}`,
 
       beforeEach() {
         this.set(
@@ -48,31 +48,6 @@ discourseModule(
 
       async test(assert) {
         assert.notOk(exists(".chat-message-collapser"));
-      },
-    });
-
-    componentTest("is edited and shows that it's edited", {
-      template: hbs`{{chat-message-text cooked=cooked uploads=uploads edited=edited}}`,
-
-      beforeEach() {
-        this.set("cooked", "<p></p>");
-        this.set("edited", true);
-      },
-
-      async test(assert) {
-        assert.ok(exists(".chat-message-edited"));
-      },
-    });
-
-    componentTest("is not edited and does not show", {
-      template: hbs`{{chat-message-text cooked=cooked uploads=uploads edited=edited}}`,
-
-      beforeEach() {
-        this.set("cooked", "<p></p>");
-      },
-
-      async test(assert) {
-        assert.notOk(exists(".chat-message-edited"));
       },
     });
   }


### PR DESCRIPTION
Makes edit subtler and consistent with the edit indicator elsewhere in Discourse.

![image](https://user-images.githubusercontent.com/1385470/152230678-86803247-df90-4545-ae5a-fcc731a994ae.png)
