### PR TITLE
FEATURE: Notify chat message users on quote

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -211,14 +211,18 @@ en:
         dm: "Personal chat history is retained for %{days} days."
 
     notifications:
+      chat_quoted: "<span>%{username}</span> %{description}"
+
       popup:
         chat_mention: "%{username} mentioned you in chat"
         chat_group_mention: "%{username} mentioned @%{groupName} in chat"
         chat_message: "New chat message"
+        chat_quoted: "%{username} quoted your chat message"
 
       titles:
         chat_mention: "Chat mention"
         chat_invitation: "Chat invitation"
+        chat_quoted: "Chat quoted"
     topic:
       actions:
         chat_enable: "Enable Chat"

--- a/lib/post_notification_handler.rb
+++ b/lib/post_notification_handler.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+##
+# Handles :post_alerter_after_save_post events from
+# core. Used for notifying users that their chat message
+# has been quoted in a post.
+class DiscourseChat::PostNotificationHandler
+  attr_reader :post
+
+  def initialize(post, notified_users)
+    @post = post
+    @notified_users = notified_users
+  end
+
+  def handle
+    return false if post.post_type == Post.types[:whisper]
+    return false if post.topic.blank?
+    return false if post.topic.private_message?
+
+    quoted_users = extract_quoted_users(post)
+    if @notified_users.present?
+      quoted_users = quoted_users.where("users.id NOT IN (?)", @notified_users)
+    end
+
+    opts = { user_id: post.user.id, display_username: post.user.username }
+    quoted_users.each do |user|
+
+      # PostAlerter.create_notification handles many edge cases, such as
+      # muting, ignoring, double notifications etc.
+      PostAlerter.new.create_notification(
+        user,
+        Notification.types[:chat_quoted],
+        post,
+        opts
+      )
+    end
+  end
+
+  private
+
+  def extract_quoted_users(post)
+    usernames = post.raw.scan(/\[chat quote=\"([^;]+);.+\"\]/).uniq.map { |q| q.first.strip.downcase }
+    User.where.not(id: post.user_id).where(username_lower: usernames)
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -91,6 +91,7 @@ after_initialize do
   load File.expand_path('../lib/extensions/topic_view_serializer_extension.rb', __FILE__)
   load File.expand_path('../lib/extensions/detailed_tag_serializer_extension.rb', __FILE__)
   load File.expand_path('../lib/slack_compatibility.rb', __FILE__)
+  load File.expand_path('../lib/post_notification_handler.rb', __FILE__)
   load File.expand_path('../app/jobs/regular/process_chat_message.rb', __FILE__)
   load File.expand_path('../app/jobs/regular/create_chat_mention_notifications.rb', __FILE__)
   load File.expand_path('../app/jobs/regular/notify_users_watching_chat.rb', __FILE__)
@@ -261,7 +262,7 @@ after_initialize do
     chat_channel_retention_days: :dismissed_channel_retention_reminder,
     chat_dm_retention_days: :dismissed_dm_retention_reminder
   }
-  DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
+  on(:site_setting_changed) do |name, old_value, new_value|
     user_option_field = RETENTION_SETTINGS_TO_USER_OPTION_FIELDS[name.to_sym]
     begin
       if user_option_field && old_value != new_value && !new_value.zero?
@@ -270,6 +271,11 @@ after_initialize do
     rescue => e
       Rails.logger.warn("Error updating user_options fields after chat retention settings changed: #{e}")
     end
+  end
+
+  on(:post_alerter_after_save_post) do |post, new_record, notified|
+    next if !new_record
+    DiscourseChat::PostNotificationHandler.new(post, notified).handle
   end
 
   register_presence_channel_prefix("chat") do |channel|

--- a/spec/lib/post_notification_handler_spec.rb
+++ b/spec/lib/post_notification_handler_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DiscourseChat::PostNotificationHandler do
+  let(:post) { Fabricate(:post) }
+  let(:notified_users) { [] }
+  let(:subject) { DiscourseChat::PostNotificationHandler.new(post, notified_users) }
+
+  fab!(:channel) { Fabricate(:chat_channel) }
+  fab!(:message1) do
+    Fabricate(
+      :chat_message,
+      chat_channel: channel,
+      message: "hey this is the first message :)"
+    )
+  end
+  fab!(:message2) do
+    Fabricate(
+      :chat_message,
+      chat_channel: channel,
+      message: "our true enemy. has yet. to reveal himself."
+    )
+  end
+
+  before do
+    Notification.destroy_all
+  end
+
+  def expect_no_notification
+    return_val = nil
+    expect { return_val = subject.handle }.not_to change { Notification.count }
+    expect(return_val).to eq(false)
+  end
+
+  def update_post_with_chat_quote(messages)
+    quote_markdown = ChatTranscriptService.new(channel, messages.map(&:id)).generate_markdown
+    post.update!(raw: post.raw + "\n\n" + quote_markdown)
+  end
+
+  it "does nothing if the post is a whisper" do
+    post.update(post_type: Post.types[:whisper])
+    expect_no_notification
+  end
+
+  it "does nothing if the topic is deleted" do
+    post.topic.destroy && post.reload
+    expect_no_notification
+  end
+
+  it "does nothing if the topic is a private message" do
+    post.update(topic: Fabricate(:private_message_topic))
+    expect_no_notification
+  end
+
+  it "sends notifications to all of the quoted users" do
+    update_post_with_chat_quote([message1, message2])
+    subject.handle
+    expect(Notification.where(user: message1.user, notification_type: Notification.types[:chat_quoted]).count).to eq(1)
+    expect(Notification.where(user: message2.user, notification_type: Notification.types[:chat_quoted]).count).to eq(1)
+  end
+
+  it "does not send the same chat_quoted notification twice to the same post and user" do
+    update_post_with_chat_quote([message1, message2])
+    subject.handle
+    subject.handle
+    expect(Notification.where(user: message1.user, notification_type: Notification.types[:chat_quoted]).count).to eq(1)
+  end
+
+  it "does not send a notification if the user has got a reply notification to the quoted user for the same post" do
+    update_post_with_chat_quote([message1, message2])
+    Fabricate(
+      :notification,
+      notification_type: Notification.types[:replied],
+      post_number: post.post_number,
+      topic: post.topic,
+      user: message1.user
+    )
+    subject.handle
+    expect(Notification.where(user: message1.user, notification_type: Notification.types[:chat_quoted]).count).to eq(0)
+  end
+
+  context "when some users have already been notified for the post" do
+    let(:notified_users) { [message1.user] }
+
+    it "does not send notifications to those users" do
+      update_post_with_chat_quote([message1, message2])
+      subject.handle
+      expect(Notification.where(user: message1.user, notification_type: Notification.types[:chat_quoted]).count).to eq(0)
+      expect(Notification.where(user: message2.user, notification_type: Notification.types[:chat_quoted]).count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
When quoting chat messages, we want to notify all of the
users whose messages are quoted. This commit adds this
functionality, with a corresponding core PR to add the
notification type. The notification looks the same as the
regular quote notification for now.

![image](https://user-images.githubusercontent.com/920448/154190515-7b7a824e-85e9-48ab-a2c6-8c72eaf67725.png)

Related https://github.com/discourse/discourse/pull/15968