### PR TITLE
DEV: Remove a typo'd instance variable

### DIFF
--- a/lib/chat_message_processor.rb
+++ b/lib/chat_message_processor.rb
@@ -6,7 +6,6 @@ class DiscourseChat::ChatMessageProcessor
   def initialize(chat_message)
     @model = chat_message
     @previous_cooked = (chat_message.cooked || "").dup
-    @cateogry_id = nil
     @with_secure_media = false
     @size_cache = {}
     @opts = {}


### PR DESCRIPTION
Even without a typo, it wasn't needed.