### PR TITLE
FEATURE: Add simple composer shortcuts

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -143,6 +143,19 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
       this,
       "_insertUpload"
     );
+
+    this.appEvents.on("chat:modify-selection", this, "_modifySelection");
+  },
+
+  _modifySelection(opts = { type: null }) {
+    const sel = this._getSelected("", { lineVal: true });
+    if (opts.type === "bold") {
+      this._applySurround(sel, "**", "**", "bold_text");
+    } else if (opts.type === "italic") {
+      this._applySurround(sel, "_", "_", "italic_text");
+    } else if (opts.type === "code") {
+      this._applySurround(sel, "`", "`", "code_text");
+    }
   },
 
   willDestroyElement() {
@@ -173,6 +186,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
     );
 
     this.appEvents.off("chat:focus-composer", this, "_focusTextArea");
+    this.appEvents.off("chat:modify-selection", this, "_modifySelection");
   },
 
   _insertUpload(_, upload) {

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -148,13 +148,13 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   },
 
   _modifySelection(opts = { type: null }) {
-    const sel = this._getSelected("", { lineVal: true });
+    const sel = this.getSelected("", { lineVal: true });
     if (opts.type === "bold") {
-      this._applySurround(sel, "**", "**", "bold_text");
+      this.applySurround(sel, "**", "**", "bold_text");
     } else if (opts.type === "italic") {
-      this._applySurround(sel, "_", "_", "italic_text");
+      this.applySurround(sel, "_", "_", "italic_text");
     } else if (opts.type === "code") {
-      this._applySurround(sel, "`", "`", "code_text");
+      this.applySurround(sel, "`", "`", "code_text");
     }
   },
 
@@ -209,7 +209,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
       // Ctrl+Enter, plain Enter: send
       if (!event.ctrlKey) {
         // if we are inside a code block just insert newline
-        const { pre } = this._getSelected(null, { lineVal: true });
+        const { pre } = this.getSelected(null, { lineVal: true });
         if (this._isInside(pre, /(^|\n)```/g)) {
           return;
         }
@@ -502,7 +502,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   },
 
   addText(text) {
-    const selected = this._getSelected(null, {
+    const selected = this.getSelected(null, {
       lineVal: true,
     });
     this._addText(selected, text);

--- a/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
+++ b/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
@@ -32,6 +32,16 @@ export default {
       chatService.switchChannelUpOrDown("down");
     };
 
+    const isChatComposer = (el) => el.classList.contains("chat-composer-input");
+    const modifyComposerSelection = (event, type) => {
+      if (!isChatComposer(event.target)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      appEvents.trigger("chat:modify-selection", { type });
+    };
+
     withPluginApi("0.12.1", (api) => {
       api.addKeyboardShortcut("command+k", openChannelSelector, {
         global: true,
@@ -41,6 +51,22 @@ export default {
       api.addKeyboardShortcut("alt+down", handleMoveDownShortcut, {
         global: true,
       });
+
+      api.addKeyboardShortcut(
+        "ctrl+b",
+        (event) => modifyComposerSelection(event, "bold"),
+        { global: true }
+      );
+      api.addKeyboardShortcut(
+        "ctrl+i",
+        (event) => modifyComposerSelection(event, "italic"),
+        { global: true }
+      );
+      api.addKeyboardShortcut(
+        "ctrl+e",
+        (event) => modifyComposerSelection(event, "code"),
+        { global: true }
+      );
     });
   },
 };

--- a/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
+++ b/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
@@ -43,27 +43,29 @@ export default {
     };
 
     withPluginApi("0.12.1", (api) => {
-      api.addKeyboardShortcut("command+k", openChannelSelector, {
+      const mac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+      const mod = mac ? "meta" : "ctrl";
+
+      api.addKeyboardShortcut(`${mod}+k`, openChannelSelector, {
         global: true,
       });
-      api.addKeyboardShortcut("ctrl+k", openChannelSelector, { global: true });
       api.addKeyboardShortcut("alt+up", handleMoveUpShortcut, { global: true });
       api.addKeyboardShortcut("alt+down", handleMoveDownShortcut, {
         global: true,
       });
 
       api.addKeyboardShortcut(
-        "ctrl+b",
+        `${mod}+b`,
         (event) => modifyComposerSelection(event, "bold"),
         { global: true }
       );
       api.addKeyboardShortcut(
-        "ctrl+i",
+        `${mod}+i`,
         (event) => modifyComposerSelection(event, "italic"),
         { global: true }
       );
       api.addKeyboardShortcut(
-        "ctrl+e",
+        `${mod}+e`,
         (event) => modifyComposerSelection(event, "code"),
         { global: true }
       );

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -121,6 +121,9 @@ en:
 
       composer:
         toggle_toolbar: "Toggle toolbar"
+        italic_text: "emphasized text"
+        bold_title: "Strong"
+        code_text: "indent preformatted text by 4 spaces"
 
       quote:
         original_channel: "Originally sent in <a href=\"%{channelLink}\">#%{channel}</a>."

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -122,7 +122,7 @@ en:
       composer:
         toggle_toolbar: "Toggle toolbar"
         italic_text: "emphasized text"
-        bold_title: "Strong"
+        bold_text: "strong text"
         code_text: "indent preformatted text by 4 spaces"
 
       quote:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -123,7 +123,7 @@ en:
         toggle_toolbar: "Toggle toolbar"
         italic_text: "emphasized text"
         bold_text: "strong text"
-        code_text: "indent preformatted text by 4 spaces"
+        code_text: "code text"
 
       quote:
         original_channel: "Originally sent in <a href=\"%{channelLink}\">#%{channel}</a>."


### PR DESCRIPTION
This commit adds the simplest "surround" formatting shortcuts
from the composer into the chat composer:

* ctrl+b - bold selection
* ctrl+i - italicize selection
* ctrl+e - inline code selection

These shortcuts only work when the chat composer is focused.

Requires https://github.com/discourse/discourse/pull/15950 to work.