### PR TITLE
UX: Small padding fix

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -111,7 +111,7 @@ body.composer-open .topic-chat-float-container {
 
   .chat-channels {
     .chat-channel-row {
-      padding: 0 0.5rem 0 0.5rem;
+      padding: 0 0 0 0.5rem;
       margin: 0 0.5rem 0.125rem 0.5rem;
       border-radius: 0.25em;
     }
@@ -1189,7 +1189,7 @@ body.has-full-page-chat {
     border-right: 1px solid var(--primary-low);
 
     .chat-channel-row {
-      padding: 0 0.5rem 0 0.5rem;
+      padding: 0 0 0 0.5rem;
       margin: 0 0.5rem 0.125rem 0.5rem;
       border-radius: 0.25em;
 


### PR DESCRIPTION
This PR adjusts the padding to align the `x` button on personal chat channels.

### After
<img width="350" alt="image" src="https://user-images.githubusercontent.com/30537603/154729389-79cd4e23-02d8-4d3f-bd31-4c8b8025ed06.png">

### Before
<img width="350" alt="image" src="https://user-images.githubusercontent.com/30537603/154729464-642c3386-727c-409f-8b5a-94195ea38377.png">
