### PR TITLE
FEATURE: Allow using [quote] bbcode in chat messages

### DIFF
--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -121,11 +121,12 @@ class ChatMessage < ActiveRecord::Base
     html-img
     mentions
     onebox
+    quotes
+    spoiler-alert
+    table
     text-post-process
     upload-protocol
     watched-words
-    table
-    spoiler-alert
   }
 
   MARKDOWN_IT_RULES = %w{
@@ -145,7 +146,12 @@ class ChatMessage < ActiveRecord::Base
   }
 
   def self.cook(message, opts = {})
-    cooked = PrettyText.cook(message, features_override: MARKDOWN_FEATURES, markdown_it_rules: MARKDOWN_IT_RULES)
+    cooked = PrettyText.cook(
+      message,
+      features_override: MARKDOWN_FEATURES,
+      markdown_it_rules: MARKDOWN_IT_RULES,
+      force_quote_link: true
+    )
 
     result = Oneboxer.apply(cooked) do |url|
       if opts[:invalidate_oneboxes]

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -618,6 +618,13 @@ export default Component.extend({
           stagedId: null,
           rateLimited: false,
         });
+
+        // some markdown is cooked differently on the server-side, e.g.
+        // quotes, avatar images etc.
+        if (data.chat_message.cooked !== stagedMessage.cooked) {
+          stagedMessage.set("cooked", data.chat_message.cooked);
+        }
+
         this.messageLookup[data.chat_message.id] = stagedMessage;
         delete this.messageLookup[`staged-${data.stagedId}`];
         return;

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -621,7 +621,10 @@ export default Component.extend({
 
         // some markdown is cooked differently on the server-side, e.g.
         // quotes, avatar images etc.
-        if (data.chat_message.cooked !== stagedMessage.cooked) {
+        if (
+          data.chat_message.cooked &&
+          data.chat_message.cooked !== stagedMessage.cooked
+        ) {
           stagedMessage.set("cooked", data.chat_message.cooked);
         }
 

--- a/spec/models/chat_message_spec.rb
+++ b/spec/models/chat_message_spec.rb
@@ -66,6 +66,29 @@ describe ChatMessage do
       expect(cooked).to eq("<blockquote>\n<p>a quote</p>\n</blockquote>")
     end
 
+    it 'supports quote bbcode' do
+      topic = Fabricate(:topic, title: "Some quotable topic")
+      post = Fabricate(:post, topic: topic)
+
+      cooked = ChatMessage.cook(<<~RAW)
+      [quote="#{post.user.username}, post:#{post.post_number}, topic:#{topic.id}"]
+      Mark me...this will go down in history.
+      [/quote]
+      RAW
+
+      expect(cooked).to eq(<<~COOKED.chomp)
+      <aside class="quote no-group" data-username="#{post.user.username}" data-post="#{post.post_number}" data-topic="#{topic.id}">
+      <div class="title">
+      <div class="quote-controls"></div>
+      <img loading="lazy" alt="" width="20" height="20" src="//test.localhost/letter_avatar_proxy/v4/letter/b/9de053/40.png" class="avatar"><a href="http://test.localhost/t/some-quotable-topic/#{topic.id}/#{post.post_number}">#{topic.title}</a>
+      </div>
+      <blockquote>
+      <p>Mark me...this will go down in history.</p>
+      </blockquote>
+      </aside>
+      COOKED
+    end
+
     it 'supports strikethrough rule' do
       cooked = ChatMessage.cook("~~test~~")
 

--- a/spec/models/chat_message_spec.rb
+++ b/spec/models/chat_message_spec.rb
@@ -69,6 +69,8 @@ describe ChatMessage do
     it 'supports quote bbcode' do
       topic = Fabricate(:topic, title: "Some quotable topic")
       post = Fabricate(:post, topic: topic)
+      SiteSetting.external_system_avatars_enabled = false
+      avatar_src = "//test.localhost#{User.system_avatar_template(post.user.username).gsub("{size}", "40")}"
 
       cooked = ChatMessage.cook(<<~RAW)
       [quote="#{post.user.username}, post:#{post.post_number}, topic:#{topic.id}"]
@@ -80,7 +82,7 @@ describe ChatMessage do
       <aside class="quote no-group" data-username="#{post.user.username}" data-post="#{post.post_number}" data-topic="#{topic.id}">
       <div class="title">
       <div class="quote-controls"></div>
-      <img loading="lazy" alt="" width="20" height="20" src="//test.localhost/letter_avatar_proxy/v4/letter/b/9de053/40.png" class="avatar"><a href="http://test.localhost/t/some-quotable-topic/#{topic.id}/#{post.post_number}">#{topic.title}</a>
+      <img loading="lazy" alt="" width="20" height="20" src="#{avatar_src}" class="avatar"><a href="http://test.localhost/t/some-quotable-topic/#{topic.id}/#{post.post_number}">#{topic.title}</a>
       </div>
       <blockquote>
       <p>Mark me...this will go down in history.</p>

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -113,8 +113,8 @@ RSpec.describe DiscourseChat::ChatController do
         get "/chat/#{chat_channel.id}/messages.json", params: { before_message_id: message_40.id, page_size: page_size }
         messages = response.parsed_body["chat_messages"]
         expect(messages.count).to eq(page_size)
-        expect(messages.first["id"]).to eq(chat_channel.chat_messages[40 - page_size].id)
-        expect(messages.last["id"]).to eq(chat_channel.chat_messages[39].id)
+        expect(messages.first["id"]).to eq(message_10.id)
+        expect(messages.last["id"]).to eq(message_39.id)
       end
 
       it "returns 'can_load...' properly when there are more past messages" do
@@ -135,8 +135,8 @@ RSpec.describe DiscourseChat::ChatController do
         get "/chat/#{chat_channel.id}/messages.json", params: { after_message_id: message_10.id, page_size: page_size }
         messages = response.parsed_body["chat_messages"]
         expect(messages.count).to eq(page_size)
-        expect(messages.first["id"]).to eq(chat_channel.chat_messages[11].id)
-        expect(messages.last["id"]).to eq(chat_channel.chat_messages[10 + page_size].id)
+        expect(messages.first["id"]).to eq(message_11.id)
+        expect(messages.last["id"]).to eq(message_40.id)
       end
 
       it "return 'can_load..' properly when there are future messages" do

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -543,6 +543,7 @@ acceptance("Discourse Chat - without unread", function (needs) {
         user: {
           id: 1,
         },
+        cooked: messageContent + " some extra cooked stuff",
       },
     });
 
@@ -555,6 +556,12 @@ acceptance("Discourse Chat - without unread", function (needs) {
         .classList.contains("chat-message-container-202")
     );
     assert.notOk(lastMessage.classList.contains("chat-message-staged"));
+
+    assert.equal(
+      lastMessage.querySelector(".chat-message-text").innerText.trim(),
+      messageContent + " some extra cooked stuff",
+      "last message is updated with the cooked content of the message"
+    );
 
     const nextMessageContent = "What up what up!";
     await fillIn(composerInput, nextMessageContent);


### PR DESCRIPTION
This commit enables the "quotes" markdown feature for
chat messages, and also makes sure the quote always has
a link to the quoted post with the force_quote_link
param for PrettyText.

**This core PR must be merged first: https://github.com/discourse/discourse/pull/16034**