### PR TITLE
FIX: Don't collapse emoji images

### DIFF
--- a/assets/javascripts/discourse/components/chat-message-collapser.js
+++ b/assets/javascripts/discourse/components/chat-message-collapser.js
@@ -154,7 +154,8 @@ function imagePredicate(e) {
   return (
     e.nodeName === "P" &&
     e.firstElementChild &&
-    e.firstElementChild.nodeName === "IMG"
+    e.firstElementChild.nodeName === "IMG" &&
+    !e.firstElementChild.classList.contains("emoji")
   );
 }
 

--- a/test/javascripts/components/chat-message-collapser-test.js
+++ b/test/javascripts/components/chat-message-collapser-test.js
@@ -35,7 +35,8 @@ const imageCooked =
   '<p><img src="http://cat1.com" alt="shows alt"></p>' +
   "<p>more written text</p>" +
   '<p><img src="http://cat2.com" alt=""></p>' +
-  "<p>and even more</p>";
+  "<p>and even more</p>" +
+  '<p><img src="http://cat3.com" class="emoji"></p>';
 
 discourseModule(
   "Discourse Chat | Component | chat message collapser youtube",
@@ -437,7 +438,7 @@ discourseModule(
       async test(assert) {
         const text = document.querySelectorAll(".chat-message-collapser p");
 
-        assert.equal(text.length, 5, "shows all written text");
+        assert.equal(text.length, 6, "shows all written text");
         assert.strictEqual(text[0].innerText, "written text");
         assert.strictEqual(text[2].innerText, "more written text");
         assert.strictEqual(text[4].innerText, "and even more");
@@ -454,7 +455,7 @@ discourseModule(
       async test(assert) {
         const images = document.querySelectorAll("img");
 
-        assert.equal(images.length, 2, "two images rendered");
+        assert.equal(images.length, 3);
 
         await click(
           document.querySelectorAll(".chat-message-collapser-opened")[0],
@@ -472,7 +473,7 @@ discourseModule(
 
         await click(".chat-message-collapser-closed");
 
-        assert.equal(images.length, 2, "two images rendered");
+        assert.equal(images.length, 3);
 
         await click(
           document.querySelectorAll(".chat-message-collapser-opened")[1],
@@ -490,7 +491,29 @@ discourseModule(
 
         await click(".chat-message-collapser-closed");
 
-        assert.equal(images.length, 2, "two images rendered");
+        assert.equal(images.length, 3);
+      },
+    });
+
+    componentTest("does not show collapser for emoji images", {
+      template: hbs`{{chat-message-collapser cooked=cooked}}`,
+
+      beforeEach() {
+        this.set("cooked", imageCooked);
+      },
+
+      async test(assert) {
+        const links = document.querySelectorAll(
+          "a.chat-message-collapser-link-small"
+        );
+        const images = document.querySelectorAll("img");
+        const collapser = document.querySelectorAll(
+          ".chat-message-collapser-opened"
+        );
+
+        assert.equal(links.length, 2);
+        assert.equal(images.length, 3, "shows images and emoji");
+        assert.equal(collapser.length, 2);
       },
     });
   }


### PR DESCRIPTION
Unfortunately due to the way we are detecting which elements need collapsing, I've also caused messages with emoji to be collapsible.

Other occurrences may happen so we just have to exclude them from the predicate.

### before:
<img width="186" alt="Screenshot 2022-02-07 at 2 57 23 PM" src="https://user-images.githubusercontent.com/1555215/152740402-c2a5db8b-4d74-4767-a523-2918ec5428ca.png">

### after:
<img width="173" alt="Screenshot 2022-02-07 at 3 02 18 PM" src="https://user-images.githubusercontent.com/1555215/152740414-403af89e-287c-4b5f-8457-a52fc5cab91d.png">

