### PR TITLE
UX: Expand target area for chat uploads

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -493,22 +493,20 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   },
 
   _uploadDropTargetOptions() {
-    let chatWidgetVisible = document.querySelector(
+    let chatWidget = document.querySelector(
       ".topic-chat-container.expanded.visible"
     );
-    let onFullPageChat = document.querySelector(".full-page-chat");
+    let fullPageChat = document.querySelector(".full-page-chat");
 
-    let targetEl;
-
-    if (chatWidgetVisible || onFullPageChat) {
-      targetEl = document.querySelector(".chat-enabled");
-    } else {
-      targetEl = document.querySelector(".chat-live-pane");
-    }
+    const targetEl =
+      chatWidget || fullPageChat
+        ? document.querySelector(".chat-enabled")
+        : null;
 
     if (!targetEl) {
       return this._super();
     }
+
     return {
       target: targetEl,
     };

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -493,7 +493,17 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   },
 
   _uploadDropTargetOptions() {
-    const targetEl = document.querySelector(".chat-live-pane");
+    let chatWidgetVisible = document.querySelector(".topic-chat-container.expanded.visible");
+    let onFullPageChat = document.querySelector(".full-page-chat")
+
+    let targetEl;
+
+    if (chatWidgetVisible || onFullPageChat) {
+      targetEl = document.querySelector(".chat-enabled")
+    } else {
+      targetEl = document.querySelector(".chat-live-pane");
+    }
+
     if (!targetEl) {
       return this._super();
     }

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -493,13 +493,15 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   },
 
   _uploadDropTargetOptions() {
-    let chatWidgetVisible = document.querySelector(".topic-chat-container.expanded.visible");
-    let onFullPageChat = document.querySelector(".full-page-chat")
+    let chatWidgetVisible = document.querySelector(
+      ".topic-chat-container.expanded.visible"
+    );
+    let onFullPageChat = document.querySelector(".full-page-chat");
 
     let targetEl;
 
     if (chatWidgetVisible || onFullPageChat) {
-      targetEl = document.querySelector(".chat-enabled")
+      targetEl = document.querySelector(".chat-enabled");
     } else {
       targetEl = document.querySelector(".chat-live-pane");
     }

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -493,10 +493,10 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   },
 
   _uploadDropTargetOptions() {
-    let chatWidget = document.querySelector(
+    const chatWidget = document.querySelector(
       ".topic-chat-container.expanded.visible"
     );
-    let fullPageChat = document.querySelector(".full-page-chat");
+    const fullPageChat = document.querySelector(".full-page-chat");
 
     const targetEl =
       chatWidget || fullPageChat

--- a/assets/javascripts/discourse/templates/components/chat-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer.hbs
@@ -15,6 +15,10 @@
   }}
 {{/if}}
 
+{{#if isDragOver }}
+  <div>Drop a file to upload it!</div>
+{{/if}}
+
 <div class="chat-composer-row">
   {{#if showToolbar}}
     <div class="chat-composer-toolbar">

--- a/assets/javascripts/discourse/templates/components/chat-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer.hbs
@@ -15,10 +15,6 @@
   }}
 {{/if}}
 
-{{#if isDragOver }}
-  <div>Drop a file to upload it!</div>
-{{/if}}
-
 <div class="chat-composer-row">
   {{#if showToolbar}}
     <div class="chat-composer-toolbar">


### PR DESCRIPTION
This PR expands the target area for dropping in uploads to discourse chat. *If* the chat widget, or chat full page is open, dropping anywhere on the screen will upload the file to the chat composer. 

Without this PR, dragging an upload onto the view would only upload if specifically within the confines of the chat area, triggering the browser to open the image.

### After
https://user-images.githubusercontent.com/30537603/155375743-bca23832-9582-411e-865f-9ea067365f30.mp4

### Before
https://user-images.githubusercontent.com/30537603/155376197-00d2b012-d9f0-4fae-9116-567949798b01.mp4


