### PR TITLE
FIX: New DM erroring on create because of canModifyMessages

### DIFF
--- a/assets/javascripts/discourse/components/dm-creator.js
+++ b/assets/javascripts/discourse/components/dm-creator.js
@@ -3,6 +3,7 @@ import { action } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 import { empty } from "@ember/object/computed";
 import { inject as service } from "@ember/service";
+import ChatChannel from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 
 export default Component.extend({
   chat: service(),
@@ -21,7 +22,7 @@ export default Component.extend({
     }).then((response) => {
       this.set("usernames", null);
       this.chat.startTrackingChannel(response.chat_channel);
-      this.afterCreate(response.chat_channel);
+      this.afterCreate(ChatChannel.create(response.chat_channel));
     });
   },
 

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -885,6 +885,18 @@ Widget.triangulate(arg: "test")
     );
   });
 
+  test("creating a new direct message channel from popup chat works", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click(".new-dm");
+    let users = selectKit(".dm-user-chooser");
+    await click(".dm-user-chooser");
+    await users.expand();
+    await fillIn(".dm-user-chooser input.filter-input", "hawk");
+    await users.selectRowByValue("hawk");
+    await click("button.create-dm");
+    assert.strictEqual(query(".dm-username").innerText, "hawk");
+  });
+
   test("Reacting works with no existing reactions", async function (assert) {
     await visit("/chat/channel/9/Site");
     const message = query(".chat-message-container");


### PR DESCRIPTION
When we were creating a new DM channel in non-isolated chat
mode, we were not creating a ChatChannel instance to wrap
the returned channel in, meaning the canModifyMessages
function cannot be found and throws an error. This is not
a problem in isolated chat because the channel is loaded via
a route.