### PR TITLE
FIX: Prevent update read timer from stalling

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -75,12 +75,6 @@ export default Component.extend({
       "highlightOrFetchMessage"
     );
 
-    if (!isTesting()) {
-      next(this, () => {
-        this._updateReadTimer = this._updateLastReadMessage();
-      });
-    }
-
     this._scrollerEl = this.element.querySelector(".chat-messages-scroll");
     this._scrollerEl.addEventListener(
       "scroll",
@@ -139,6 +133,7 @@ export default Component.extend({
             this.set("previewing", !Boolean(trackedChannel));
             this.fetchMessages(this.chatChannel.id);
             this.loadDraftForChannel(this.chatChannel.id);
+            this._startLastReadRunner();
           });
       }
     }
@@ -678,6 +673,7 @@ export default Component.extend({
     return !this.element || this.isDestroying || this.isDestroyed;
   },
 
+  @bind
   _updateLastReadMessage() {
     if (this._selfDeleted()) {
       return;
@@ -721,6 +717,19 @@ export default Component.extend({
 
   _floatOpenAndFocused() {
     return userPresent() && this.expanded && !this.floatHidden;
+  },
+
+  _startLastReadRunner() {
+    if (!isTesting()) {
+      cancel(this._updateReadTimer);
+      next(this, () => {
+        this._updateLastReadMessage();
+        this._updateReadTimer = later(
+          this._updateLastReadMessage,
+          READ_INTERVAL
+        );
+      });
+    }
   },
 
   _stopLastReadRunner() {

--- a/lib/chat_channel_fetcher.rb
+++ b/lib/chat_channel_fetcher.rb
@@ -18,7 +18,6 @@ module DiscourseChat::ChatChannelFetcher
 
   def self.secured_public_channels(guardian, memberships, scope_with_membership: true)
     channels = ChatChannel.includes(:chatable)
-
     channels = channels.where(chatable_type: ChatChannel.public_channel_chatable_types)
     if scope_with_membership
       channels = channels
@@ -37,7 +36,6 @@ module DiscourseChat::ChatChannelFetcher
 
     preload_fields = Topic.instance_variable_get(:@custom_field_types).keys
     Topic.preload_custom_fields(channels.select { |c| c.chatable_type == 'Topic' }.map(&:chatable), preload_fields)
-
   end
 
   def self.public_channels_with_filter(guardian, memberships, filter)


### PR DESCRIPTION
Currently the `_updateReadTimer` is set in `willIInsertElement`, and if something goes wrong and the timer is canceled, it will only be started again if the component is destroyed and re-created. Changing channels does not fix this.

This moves the initialization of `updateReadTimer` into a function called on channel change.