### PR TITLE
DEV: Standardise chatable_type checks in JS

### DIFF
--- a/assets/javascripts/discourse/components/chat-channel-selector-modal-inner.js
+++ b/assets/javascripts/discourse/components/chat-channel-selector-modal-inner.js
@@ -99,7 +99,7 @@ export default Component.extend({
     if (channel.user) {
       return this.fetchChannelForUser(channel).then((response) => {
         this.chat
-          .startTrackingChannel(response.chat_channel)
+          .startTrackingChannel(ChatChannel.create(response.chat_channel))
           .then((newlyTracked) => {
             this.chat.openChannel(newlyTracked);
             this.close();

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -558,7 +558,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   },
 
   messageRecipient(chatChannel) {
-    if (chatChannel.isDirectMessageChannel()) {
+    if (chatChannel.isDirectMessageChannel) {
       const directMessageRecipients = chatChannel.chatable.users;
       if (
         directMessageRecipients.length === 1 &&

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -558,7 +558,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   },
 
   messageRecipient(chatChannel) {
-    if (chatChannel.chatable_type === "DirectMessageChannel") {
+    if (chatChannel.isDirectMessageChannel()) {
       const directMessageRecipients = chatChannel.chatable.users;
       if (
         directMessageRecipients.length === 1 &&

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1026,7 +1026,7 @@ export default Component.extend({
 
   @discourseComputed()
   canQuote() {
-    if (this.chatChannel.isDirectMessageChannel()) {
+    if (this.chatChannel.isDirectMessageChannel) {
       return false;
     }
 
@@ -1111,7 +1111,7 @@ export default Component.extend({
         const composer = container.lookup("controller:composer");
         const openOpts = {};
 
-        if (this.chatChannel.isCategoryChannel()) {
+        if (this.chatChannel.isCategoryChannel) {
           openOpts.categoryId = this.chatChannel.chatable_id;
         }
 

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1026,7 +1026,7 @@ export default Component.extend({
 
   @discourseComputed()
   canQuote() {
-    if (this.chatChannel.chatable_type === "DirectMessageChannel") {
+    if (this.chatChannel.isDirectMessageChannel()) {
       return false;
     }
 
@@ -1111,7 +1111,7 @@ export default Component.extend({
         const composer = container.lookup("controller:composer");
         const openOpts = {};
 
-        if (this.chatChannel.chatable_type === "Category") {
+        if (this.chatChannel.isCategoryChannel()) {
           openOpts.categoryId = this.chatChannel.chatable_id;
         }
 

--- a/assets/javascripts/discourse/components/chat-retention-reminder.js
+++ b/assets/javascripts/discourse/components/chat-retention-reminder.js
@@ -3,7 +3,6 @@ import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "I18n";
 import { action } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
-import { CHATABLE_TYPES } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 
 export default Component.extend({
@@ -14,21 +13,21 @@ export default Component.extend({
     "chatChannel.chatable_type",
     "currentUser.{needs_dm_retention_reminder,needs_channel_retention_reminder}"
   )
-  show(chatableType) {
+  show() {
     return (
-      (chatableType === CHATABLE_TYPES.directMessageChannel &&
+      (this.chatChannel.isDirectMessageChannel() &&
         this.currentUser.needs_dm_retention_reminder) ||
-      (chatableType !== CHATABLE_TYPES.directMessageChannel &&
+      (!this.chatChannel.isDirectMessageChannel() &&
         this.currentUser.needs_channel_retention_reminder)
     );
   },
 
   @discourseComputed("chatChannel.chatable_type")
-  text(chatableType) {
+  text() {
     let days = this.siteSettings.chat_channel_retention_days;
     let translationKey = "chat.retention_reminders.public";
 
-    if (chatableType === CHATABLE_TYPES.directMessageChannel) {
+    if (this.chatChannel.isDirectMessageChannel()) {
       days = this.siteSettings.chat_dm_retention_days;
       translationKey = "chat.retention_reminders.dm";
     }
@@ -36,8 +35,8 @@ export default Component.extend({
   },
 
   @discourseComputed("chatChannel.chatable_type")
-  daysCount(chatableType) {
-    return chatableType === CHATABLE_TYPES.directMessageChannel
+  daysCount() {
+    return this.chatChannel.isDirectMessageChannel()
       ? this.siteSettings.chat_dm_retention_days
       : this.siteSettings.chat_channel_retention_days;
   },
@@ -49,10 +48,9 @@ export default Component.extend({
       data: { chatable_type: this.chatChannel.chatable_type },
     })
       .then(() => {
-        const field =
-          this.chatChannel.chatable_type === CHATABLE_TYPES.directMessageChannel
-            ? "needs_dm_retention_reminder"
-            : "needs_channel_retention_reminder";
+        const field = this.chatChannel.isDirectMessageChannel()
+          ? "needs_dm_retention_reminder"
+          : "needs_channel_retention_reminder";
         this.currentUser.set(field, false);
       })
       .catch(popupAjaxError);

--- a/assets/javascripts/discourse/components/chat-retention-reminder.js
+++ b/assets/javascripts/discourse/components/chat-retention-reminder.js
@@ -15,9 +15,9 @@ export default Component.extend({
   )
   show() {
     return (
-      (this.chatChannel.isDirectMessageChannel() &&
+      (this.chatChannel.isDirectMessageChannel &&
         this.currentUser.needs_dm_retention_reminder) ||
-      (!this.chatChannel.isDirectMessageChannel() &&
+      (!this.chatChannel.isDirectMessageChannel &&
         this.currentUser.needs_channel_retention_reminder)
     );
   },
@@ -27,7 +27,7 @@ export default Component.extend({
     let days = this.siteSettings.chat_channel_retention_days;
     let translationKey = "chat.retention_reminders.public";
 
-    if (this.chatChannel.isDirectMessageChannel()) {
+    if (this.chatChannel.isDirectMessageChannel) {
       days = this.siteSettings.chat_dm_retention_days;
       translationKey = "chat.retention_reminders.dm";
     }
@@ -36,7 +36,7 @@ export default Component.extend({
 
   @discourseComputed("chatChannel.chatable_type")
   daysCount() {
-    return this.chatChannel.isDirectMessageChannel()
+    return this.chatChannel.isDirectMessageChannel
       ? this.siteSettings.chat_dm_retention_days
       : this.siteSettings.chat_channel_retention_days;
   },
@@ -48,7 +48,7 @@ export default Component.extend({
       data: { chatable_type: this.chatChannel.chatable_type },
     })
       .then(() => {
-        const field = this.chatChannel.isDirectMessageChannel()
+        const field = this.chatChannel.isDirectMessageChannel
           ? "needs_dm_retention_reminder"
           : "needs_channel_retention_reminder";
         this.currentUser.set(field, false);

--- a/assets/javascripts/discourse/components/dm-creator.js
+++ b/assets/javascripts/discourse/components/dm-creator.js
@@ -20,9 +20,10 @@ export default Component.extend({
       method: "POST",
       data: { usernames: this.usernames.uniq().join(",") },
     }).then((response) => {
+      const chatChannel = ChatChannel.create(response.chat_channel);
       this.set("usernames", null);
-      this.chat.startTrackingChannel(response.chat_channel);
-      this.afterCreate(ChatChannel.create(response.chat_channel));
+      this.chat.startTrackingChannel(chatChannel);
+      this.afterCreate(chatChannel);
     });
   },
 

--- a/assets/javascripts/discourse/controllers/create-channel-modal.js
+++ b/assets/javascripts/discourse/controllers/create-channel-modal.js
@@ -1,4 +1,5 @@
 import Controller from "@ember/controller";
+import ChatChannel from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 import discourseComputed from "discourse-common/utils/decorators";
 import escape from "discourse-common/lib/escape";
 import I18n from "I18n";
@@ -91,12 +92,11 @@ export default Controller.extend(ModalFunctionality, {
 
     return ajax("/chat/chat_channels", { method: "PUT", data })
       .then((response) => {
-        return this.chat
-          .startTrackingChannel(response.chat_channel)
-          .then(() => {
-            this.send("closeModal");
-            this.appEvents.trigger("chat:open-channel", response.chat_channel);
-          });
+        const chatChannel = ChatChannel.create(response.chat_channel);
+        return this.chat.startTrackingChannel(chatChannel).then(() => {
+          this.send("closeModal");
+          this.appEvents.trigger("chat:open-channel", chatChannel);
+        });
       })
       .catch((e) => {
         this.flash(e.jqXHR.responseJSON.errors[0], "error");

--- a/assets/javascripts/discourse/models/chat-channel.js
+++ b/assets/javascripts/discourse/models/chat-channel.js
@@ -46,4 +46,20 @@ export default RestModel.extend({
 
     return !READONLY_STATUSES.includes(this.status);
   },
+
+  isDirectMessageChannel() {
+    return this.chatable_type === CHATABLE_TYPES.directMessageChannel;
+  },
+
+  isTopicChannel() {
+    return this.chatable_type === CHATABLE_TYPES.topicChannel;
+  },
+
+  isCategoryChannel() {
+    return this.chatable_type === CHATABLE_TYPES.categoryChannel;
+  },
+
+  isTagChannel() {
+    return this.chatable_type === CHATABLE_TYPES.tagChannel;
+  },
 });

--- a/assets/javascripts/discourse/models/chat-channel.js
+++ b/assets/javascripts/discourse/models/chat-channel.js
@@ -47,19 +47,19 @@ export default RestModel.extend({
     return !READONLY_STATUSES.includes(this.status);
   },
 
-  isDirectMessageChannel() {
+  get isDirectMessageChannel() {
     return this.chatable_type === CHATABLE_TYPES.directMessageChannel;
   },
 
-  isTopicChannel() {
+  get isTopicChannel() {
     return this.chatable_type === CHATABLE_TYPES.topicChannel;
   },
 
-  isCategoryChannel() {
+  get isCategoryChannel() {
     return this.chatable_type === CHATABLE_TYPES.categoryChannel;
   },
 
-  isTagChannel() {
+  get isTagChannel() {
     return this.chatable_type === CHATABLE_TYPES.tagChannel;
   },
 });

--- a/assets/javascripts/discourse/routes/chat-browse.js
+++ b/assets/javascripts/discourse/routes/chat-browse.js
@@ -1,5 +1,5 @@
 import DiscourseRoute from "discourse/routes/discourse";
-import EmberObject from "@ember/object";
+import ChatChannel from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 import { ajax } from "discourse/lib/ajax";
 import { inject as service } from "@ember/service";
 
@@ -11,11 +11,11 @@ export default DiscourseRoute.extend({
       const topicChannels = [];
 
       const allChannels = this.chat.sortPublicChannels(
-        channels.map((channel) => EmberObject.create(channel))
+        channels.map((channel) => ChatChannel.create(channel))
       );
 
       allChannels.forEach((channel) => {
-        if (channel.chatable_type === "Category") {
+        if (channel.isCategoryChannel()) {
           categoryChannels.push(channel);
         } else {
           topicChannels.push(channel);

--- a/assets/javascripts/discourse/routes/chat-browse.js
+++ b/assets/javascripts/discourse/routes/chat-browse.js
@@ -15,7 +15,7 @@ export default DiscourseRoute.extend({
       );
 
       allChannels.forEach((channel) => {
-        if (channel.isCategoryChannel()) {
+        if (channel.isCategoryChannel) {
           categoryChannels.push(channel);
         } else {
           topicChannels.push(channel);

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -202,7 +202,7 @@ export default Service.extend({
         return true;
       }
 
-      if (channel.chatable_type === CHATABLE_TYPES.directMessageChannel) {
+      if (channel.isDirectMessageChannel()) {
         let userFound = false;
         channel.chatable.users.forEach((user) => {
           if (
@@ -224,11 +224,9 @@ export default Service.extend({
     if (!activeChannel) {
       return; // Chat isn't open. Return and do nothing!
     }
-    const inDmChannel =
-      activeChannel.chatable_type === CHATABLE_TYPES.directMessageChannel;
 
     let currentList, otherList;
-    if (inDmChannel) {
+    if (activeChannel.isDirectMessageChannel()) {
       currentList = this.truncateDirectMessageChannels(
         this.directMessageChannels
       );
@@ -362,7 +360,7 @@ export default Service.extend({
       for (const [channel, state] of Object.entries(
         this.currentUser.chat_channel_tracking_state
       )) {
-        if (state.chatable_type === "DirectMessageChannel") {
+        if (state.chatable_type === CHATABLE_TYPES.directMessageChannel) {
           if (!dmChannelWithUnread && state.unread_count > 0) {
             dmChannelWithUnread = channel;
           } else if (!dmChannel) {
@@ -489,9 +487,7 @@ export default Service.extend({
       return existingChannel; // User is already tracking this channel. return!
     }
 
-    const isDirectMessageChannel =
-      channel.chatable_type === "DirectMessageChannel";
-    const existingChannels = isDirectMessageChannel
+    const existingChannels = channel.isDirectMessageChannel()
       ? this.directMessageChannels
       : this.publicChannels;
 
@@ -510,7 +506,7 @@ export default Service.extend({
       chatable_type: channel.chatable_type,
     };
     this.userChatChannelTrackingStateChanged();
-    if (!isDirectMessageChannel) {
+    if (!channel.isDirectMessageChannel()) {
       this.set("publicChannels", this.sortPublicChannels(this.publicChannels));
     }
     this.appEvents.trigger("chat:refresh-channels");
@@ -556,7 +552,7 @@ export default Service.extend({
       return;
     }
 
-    if (channel.chatable_type !== "DirectMessageChannel") {
+    if (!channel.isDirectMessageChannel()) {
       this._subscribeToMentionChannel(channel);
     }
 
@@ -640,7 +636,7 @@ export default Service.extend({
 
   _unsubscribeFromChatChannel(channel) {
     this.messageBus.unsubscribe(`/chat/${channel.id}/new-messages`);
-    if (channel.chatable_type !== "DirectMessageChannel") {
+    if (!channel.isDirectMessageChannel()) {
       this.messageBus.unsubscribe(`/chat/${channel.id}/new-mentions`);
     }
   },
@@ -707,7 +703,7 @@ export default Service.extend({
           return;
         }
 
-        if (state.chatable_type === "DirectMessageChannel") {
+        if (state.chatable_type === CHATABLE_TYPES.directMessageChannel) {
           unreadUrgentCount += state.unread_count || 0;
         } else {
           unreadUrgentCount += state.unread_mentions || 0;

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -202,7 +202,7 @@ export default Service.extend({
         return true;
       }
 
-      if (channel.isDirectMessageChannel()) {
+      if (channel.isDirectMessageChannel) {
         let userFound = false;
         channel.chatable.users.forEach((user) => {
           if (
@@ -226,7 +226,7 @@ export default Service.extend({
     }
 
     let currentList, otherList;
-    if (activeChannel.isDirectMessageChannel()) {
+    if (activeChannel.isDirectMessageChannel) {
       currentList = this.truncateDirectMessageChannels(
         this.directMessageChannels
       );
@@ -487,7 +487,7 @@ export default Service.extend({
       return existingChannel; // User is already tracking this channel. return!
     }
 
-    const existingChannels = channel.isDirectMessageChannel()
+    const existingChannels = channel.isDirectMessageChannel
       ? this.directMessageChannels
       : this.publicChannels;
 
@@ -506,7 +506,7 @@ export default Service.extend({
       chatable_type: channel.chatable_type,
     };
     this.userChatChannelTrackingStateChanged();
-    if (!channel.isDirectMessageChannel()) {
+    if (!channel.isDirectMessageChannel) {
       this.set("publicChannels", this.sortPublicChannels(this.publicChannels));
     }
     this.appEvents.trigger("chat:refresh-channels");
@@ -539,7 +539,7 @@ export default Service.extend({
 
   _subscribeToNewDmChannelUpdates() {
     this.messageBus.subscribe("/chat/new-direct-message-channel", (busData) => {
-      this.startTrackingChannel(busData.chat_channel);
+      this.startTrackingChannel(ChatChannel.create(busData.chat_channel));
     });
   },
 
@@ -552,7 +552,7 @@ export default Service.extend({
       return;
     }
 
-    if (!channel.isDirectMessageChannel()) {
+    if (!channel.isDirectMessageChannel) {
       this._subscribeToMentionChannel(channel);
     }
 
@@ -636,7 +636,7 @@ export default Service.extend({
 
   _unsubscribeFromChatChannel(channel) {
     this.messageBus.unsubscribe(`/chat/${channel.id}/new-messages`);
-    if (!channel.isDirectMessageChannel()) {
+    if (!channel.isDirectMessageChannel) {
       this.messageBus.unsubscribe(`/chat/${channel.id}/new-mentions`);
     }
   },

--- a/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
@@ -1,5 +1,5 @@
 <div role="button" class="chat-channel-title" {{on "click" (fn this.handleOnClick)}}>
-  {{#if (eq channel.isDirectMessageChannel)}}
+  {{#if channel.isDirectMessageChannel}}
     {{#if multiDm}}
       <span class="dm-multi-count">
         {{channel.chatable.users.length}}
@@ -14,12 +14,12 @@
         {{/let}}
       </span>
     {{/if}}
-  {{else if (eq channel.isTagChannel)}}
+  {{else if channel.isTagChannel}}
     <span class="tag-chat-badge">
       {{d-icon "tag"}}
     </span>
     <span class="tag-chat-name">{{channel.title}}</span>
-  {{else if (eq channel.isCategoryChannel)}}
+  {{else if channel.isCategoryChannel}}
     <span class="category-chat-badge" style={{html-safe (concat "color: #" channel.chatable.color)}}>
       {{d-icon "hashtag"}}
       {{#if channel.chatable.read_restricted}}
@@ -31,7 +31,7 @@
     <span class="category-chat-name">
       {{replace-emoji channel.title}}
     </span>
-  {{else if (eq channel.isTopicChannel)}}
+  {{else if channel.isTopicChannel}}
     <span class="topic-chat-badge">
       <span class="topic-chat-icon">{{d-icon "far-comments"}}</span>
     </span>

--- a/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
@@ -1,5 +1,5 @@
 <div role="button" class="chat-channel-title" {{on "click" (fn this.handleOnClick)}}>
-  {{#if (eq channel.chatable_type "DirectMessageChannel")}}
+  {{#if (eq channel.isDirectMessageChannel)}}
     {{#if multiDm}}
       <span class="dm-multi-count">
         {{channel.chatable.users.length}}
@@ -14,12 +14,12 @@
         {{/let}}
       </span>
     {{/if}}
-  {{else if (eq channel.chatable_type "Tag")}}
+  {{else if (eq channel.isTagChannel)}}
     <span class="tag-chat-badge">
       {{d-icon "tag"}}
     </span>
     <span class="tag-chat-name">{{channel.title}}</span>
-  {{else if (eq channel.chatable_type "Category")}}
+  {{else if (eq channel.isCategoryChannel)}}
     <span class="category-chat-badge" style={{html-safe (concat "color: #" channel.chatable.color)}}>
       {{d-icon "hashtag"}}
       {{#if channel.chatable.read_restricted}}
@@ -31,7 +31,7 @@
     <span class="category-chat-name">
       {{replace-emoji channel.title}}
     </span>
-  {{else if (eq channel.chatable_type "Topic")}}
+  {{else if (eq channel.isTopicChannel)}}
     <span class="topic-chat-badge">
       <span class="topic-chat-icon">{{d-icon "far-comments"}}</span>
     </span>

--- a/test/javascripts/components/chat-retention-reminder-test.js
+++ b/test/javascripts/components/chat-retention-reminder-test.js
@@ -1,3 +1,4 @@
+import ChatChannel from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 import { set } from "@ember/object";
 import componentTest, {
   setupRenderingTest,
@@ -19,7 +20,10 @@ discourseModule(
       template: hbs`{{chat-retention-reminder chatChannel=chatChannel}}`,
 
       async beforeEach() {
-        this.set("chatChannel", { chatable_type: "Category" });
+        this.set(
+          "chatChannel",
+          ChatChannel.create({ chatable_type: "Category" })
+        );
         set(this.currentUser, "needs_channel_retention_reminder", true);
         set(this.siteSettings, "chat_channel_retention_days", 100);
       },
@@ -38,7 +42,10 @@ discourseModule(
         template: hbs`{{chat-retention-reminder chatChannel=chatChannel}}`,
 
         async beforeEach() {
-          this.set("chatChannel", { chatable_type: "Category" });
+          this.set(
+            "chatChannel",
+            ChatChannel.create({ chatable_type: "Category" })
+          );
           set(this.currentUser, "needs_channel_retention_reminder", false);
           set(this.siteSettings, "chat_channel_retention_days", 100);
         },
@@ -53,7 +60,10 @@ discourseModule(
       template: hbs`{{chat-retention-reminder chatChannel=chatChannel}}`,
 
       async beforeEach() {
-        this.set("chatChannel", { chatable_type: "DirectMessageChannel" });
+        this.set(
+          "chatChannel",
+          ChatChannel.create({ chatable_type: "DirectMessageChannel" })
+        );
         set(this.currentUser, "needs_dm_retention_reminder", true);
         set(this.siteSettings, "chat_dm_retention_days", 100);
       },
@@ -70,7 +80,10 @@ discourseModule(
       template: hbs`{{chat-retention-reminder chatChannel=chatChannel}}`,
 
       async beforeEach() {
-        this.set("chatChannel", { chatable_type: "DirectMessageChannel" });
+        this.set(
+          "chatChannel",
+          ChatChannel.create({ chatable_type: "DirectMessageChannel" })
+        );
         set(this.currentUser, "needs_dm_retention_reminder", false);
         set(this.siteSettings, "chat_dm_retention_days", 100);
       },

--- a/test/javascripts/helpers/fabricators.js
+++ b/test/javascripts/helpers/fabricators.js
@@ -39,14 +39,16 @@ export default function fabricate(model, options = {}) {
   let base;
 
   if (model === "chat-channel") {
-    base = ChatChannel.create(
-      defaultChatChannelForType(
-        options.chatable_type || CHATABLE_TYPES.topicChannel
-      )
+    base = defaultChatChannelForType(
+      options.chatable_type || CHATABLE_TYPES.topicChannel
     );
   } else {
     throw `Unkown fabricator ${model}`;
   }
 
-  return Object.assign(base, options);
+  const final = Object.assign(base, options);
+  switch (model) {
+    case "chat-channel":
+      return ChatChannel.create(final);
+  }
 }

--- a/test/javascripts/helpers/fabricators.js
+++ b/test/javascripts/helpers/fabricators.js
@@ -1,4 +1,6 @@
-import { CHATABLE_TYPES } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
+import ChatChannel, {
+  CHATABLE_TYPES,
+} from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 
 function defaultChatChannelForType(chatableType) {
   const base = {
@@ -37,8 +39,10 @@ export default function fabricate(model, options = {}) {
   let base;
 
   if (model === "chat-channel") {
-    base = defaultChatChannelForType(
-      options.chatable_type || CHATABLE_TYPES.topicChannel
+    base = ChatChannel.create(
+      defaultChatChannelForType(
+        options.chatable_type || CHATABLE_TYPES.topicChannel
+      )
     );
   } else {
     throw `Unkown fabricator ${model}`;


### PR DESCRIPTION
We now create ChatChannel model instances in the chat
JS code, so we can add shorthand methods for checking
the chatable type instead of comparing directly to
a hardcoded string, and in the places where this does
not fit this commit changes the comparison to look
at the CHATABLE_TYPES const.

Also standardises in more places to use instances of
`ChatChannel` instead of `EmberObject`