### PR TITLE
FIX: Ability to react to previously staged message

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -640,6 +640,9 @@ export default Component.extend({
         ) {
           stagedMessage.set("cooked", data.chat_message.cooked);
         }
+        this.appEvents.trigger(
+          `chat-message-staged-${data.stagedId}:id-populated`
+        );
 
         this.messageLookup[data.chat_message.id] = stagedMessage;
         delete this.messageLookup[`staged-${data.stagedId}`];

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -974,6 +974,51 @@ Widget.triangulate(arg: "test")
     assert.ok(sneezingFaceReaction.classList.contains("reacted"));
   });
 
+  test("Reacting and unreacting works on newly created chat messages", async function (assert) {
+    await visit("/chat/channel/9/Site");
+    const composerInput = query(".chat-composer-input");
+    await fillIn(composerInput, "hellloooo");
+    await focus(composerInput);
+    await triggerKeyEvent(composerInput, "keydown", 13); // 13 is enter keycode. Send message
+    const messages = queryAll(".chat-message-container");
+    const lastMessage = messages[messages.length - 1];
+    publishToMessageBus("/chat/9", {
+      typ: "sent",
+      stagedId: 1,
+      chat_message: {
+        id: 202,
+        user: {
+          id: 1,
+        },
+        cooked: "<p>hellloooo</p>",
+      },
+    });
+    await chatSettled();
+    assert.ok(lastMessage.classList.contains("chat-message-container-202"));
+    await click(lastMessage.querySelector(".chat-msgactions .react-btn"));
+    await click(
+      lastMessage.querySelector(
+        ".emoji-picker .section-group .emoji[alt='grin']"
+      )
+    );
+
+    const reaction = lastMessage.querySelector(
+      ".chat-message-reaction.grin.reacted"
+    );
+    publishToMessageBus("/chat/9", {
+      action: "add",
+      user: { id: 1, username: "eviltrout" },
+      emoji: "grin",
+      typ: "reaction",
+      chat_message_id: 202,
+    });
+    await chatSettled();
+    await click(reaction);
+    assert.notOk(
+      lastMessage.querySelector(".chat-message-reaction.grin.reacted")
+    );
+  });
+
   test("mention warning is rendered", async function (assert) {
     await visit("/chat/channel/9/Site");
     publishToMessageBus("/chat/9", {


### PR DESCRIPTION
Previously, chat messages subscribed to `appEvents` channels for reactions on `init`. This is a problem because newly created messages (by you the sender), do not have an `id` in `init`. The `id` is hydrated later when message_bus sends the `id` along with the `staged-id` to the sender's client.

This checks for an `id` in `init`. If one is present, continue with the logic as it were before. If there is no ID present, subscribe to a new `appEvents` channel for hydrating `ids`, with the callback of subscribing to the normal `appEvent` channels.

The logic might look a bit funky with more appEvents, but this avoids throwing an `observes` in `chat-message` for when `stagedId` changes.