### PR TITLE
UX: Adjust styles, remove leave chat button

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1211,11 +1211,6 @@ export default Component.extend({
     evt.preventDefault();
   },
 
-  @action
-  exitChat() {
-    return this.router.transitionTo(this.chat.lastNonChatRoute);
-  },
-
   @bind
   forceLinksToOpenNewTab() {
     if (this._selfDeleted) {

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -49,7 +49,6 @@ export default Service.extend({
   _chatOpen: false,
   _fetchingChannels: null,
   _fullScreenChatOpen: false,
-  _lastNonChatRoute: null,
 
   init() {
     this._super(...arguments);
@@ -63,7 +62,6 @@ export default Service.extend({
       this._subscribeToNewDmChannelUpdates();
       this._subscribeToUserTrackingChannel();
       this._subscribeToChannelEdits();
-      this.appEvents.on("page:changed", this, "_storeLastNonChatRouteInfo");
       this.presenceChannel = this.presence.getChannel("/chat/online");
       this.draftStore = {};
 
@@ -84,23 +82,7 @@ export default Service.extend({
       this._unsubscribeFromUserTrackingChannel();
       this._unsubscribeFromChannelEdits();
       this._unsubscribeFromAllChatChannels();
-      this.appEvents.off("page:changed", this, "_storeLastNonChatRouteInfo");
     }
-  },
-
-  _storeLastNonChatRouteInfo(data) {
-    if (
-      data.currentRouteName !== "chat" &&
-      data.currentRouteName !== "chat.channel"
-    ) {
-      this.set("_lastNonChatRoute", data.url);
-    }
-  },
-
-  get lastNonChatRoute() {
-    return this._lastNonChatRoute && this._lastNonChatRoute !== "/"
-      ? this._lastNonChatRoute
-      : `discovery.${defaultHomepage()}`;
   },
 
   get isChatPage() {

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -4,7 +4,6 @@ import Site from "discourse/models/site";
 import { addChatToolbarButton } from "discourse/plugins/discourse-chat/discourse/components/chat-composer";
 import { ajax } from "discourse/lib/ajax";
 import { A } from "@ember/array";
-import { defaultHomepage } from "discourse/lib/utilities";
 import { generateCookFunction } from "discourse/lib/text";
 import { next } from "@ember/runloop";
 import { Promise } from "rsvp";

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -21,14 +21,6 @@
         }}
       {{/if}}
 
-      {{!-- {{#unless currentUser.chat_isolated}}
-        {{d-button
-          action=(action "exitChat")
-          class="btn-flat exit-chat-btn"
-          icon="times"
-          title="chat.exit"
-        }}
-      {{/unless}} --}}
     </div>
   </div>
 {{/if}}

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -21,14 +21,14 @@
         }}
       {{/if}}
 
-      {{#unless currentUser.chat_isolated}}
+      {{!-- {{#unless currentUser.chat_isolated}}
         {{d-button
           action=(action "exitChat")
           class="btn-flat exit-chat-btn"
           icon="times"
           title="chat.exit"
         }}
-      {{/unless}}
+      {{/unless}} --}}
     </div>
   </div>
 {{/if}}

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -318,17 +318,6 @@ body.composer-open .topic-chat-float-container {
   }
 }
 
-.btn.exit-chat-btn {
-  background: transparent;
-  color: var(--primary-medium);
-  font-size: var(--font-0-rem);
-  padding: 0.5rem;
-
-  &:hover {
-    background: transparent;
-  }
-}
-
 .chat-channels {
   overflow-y: auto;
   height: 100%;
@@ -1273,15 +1262,7 @@ body.has-full-page-chat {
   }
 
   .chat-full-page-header {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
     border-bottom: 1px solid var(--primary-low);
-
-    .exit-chat-btn {
-      margin-left: auto;
-      color: var(--primary-high);
-    }
 
     .chat-channel-title {
       .category-chat-name,
@@ -1303,9 +1284,6 @@ body.has-full-page-chat {
       .join-channel-btn {
         margin-left: auto;
       }
-      .exit-chat-btn {
-        margin-left: 0.25em;
-      }
     }
   }
 
@@ -1320,9 +1298,10 @@ body.has-full-page-chat {
 }
 
 .chat-full-page-header {
-  flex-direction: column;
-  align-items: flex-start;
-
+  .chat-channel-header-details {
+    display: flex;
+    flex-direction: row;
+  }
   .chat-channel-title {
     margin: 0;
     max-width: 100%;

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -18,7 +18,7 @@
   }
 
   .chat-full-page-header {
-    padding: 0.5rem 0.5rem 0.5rem 1rem;
+    padding: 1rem;
     flex-shrink: 0;
   }
 

--- a/assets/stylesheets/mobile/mobile.scss
+++ b/assets/stylesheets/mobile/mobile.scss
@@ -90,7 +90,7 @@ body.has-full-page-chat {
   }
 
   .chat-full-page-header {
-    padding: 0.5em 0.25em;
+    padding: 0.5em 0.5em 0.5em 0em;
     font-weight: bold;
   }
 }

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -1168,15 +1168,6 @@ acceptance(
         `/chat/channel/${channelWithUnread.id}/${channelWithUnread.title}`
       );
     });
-
-    test("Exit full screen chat button takes you to previous non-chat location", async function (assert) {
-      const nonChatPath = "/t/internationalization-localization/280";
-      await visit(nonChatPath);
-      await visit("/chat/channel/75/@hawk");
-      await visit("/chat/channel/9/Site");
-      await click(".exit-chat-btn");
-      assert.equal(currentURL(), nonChatPath);
-    });
   }
 );
 


### PR DESCRIPTION
This PR makes adjustments for the new `div` that will be used to add more details to archived & closed channels. It also removes the `x` button, as it is possible to leave chat in the same way users can "leave" other pages in Discourse core, which is by clicking the "home" logo.

### After
**Desktop**
<img width="700" alt="image" src="https://user-images.githubusercontent.com/30537603/155746818-05e258f3-d2ae-4847-bb13-4fa7af8cdea6.png">

<img width="700" alt="image" src="https://user-images.githubusercontent.com/30537603/155746863-b65a42be-67f0-49e3-970b-38185a86358b.png">

**Mobile**
<img width="300" alt="image" src="https://user-images.githubusercontent.com/30537603/155747046-0e073c58-5232-40f3-9276-3e2dc4e2a92d.png">

<img width="300" alt="image" src="https://user-images.githubusercontent.com/30537603/155747136-9621513c-ae6b-4b92-91e6-e89ff3fbfd13.png">


