### PR TITLE
UX: Remove the alert gap on more alert types

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1170,8 +1170,11 @@ body.composer-open .topic-chat-float-container {
 }
 
 body.has-full-page-chat {
-  .alert-info:last-of-type {
-    margin-bottom: 0;
+  .alert-error,
+  .alert-info,
+  .alert-success,
+  .alert-warning {
+    margin: 0;
     border-bottom: 1px solid var(--primary-low);
   }
 }


### PR DESCRIPTION
This also smushes all alerts together (in rare cases when you have more than one), but that's a better way to display them on the full page chat page (especially in the standalone app context!)