### PR TITLE
FIX: Focus in composer after 'edit message' button is clicked

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1004,6 +1004,9 @@ export default Component.extend({
     const message = this.messageLookup[messageId];
     this.set("editingMessage", message);
     next(this.reStickScrollIfNeeded.bind(this));
+    next(this, () => {
+      this._focusComposer();
+    });
   },
 
   @discourseComputed()


### PR DESCRIPTION
Currently we have to manually click in composer after we "edit" a message. This focuses your cursor there so you don't have to.