### PR TITLE
FEATURE: Add multiquote and chained attrs for chat-transcript

### DIFF
--- a/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/assets/javascripts/discourse/initializers/chat-setup.js
@@ -49,28 +49,33 @@ export default {
 
       api.addToHeaderIcons("header-chat-link");
 
-      api.decorateCookedElement((elem) => {
-        const currentUserTimezone = currentUser?.resolvedTimezone(currentUser);
-        const chatTranscriptElements = elem.querySelectorAll(
-          ".discourse-chat-transcript"
-        );
-        chatTranscriptElements.forEach((el) => {
-          const dateTimeRaw = el.dataset["datetime"];
-          const dateTimeLinkEl = el.querySelector(
-            ".chat-transcript-datetime a"
+      api.decorateCookedElement(
+        (elem) => {
+          const currentUserTimezone = currentUser?.resolvedTimezone(
+            currentUser
           );
-
-          if (currentUserTimezone) {
-            dateTimeLinkEl.innerText = moment
-              .tz(dateTimeRaw, currentUserTimezone)
-              .format(I18n.t("dates.long_no_year"));
-          } else {
-            dateTimeLinkEl.innerText = moment(dateTimeRaw).format(
-              I18n.t("dates.long_no_year")
+          const chatTranscriptElements = elem.querySelectorAll(
+            ".discourse-chat-transcript"
+          );
+          chatTranscriptElements.forEach((el) => {
+            const dateTimeRaw = el.dataset["datetime"];
+            const dateTimeLinkEl = el.querySelector(
+              ".chat-transcript-datetime a"
             );
-          }
-        });
-      }, { id: "chat-transcript-datetime" });
+
+            if (currentUserTimezone) {
+              dateTimeLinkEl.innerText = moment
+                .tz(dateTimeRaw, currentUserTimezone)
+                .format(I18n.t("dates.long_no_year"));
+            } else {
+              dateTimeLinkEl.innerText = moment(dateTimeRaw).format(
+                I18n.t("dates.long_no_year")
+              );
+            }
+          });
+        },
+        { id: "chat-transcript-datetime" }
+      );
     });
   },
 

--- a/assets/javascripts/discourse/routes/chat-channel-by-name.js
+++ b/assets/javascripts/discourse/routes/chat-channel-by-name.js
@@ -1,6 +1,5 @@
 import DiscourseRoute from "discourse/routes/discourse";
-import Promise from "rsvp";
-import EmberObject, { action } from "@ember/object";
+import { defaultHomepage } from "discourse/lib/utilities";
 import { ajax } from "discourse/lib/ajax";
 import { inject as service } from "@ember/service";
 export default DiscourseRoute.extend({

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -124,8 +124,12 @@ export default Service.extend({
     }
 
     const prettyTextFeatures = {
-      featuresOverride: Site.currentProp("chat_pretty_text_features"),
-      markdownItRules: Site.currentProp("chat_pretty_text_markdown_rules"),
+      featuresOverride: Site.currentProp(
+        "markdown_additional_options.chat.limited_pretty_text_features"
+      ),
+      markdownItRules: Site.currentProp(
+        "markdown_additional_options.chat.limited_pretty_text_markdown_rules"
+      ),
     };
 
     return generateCookFunction(prettyTextFeatures).then((cookFunction) => {

--- a/assets/stylesheets/common/chat-transcript.scss
+++ b/assets/stylesheets/common/chat-transcript.scss
@@ -3,8 +3,23 @@
   border: 1px solid $primary-low;
   min-height: 50px;
   padding: 12px;
+  margin: 1em 0;
 
   @include post-aside;
+
+  &.chat-transcript-chained {
+    margin: 0;
+    border-top: 0;
+    border-bottom: 0;
+
+    &:first-of-type {
+      border-top: 1px solid $primary-low;
+    }
+
+    &:last-of-type {
+      border-bottom: 1px solid $primary-low;
+    }
+  }
 
   .chat-transcript-meta {
     color: var(--primary-high);
@@ -12,6 +27,11 @@
     border-bottom: 1px solid var(--primary-low);
     margin-bottom: 1em;
     padding-bottom: 0.5em;
+  }
+
+  .chat-transcript-channel {
+    font-size: var(--font-down-2);
+    padding-left: 0.5em;
   }
 
   .chat-transcript-username {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -117,7 +117,7 @@ en:
         toggle_toolbar: "Toggle toolbar"
 
       quote:
-        original_channel: "Originally sent in #%{channel}."
+        original_channel: "Originally sent in <a href=\"%{channelLink}\">#%{channel}</a>."
 
       notification_levels:
         never: "Never"

--- a/spec/requests/chat_channel_controller_spec.rb
+++ b/spec/requests/chat_channel_controller_spec.rb
@@ -478,7 +478,7 @@ RSpec.describe DiscourseChat::ChatChannelsController do
 
     it "can find channel by name" do
       sign_in(user)
-      get "/chat/chat_channels/#{URI.encode("My Great Channel & Stuff")}.json"
+      get "/chat/chat_channels/#{UrlHelper.encode_component("My Great Channel & Stuff")}.json"
       expect(response.status).to eq(200)
       expect(response.parsed_body["chat_channel"]["id"]).to eq(channel.id)
     end
@@ -488,7 +488,7 @@ RSpec.describe DiscourseChat::ChatChannelsController do
       sign_in(user)
       get "/chat/chat_channels/#{channel.id}.json"
       expect(response.status).to eq(404)
-      get "/chat/chat_channels/#{URI.encode(channel.name)}.json"
+      get "/chat/chat_channels/#{UrlHelper.encode_component(channel.name)}.json"
       expect(response.status).to eq(404)
     end
   end

--- a/test/javascripts/acceptance/chat-transcript-test.js
+++ b/test/javascripts/acceptance/chat-transcript-test.js
@@ -77,7 +77,7 @@ ${opts.username}</div>
 
   if (opts.channel && !opts.multiQuote) {
     transcript.push(
-      `<a class=\"chat-transcript-channel\" href="/chat/channel/${encodeURIComponent(
+      `<a class=\"chat-transcript-channel\" href="/chat/chat_channels/${encodeURIComponent(
         opts.channel.toLowerCase()
       )}">
 #${opts.channel}</a></div>`

--- a/test/javascripts/acceptance/chat-transcript-test.js
+++ b/test/javascripts/acceptance/chat-transcript-test.js
@@ -54,7 +54,11 @@ function generateTranscriptHTML(messageContent, opts) {
 
   const transcript = [];
   transcript.push(
-    `<div class=\"${transcriptClasses.join(" ")}\" data-message-id=\"${opts.messageId}\" data-username=\"${opts.username}\" data-datetime=\"${opts.datetime}\"${channelDataAttr}>`
+    `<div class=\"${transcriptClasses.join(" ")}\" data-message-id=\"${
+      opts.messageId
+    }\" data-username=\"${opts.username}\" data-datetime=\"${
+      opts.datetime
+    }\"${channelDataAttr}>`
   );
 
   if (opts.channel && opts.multiQuote) {


### PR DESCRIPTION
The multiQuote attribute for [chat] makes the channel name show
above the username + datetime. If the channel name is provided
and the multiQuote attribute is not present or false, then the
channel name is put to the right of the datetime of the chat message.
This commit also links to the chat channel by name and the corresponding
ember route.

```
[chat quote="martin;155;2022-01-25T05:40:39Z" channel="Staff" multiQuote="true"]
a chat message for multi quote

that goes over several

messages
[/chat]

[chat quote="lowell_jacobi;4;2022-01-25T05:41:39Z" channel="Arts & Media"]
wow this is a whole new quote from a different channel
[/chat]

[chat quote="hunter;4;2022-01-25T05:41:39Z"]
this is someone else responding in some channel we have no idea about
[/chat]
```

![image](https://user-images.githubusercontent.com/920448/152706720-5436393c-b387-4601-b626-21b044fdfd51.png)

Also in this commit is the chained CSS class that can be added
to `[chat]`. This is used on subsequent messages from the same
channel so no margin is added to the chat messages, making them
all stick together with CSS. This is added via a new `chained` attribute
on the BBCode.