### PR TITLE
FIX: Don't create errored chat message from webhook event

### DIFF
--- a/app/controllers/incoming_chat_webhooks_controller.rb
+++ b/app/controllers/incoming_chat_webhooks_controller.rb
@@ -61,7 +61,7 @@ class DiscourseChat::IncomingChatWebhooksController < ApplicationController
       incoming_chat_webhook: webhook
     )
     if chat_message_creator.failed?
-      render_json_error(chat_message_creator.chat_message)
+      render_json_error(chat_message_creator.error)
     else
       render json: success_json
     end
@@ -77,7 +77,8 @@ class DiscourseChat::IncomingChatWebhooksController < ApplicationController
   end
 
   def validate_message_length(message)
-    raise Discourse::InvalidParameters.new("Body cannot be over 1000 characters") if message.length > WEBHOOK_MAX_MESSAGE_LENGTH
+    return if message.length <= WEBHOOK_MAX_MESSAGE_LENGTH
+    raise Discourse::InvalidParameters.new("Body cannot be over #{WEBHOOK_MAX_MESSAGE_LENGTH} characters")
   end
 
   def validate_payload


### PR DESCRIPTION
When we create chat messages with ChatMessageCreator, there
is a chance the message will fail and return an error message.
This was working fine, however when we were creating the
ChatWebhookEvent record we were passing the `@chat_message` to
it, which meant that the chat message was always created regardless
of whether the chat message creator errored or not.

This commit fixes the issue by only making the ChatWebhookEvent once
the chat message has been validated. Any other validations must
occur before the chat message is saved, and any records created
linking to the message must be created after the message is saved.