### PR TITLE
FEATURE: Uses upload filename for reply to excerpt if message is empty

### DIFF
--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -37,7 +37,11 @@ class ChatMessage < ActiveRecord::Base
   end
 
   def excerpt
-    PrettyText.excerpt(cooked, 50, {})
+    prettify = cooked
+    if (cooked == "" && uploads.present?)
+      prettify = uploads.first.original_filename
+    end
+    PrettyText.excerpt(prettify, 50, {})
   end
 
   def push_notification_excerpt

--- a/spec/models/chat_message_spec.rb
+++ b/spec/models/chat_message_spec.rb
@@ -172,6 +172,14 @@ describe ChatMessage do
       expect(cooked).to eq("<p>■■■■■</p>")
     end
 
+    it "excerpts upload file name if message is empty" do
+      gif = Fabricate(:upload, original_filename: "cat.gif", width: 400, height: 300, extension: "gif")
+      message = Fabricate.build(:chat_message, message: "")
+      ChatUpload.create(chat_message: message, upload: gif)
+
+      expect(message.excerpt).to eq "cat.gif"
+    end
+
     it 'supports autolink with <>' do
       cooked = ChatMessage.cook("<https://github.com/discourse/discourse-chat/pull/468>")
 


### PR DESCRIPTION
Previously, the reply excerpt would be empty. So using adding the file name would perhaps make it more useful to the the viewer what the message is in reply to.

<img width="199" alt="Screenshot 2022-02-25 at 12 51 08 AM" src="https://user-images.githubusercontent.com/1555215/155570061-61ebd295-0a14-42bc-9edb-dd0ea737b70c.png">

