### PR TITLE
FIX: Prevent youtube from being gigantic

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-message-collapser.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message-collapser.hbs
@@ -12,7 +12,9 @@
     {{#each youtubeCooked as |cooked|}}
       {{#if cooked.needsCollapser}}
         {{#collapser header=cooked.header}}
-          {{cooked.body}}
+          <div class="chat-message-collapser-youtube">
+            {{cooked.body}}
+          </div>
         {{/collapser}}
       {{else}}
         {{cooked.body}}

--- a/assets/stylesheets/common/chat-message-collapser.scss
+++ b/assets/stylesheets/common/chat-message-collapser.scss
@@ -1,3 +1,5 @@
+$max_image_height: 150px;
+
 .chat-message-collapser {
   .chat-message-collapser-header {
     display: flex;
@@ -40,9 +42,15 @@
   img.onebox,
   .chat-uploads img {
     object-fit: contain;
-    max-height: 150px;
+    max-height: $max_image_height;
     max-width: 100%;
 
     width: unset;
+  }
+
+  .chat-message-collapser-header + div .chat-message-collapser-youtube {
+    object-fit: contain;
+    height: $max_image_height;
+    width: 266px;
   }
 }

--- a/assets/stylesheets/common/chat-message-collapser.scss
+++ b/assets/stylesheets/common/chat-message-collapser.scss
@@ -51,6 +51,6 @@ $max_image_height: 150px;
   .chat-message-collapser-header + div .chat-message-collapser-youtube {
     object-fit: contain;
     height: $max_image_height;
-    width: 266px;
+    width: calc(#{$max_image_height} / 9 * 16);
   }
 }


### PR DESCRIPTION
There's currently no sizing for youtube so everything's gigantic. This adds some fixed styles to youtube oneboxes with this assumption https://support.google.com/youtube/answer/6375112:

> The standard aspect ratio for YouTube on a computer is 16:9. If your video has a different aspect ratio, the player will automatically change to the ideal size to match your video and the viewer’s device. 

Images are currently set to a max height of 150px, so we're basing our 16:9 off that value. Here's an example of the player doing padding (based on link above)

> For some video and device aspects ratios like 9:16 vertical videos on computer browsers, YouTube may add more padding for optimal viewing.

<img width="479" alt="Screenshot 2022-02-07 at 1 11 21 PM" src="https://user-images.githubusercontent.com/1555215/152727987-9b2a44cf-8b3f-468f-9a63-f9a20e6952c5.png">

