### PR TITLE
UX: Fix style inconsistencies in chat quoting

### DIFF
--- a/assets/stylesheets/common/chat-transcript.scss
+++ b/assets/stylesheets/common/chat-transcript.scss
@@ -1,9 +1,8 @@
 .discourse-chat-transcript {
   @extend .chat-message-container;
-  border: 1px solid $primary-low;
   min-height: 50px;
   padding: 12px;
-  margin: 1em 0;
+  margin: 1rem 0;
 
   @include post-aside;
 
@@ -11,45 +10,41 @@
     margin: 0;
     border-top: 0;
     border-bottom: 0;
-
-    &:first-of-type {
-      border-top: 1px solid $primary-low;
-    }
-
-    &:last-of-type {
-      border-bottom: 1px solid $primary-low;
-    }
   }
 
   .chat-transcript-meta {
     color: var(--primary-high);
-    font-size: var(--font-down-3);
+    font-size: var(--font-down-2-rem);
     border-bottom: 1px solid var(--primary-low);
-    margin-bottom: 1em;
-    padding-bottom: 0.5em;
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
   }
 
   .chat-transcript-channel {
-    font-size: var(--font-down-2);
-    padding-left: 0.5em;
+    font-size: var(--font-down-2-rem);
+    padding-left: 0.5rem;
   }
 
   .chat-transcript-username {
+    color: var(--primary-high-or-secondary-low);
     font-weight: bold;
   }
 
   .chat-transcript-datetime {
     color: var(--primary-high);
+    font-size: var(--font-down-2-rem);
+    padding-left: 0.5rem;
 
     a {
       color: var(--primary-high);
     }
-
-    font-size: var(--font-down-2);
-    padding-left: 0.5em;
   }
 
   .chat-transcript-messages {
+    p {
+      margin: 0.5rem 0;
+    }
+
     p:last-of-type {
       margin-bottom: 0;
     }
@@ -57,10 +52,10 @@
 
   .chat-transcript-user {
     display: flex;
-    align-items: center;
+    align-items: baseline;
 
     .chat-transcript-user-avatar {
-      padding-right: 0.5em;
+      padding-right: 0.5rem;
     }
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -123,7 +123,7 @@ en:
         toggle_toolbar: "Toggle toolbar"
 
       quote:
-        original_channel: "Originally sent in <a href=\"%{channelLink}\">#%{channel}</a>."
+        original_channel: 'Originally sent in <a href="%{channelLink}">#%{channel}</a>'
         copy_success: "Chat quote copied to clipboard."
 
       notification_levels:
@@ -246,4 +246,3 @@ en:
         reviewable_chat_message:
           title: "Flagged Chat Message"
           flagged_by: "Flagged By"
-


### PR DESCRIPTION
* Got rid of the border to match the regular quotes (btw. always use `var(--x)`, never `$x`; that's why it was broken on dark theme 😃)
* Changed the username color to match regular quotes
* Fixed timestamp alignment
* Increased the minimal font size (header)
* Removed the period after the channel link
* Made the margins of `<p>` elements smaller

Before / After

<img width="714" alt="Screen Shot 2022-02-15 at 11 52 03" src="https://user-images.githubusercontent.com/66961/154047602-34beb8f2-f0b6-457c-a134-9de5e4e109e2.png">

<img width="714" alt="Screen Shot 2022-02-15 at 11 51 13" src="https://user-images.githubusercontent.com/66961/154047617-08aae4bc-6d21-4ef0-9703-21ec42f30072.png">

