### PR TITLE
FIX: User could not re-enable chat after disabling it

### DIFF
--- a/assets/javascripts/discourse/controllers/preferences-chat.js
+++ b/assets/javascripts/discourse/controllers/preferences-chat.js
@@ -1,4 +1,5 @@
 import Controller from "@ember/controller";
+import { isTesting } from "discourse-common/config/environment";
 import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "I18n";
 import { action } from "@ember/object";
@@ -22,7 +23,7 @@ export default Controller.extend({
 
   @action
   onChangeChatSound(sound) {
-    if (sound) {
+    if (sound && !isTesting()) {
       const audio = new Audio(CHAT_SOUNDS[sound]);
       audio.play();
     }
@@ -36,7 +37,9 @@ export default Controller.extend({
       .save(chatAttrs)
       .then(() => {
         this.set("saved", true);
-        location.reload();
+        if (!isTesting()) {
+          location.reload();
+        }
       })
       .catch(popupAjaxError);
   },

--- a/assets/javascripts/discourse/initializers/chat-user-options.js
+++ b/assets/javascripts/discourse/initializers/chat-user-options.js
@@ -10,8 +10,8 @@ export default {
 
   initialize(container) {
     withPluginApi("0.11.0", (api) => {
-      const chatService = container.lookup("service:chat");
-      if (chatService.userCanChat) {
+      const siteSettings = container.lookup("site-settings:main");
+      if (siteSettings.chat_enabled) {
         api.addSaveableUserOptionField(CHAT_ENABLED_FIELD);
         api.addSaveableUserOptionField(CHAT_ISOLATED_FIELD);
         api.addSaveableUserOptionField(ONLY_CHAT_PUSH_NOTI_FIELD);

--- a/assets/javascripts/discourse/templates/preferences/chat.hbs
+++ b/assets/javascripts/discourse/templates/preferences/chat.hbs
@@ -3,6 +3,7 @@
 <div class="control-group chat-setting">
   <label class="controls">
     {{input
+      id="user_chat_enabled"
       type="checkbox"
       checked=model.user_option.chat_enabled
     }}
@@ -13,6 +14,7 @@
 <div class="control-group chat-setting">
   <label class="controls">
     {{input
+      id="user_chat_only_push_notifications"
       type="checkbox"
       checked=model.user_option.only_chat_push_notifications
     }}
@@ -24,6 +26,7 @@
 <div class="control-group chat-setting">
   <label class="controls">
     {{input
+      id="user_chat_isolated"
       type="checkbox"
       checked=model.user_option.chat_isolated
     }}
@@ -33,15 +36,15 @@
 </div>
 
 <div class="control-group chat-setting controls-dropdown">
-  <label for="chat-sounds">{{i18n "chat.sound.title"}}</label>
+  <label for="user_chat_sounds">{{i18n "chat.sound.title"}}</label>
   {{combo-box
     none="chat.sounds.none"
     valueProperty="value"
     content=chatSounds
     value=model.user_option.chat_sound
-    id="chat-sounds"
+    id="user_chat_sounds"
     onChange=(action "onChangeChatSound")
   }}
 </div>
 
-{{save-controls model=model action=(action "save") saved=saved}}
+{{save-controls id="user_chat_preference_save" model=model action=(action "save") saved=saved}}

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -1230,7 +1230,7 @@ acceptance("Discourse Chat - chat preferences", function (needs) {
 
   test("The user can save the settings", async function (assert) {
     updateCurrentUser({ has_chat_enabled: false });
-    let spy = sinon.spy(ajaxlib, "ajax");
+    const spy = sinon.spy(ajaxlib, "ajax");
     await visit("/u/eviltrout/preferences/chat");
     await click("#user_chat_enabled");
     await click("#user_chat_only_push_notifications");


### PR DESCRIPTION
In 18f45fc4c695407dec3df29edd3f163e86e17aab we made a change to not
call addSaveableUserOptionField for the chat-specific user options
if !userCanChat. However, this prevents the user from changing their
chat preferences if they disable chat and press save. They are not able
to re-enable it or change any other settings, because the user options
are no longer added.