### PR TITLE
DEV: Move chat reaction code into lib class

### DIFF
--- a/lib/chat_message_reactor.rb
+++ b/lib/chat_message_reactor.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class DiscourseChat::ChatMessageReactor
+  ADD_REACTION = :add
+  REMOVE_REACTION = :remove
+
+  def initialize(user, chat_channel)
+    @user = user
+    @chat_channel = chat_channel
+  end
+
+  def react!(message_id:, react_action:, emoji:)
+    if ![ADD_REACTION, REMOVE_REACTION].include?(react_action) || !Emoji.exists?(emoji)
+      raise Discourse::InvalidParameters
+    end
+
+    validate_channel_membership!
+
+    @chat_message = ChatMessage.find_by(id: message_id, chat_channel: @chat_channel)
+    raise Discourse::NotFound unless @chat_message
+
+    execute_action(react_action, emoji)
+    publish_reaction(react_action, emoji)
+
+    @chat_message
+  end
+
+  private
+
+  def validate_channel_membership!
+    raise Discourse::InvalidAccess if !UserChatChannelMembership.exists?(
+      chat_channel: @chat_channel,
+      user: @user,
+      following: true
+    )
+  end
+
+  def execute_action(react_action, emoji)
+    if react_action == ADD_REACTION
+      @chat_message.reactions.find_or_create_by(user: @user, emoji: emoji)
+    else
+      @chat_message.reactions.where(user: @user, emoji: emoji).destroy_all
+    end
+  end
+
+  def publish_reaction(react_action, emoji)
+    ChatPublisher.publish_reaction!(
+      @chat_channel,
+      @chat_message,
+      react_action,
+      @user,
+      emoji
+    )
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -85,6 +85,7 @@ after_initialize do
   load File.expand_path('../lib/chat_message_creator.rb', __FILE__)
   load File.expand_path('../lib/chat_message_processor.rb', __FILE__)
   load File.expand_path('../lib/chat_message_updater.rb', __FILE__)
+  load File.expand_path('../lib/chat_message_reactor.rb', __FILE__)
   load File.expand_path('../lib/chat_notifier.rb', __FILE__)
   load File.expand_path('../lib/chat_seeder.rb', __FILE__)
   load File.expand_path('../lib/chat_transcript_service.rb', __FILE__)


### PR DESCRIPTION
This will make the reaction code easier to work with
and also will add a nicer place to add more validations
before creating/removing the reaction (such as in the
upcoming readonly chat channel work).

We already follow this pattern with ChatMessageCreator
and ChatMessageUpdater.