### PR TITLE
DEV: Make topic selection component reusable from move modal

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1172,7 +1172,7 @@ export default Component.extend({
   moveMessagesToTopic() {
     showModal("move-chat-to-topic").setProperties({
       chatMessageIds: this.selectedMessageIds,
-      chatChannelId: this.chatChannel.id,
+      chatChannel: this.chatChannel,
     });
   },
 

--- a/assets/javascripts/discourse/components/chat-to-topic-selector.js
+++ b/assets/javascripts/discourse/components/chat-to-topic-selector.js
@@ -1,0 +1,44 @@
+import Component from "@ember/component";
+import discourseComputed from "discourse-common/utils/decorators";
+import { alias, equal } from "@ember/object/computed";
+
+const NEW_TOPIC_SELECTION = "newTopic";
+const EXISTING_TOPIC_SELECTION = "existingTopic";
+const NEW_MESSAGE_SELECTION = "newMessage";
+
+export default Component.extend({
+  newTopicSelection: NEW_TOPIC_SELECTION,
+  existingTopicSelection: EXISTING_TOPIC_SELECTION,
+  newMessageSelection: NEW_MESSAGE_SELECTION,
+
+  selection: null,
+  newTopic: equal("selection", NEW_TOPIC_SELECTION),
+  existingTopic: equal("selection", EXISTING_TOPIC_SELECTION),
+  newMessage: equal("selection", NEW_MESSAGE_SELECTION),
+  canAddTags: alias("site.can_create_tag"),
+  canTagMessages: alias("site.can_tag_pms"),
+
+  topicTitle: null,
+  categoryId: null,
+  tags: null,
+  selectedTopicId: null,
+
+  // TODO (martin) (maybe just use channel not id)
+  chatMessageIds: null,
+  chatChannelId: null,
+
+  @discourseComputed()
+  newTopicInstruction() {
+    return this.instructionLabels[NEW_TOPIC_SELECTION];
+  },
+
+  @discourseComputed()
+  existingTopicInstruction() {
+    return this.instructionLabels[EXISTING_TOPIC_SELECTION];
+  },
+
+  @discourseComputed()
+  newMessageInstruction() {
+    return this.instructionLabels[NEW_MESSAGE_SELECTION];
+  },
+});

--- a/assets/javascripts/discourse/components/chat-to-topic-selector.js
+++ b/assets/javascripts/discourse/components/chat-to-topic-selector.js
@@ -23,7 +23,6 @@ export default Component.extend({
   tags: null,
   selectedTopicId: null,
 
-  // TODO (martin) (maybe just use channel not id)
   chatMessageIds: null,
   chatChannelId: null,
 

--- a/assets/javascripts/discourse/controllers/move-chat-to-topic.js
+++ b/assets/javascripts/discourse/controllers/move-chat-to-topic.js
@@ -14,16 +14,10 @@ const EXISTING_TOPIC_SELECTION = "existingTopic";
 const NEW_MESSAGE_SELECTION = "newMessage";
 
 export default Controller.extend(ModalFunctionality, {
-  newTopicSelection: NEW_TOPIC_SELECTION,
-  existingTopicSelection: EXISTING_TOPIC_SELECTION,
-  newMessageSelection: NEW_MESSAGE_SELECTION,
-
   selection: "newTopic",
   newTopic: equal("selection", NEW_TOPIC_SELECTION),
   existingTopic: equal("selection", EXISTING_TOPIC_SELECTION),
   newMessage: equal("selection", NEW_MESSAGE_SELECTION),
-  canAddTags: alias("site.can_create_tag"),
-  canTagMessages: alias("site.can_tag_pms"),
 
   saving: false,
   topicTitle: null,
@@ -33,6 +27,30 @@ export default Controller.extend(ModalFunctionality, {
 
   onShow() {
     this.set("selection", NEW_TOPIC_SELECTION);
+  },
+
+  @discourseComputed()
+  instructionLabels() {
+    const labels = {};
+    labels[NEW_TOPIC_SELECTION] = I18n.t(
+      "chat.selection.new_topic.instructions",
+      {
+        count: this.chatMessageIds.length,
+      }
+    );
+    labels[EXISTING_TOPIC_SELECTION] = I18n.t(
+      "chat.selection.existing_topic.instructions",
+      {
+        count: this.chatMessageIds.length,
+      }
+    );
+    labels[NEW_MESSAGE_SELECTION] = I18n.t(
+      "chat.selection.new_message.instructions",
+      {
+        count: this.chatMessageIds.length,
+      }
+    );
+    return labels;
   },
 
   @discourseComputed("saving", "selectedTopicId", "topicTitle", "selection")
@@ -78,7 +96,7 @@ export default Controller.extend(ModalFunctionality, {
     const data = {
       type: this.selection,
       chat_message_ids: this.chatMessageIds,
-      chat_channel_id: this.chatChannelId,
+      chat_channel_id: this.chatChannel.id,
     };
     if (this.newTopic || this.newMessage) {
       data.title = this.topicTitle;

--- a/assets/javascripts/discourse/controllers/move-chat-to-topic.js
+++ b/assets/javascripts/discourse/controllers/move-chat-to-topic.js
@@ -4,7 +4,7 @@ import DiscourseURL from "discourse/lib/url";
 import I18n from "I18n";
 import ModalFunctionality from "discourse/mixins/modal-functionality";
 import { action } from "@ember/object";
-import { alias, equal } from "@ember/object/computed";
+import { equal } from "@ember/object/computed";
 import { ajax } from "discourse/lib/ajax";
 import { extractError } from "discourse/lib/ajax-error";
 import { isEmpty } from "@ember/utils";

--- a/assets/javascripts/discourse/templates/components/chat-to-topic-selector.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-to-topic-selector.hbs
@@ -15,43 +15,42 @@
   </div>
 
   {{#if newTopic}}
-  <p>{{html-safe newTopicInstruction}}</p>
-  <form>
-    <label>{{i18n "topic.split_topic.topic_name"}}</label>
-    {{text-field value=topicTitle placeholderKey="composer.title_placeholder" id="split-topic-name"}}
+    <p>{{html-safe newTopicInstruction}}</p>
+    <form>
+      <label>{{i18n "topic.split_topic.topic_name"}}</label>
+      {{text-field value=topicTitle placeholderKey="composer.title_placeholder" id="split-topic-name"}}
 
-    <label>{{i18n "categories.category"}}</label>
+      <label>{{i18n "categories.category"}}</label>
       {{category-chooser
         value=categoryId
         class="small"
-        onChange=(action (mut categoryId))
-      }}
-    {{#if canAddTags}}
-      <label>{{i18n "tagging.tags"}}</label>
-      {{tag-chooser tags=tags filterable=true categoryId=categoryId}}
-    {{/if}}
-  </form>
+        onChange=(action (mut categoryId))}}
+
+      {{#if canAddTags}}
+        <label>{{i18n "tagging.tags"}}</label>
+        {{tag-chooser tags=tags filterable=true categoryId=categoryId}}
+      {{/if}}
+    </form>
   {{/if}}
 
   {{#if existingTopic}}
-  <p>{{html-safe existingTopicInstruction}}</p>
-  <form>
-    {{choose-topic selectedTopicId=selectedTopicId}}
-  </form>
+    <p>{{html-safe existingTopicInstruction}}</p>
+    <form>
+      {{choose-topic selectedTopicId=selectedTopicId}}
+    </form>
   {{/if}}
 
-  <!-- this should not always show newMessage e.g. for archive -->
-  {{#if newMessage}}
-  <p>{{html-safe newMessageInstruction}}</p>
-  <form>
-    <label>{{i18n "topic.move_to_new_message.message_title"}}</label>
-    {{text-field value=topicTitle placeholderKey="composer.title_placeholder" id="split-topic-name"}}
+  {{#if (and allowNewMessage newMessage)}}
+    <p>{{html-safe newMessageInstruction}}</p>
+    <form>
+      <label>{{i18n "topic.move_to_new_message.message_title"}}</label>
+      {{text-field value=topicTitle placeholderKey="composer.title_placeholder" id="split-topic-name"}}
 
-    {{#if canTagMessages}}
-      <label>{{i18n "tagging.tags"}}</label>
-      {{tag-chooser tags=tags filterable=true}}
-    {{/if}}
-  </form>
+      {{#if canTagMessages}}
+        <label>{{i18n "tagging.tags"}}</label>
+        {{tag-chooser tags=tags filterable=true}}
+      {{/if}}
+    </form>
   {{/if}}
 </div>
 

--- a/assets/javascripts/discourse/templates/components/chat-to-topic-selector.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-to-topic-selector.hbs
@@ -1,0 +1,57 @@
+<div class="move-chat-to-topic-inner">
+  <div class="radios">
+    <label class="radio-label" for="move-to-new-topic">
+      {{radio-button id="move-to-new-topic" name="move-to-entity" value=newTopicSelection selection=selection}}
+      <b>{{i18n "topic.split_topic.radio_label"}}</b>
+    </label>
+    <label class="radio-label" for="move-to-existing-topic">
+      {{radio-button id="move-to-existing-topic" name="move-to-entity" value=existingTopicSelection selection=selection}}
+      <b>{{i18n "topic.merge_topic.radio_label"}}</b>
+    </label>
+    <label class="radio-label" for="move-to-new-message">
+      {{radio-button id="move-to-new-message" name="move-to-entity" value=newMessageSelection selection=selection}}
+      <b>{{i18n "topic.move_to_new_message.radio_label"}}</b>
+    </label>
+  </div>
+
+  {{#if newTopic}}
+  <p>{{html-safe newTopicInstruction}}</p>
+  <form>
+    <label>{{i18n "topic.split_topic.topic_name"}}</label>
+    {{text-field value=topicTitle placeholderKey="composer.title_placeholder" id="split-topic-name"}}
+
+    <label>{{i18n "categories.category"}}</label>
+      {{category-chooser
+        value=categoryId
+        class="small"
+        onChange=(action (mut categoryId))
+      }}
+    {{#if canAddTags}}
+      <label>{{i18n "tagging.tags"}}</label>
+      {{tag-chooser tags=tags filterable=true categoryId=categoryId}}
+    {{/if}}
+  </form>
+  {{/if}}
+
+  {{#if existingTopic}}
+  <p>{{html-safe existingTopicInstruction}}</p>
+  <form>
+    {{choose-topic selectedTopicId=selectedTopicId}}
+  </form>
+  {{/if}}
+
+  <!-- this should not always show newMessage e.g. for archive -->
+  {{#if newMessage}}
+  <p>{{html-safe newMessageInstruction}}</p>
+  <form>
+    <label>{{i18n "topic.move_to_new_message.message_title"}}</label>
+    {{text-field value=topicTitle placeholderKey="composer.title_placeholder" id="split-topic-name"}}
+
+    {{#if canTagMessages}}
+      <label>{{i18n "tagging.tags"}}</label>
+      {{tag-chooser tags=tags filterable=true}}
+    {{/if}}
+  </form>
+  {{/if}}
+</div>
+

--- a/assets/javascripts/discourse/templates/modal/move-chat-to-topic.hbs
+++ b/assets/javascripts/discourse/templates/modal/move-chat-to-topic.hbs
@@ -6,6 +6,7 @@
     tags=tags
     selectedTopicId=selectedTopicId
     instructionLabels=instructionLabels
+    allowNewMessage=true
   }}
 {{/d-modal-body}}
 

--- a/assets/javascripts/discourse/templates/modal/move-chat-to-topic.hbs
+++ b/assets/javascripts/discourse/templates/modal/move-chat-to-topic.hbs
@@ -1,60 +1,12 @@
 {{#d-modal-body title="chat.selection.title"}}
-  <div class="move-chat-to-topic-inner">
-    <div class="radios">
-      <label class="radio-label" for="move-to-new-topic">
-        {{radio-button id="move-to-new-topic" name="move-to-entity" value=newTopicSelection selection=selection}}
-        <b>{{i18n "topic.split_topic.radio_label"}}</b>
-      </label>
-      <label class="radio-label" for="move-to-existing-topic">
-        {{radio-button id="move-to-existing-topic" name="move-to-entity" value=existingTopicSelection selection=selection}}
-        <b>{{i18n "topic.merge_topic.radio_label"}}</b>
-      </label>
-      <label class="radio-label" for="move-to-new-message">
-        {{radio-button id="move-to-new-message" name="move-to-entity" value=newMessageSelection selection=selection}}
-        <b>{{i18n "topic.move_to_new_message.radio_label"}}</b>
-      </label>
-    </div>
-
-    {{#if newTopic}}
-      <p>{{html-safe (i18n "chat.selection.new_topic.instructions" count=chatMessageIds.length)}}</p>
-      <form>
-        <label>{{i18n "topic.split_topic.topic_name"}}</label>
-        {{text-field value=topicTitle placeholderKey="composer.title_placeholder" id="split-topic-name"}}
-
-        <label>{{i18n "categories.category"}}</label>
-        {{category-chooser
-          value=categoryId
-          class="small"
-          onChange=(action (mut categoryId))
-        }}
-        {{#if canAddTags}}
-          <label>{{i18n "tagging.tags"}}</label>
-          {{tag-chooser tags=tags filterable=true categoryId=categoryId}}
-        {{/if}}
-      </form>
-    {{/if}}
-
-    {{#if existingTopic}}
-      <p>{{html-safe (i18n "chat.selection.existing_topic.instructions" count=chatMessageIds.length)}}</p>
-      <form>
-        {{choose-topic selectedTopicId=selectedTopicId}}
-      </form>
-    {{/if}}
-
-    {{#if newMessage}}
-      <p>{{html-safe (i18n "chat.selection.new_message.instructions" count=chatMessageIds.length)}}</p>
-      <form>
-        <label>{{i18n "topic.move_to_new_message.message_title"}}</label>
-        {{text-field value=topicTitle placeholderKey="composer.title_placeholder" id="split-topic-name"}}
-
-        {{#if canTagMessages}}
-          <label>{{i18n "tagging.tags"}}</label>
-          {{tag-chooser tags=tags filterable=true}}
-        {{/if}}
-      </form>
-    {{/if}}
-  </div>
-
+  {{chat-to-topic-selector
+    selection=selection
+    topicTitle=topicTitle
+    categoryId=categoryId
+    tags=tags
+    selectedTopicId=selectedTopicId
+    instructionLabels=instructionLabels
+  }}
 {{/d-modal-body}}
 
 <div class="modal-footer">
@@ -64,5 +16,10 @@
     title="chat.selection.cancel"
     action=(action "cancel")
   }}
-  {{d-button class="btn-primary" disabled=buttonDisabled action=(action "perform") icon="sign-out-alt" translatedLabel=buttonTitle}}
+  {{d-button
+    class="btn-primary"
+    disabled=buttonDisabled
+    action=(action "perform")
+    icon="sign-out-alt"
+    translatedLabel=buttonTitle}}
 </div>


### PR DESCRIPTION
The move chat messages to topic modal has the same inner
selection component as the "move posts to topic" modal from
core. This topic selection functionality will be needed for
the archive chat channel functionality.

This commit moves the inner elements into a new chat-to-topic-selector
component, which can be used from any modal component.

For reference it is this modal:

![image](https://user-images.githubusercontent.com/920448/155927006-36ab46b1-e508-4799-82f6-061da0ca7619.png)
