### PR TITLE
FIX: Use Site.markdown_additional_options

### DIFF
--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -124,8 +124,12 @@ export default Service.extend({
     }
 
     const prettyTextFeatures = {
-      featuresOverride: Site.currentProp("chat_pretty_text_features"),
-      markdownItRules: Site.currentProp("chat_pretty_text_markdown_rules"),
+      featuresOverride: Site.currentProp(
+        "markdown_additional_options.chat.limited_pretty_text_features"
+      ),
+      markdownItRules: Site.currentProp(
+        "markdown_additional_options.chat.limited_pretty_text_markdown_rules"
+      ),
     };
 
     return generateCookFunction(prettyTextFeatures).then((cookFunction) => {


### PR DESCRIPTION
This was missed in the 034cd64c67b1adfe055282b0ed472cbc4eef80aa
change, Site.markdown_additional_options needs to be used instead
of the old site serializer additions from the plugin.