### PR TITLE
FIX: Preserve uploads with associated ChatUpload

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -155,10 +155,10 @@ after_initialize do
     results
   end
 
-  if respond_to?(:register_upload_unused_callback)
-    register_upload_unused_callback do |uploads|
+  if respond_to?(:register_upload_unused)
+    register_upload_unused do |uploads|
       uploads
-        .joins("LEFT JOIN chat_uploads pu ON cu.upload_id = uploads.id")
+        .joins("LEFT JOIN chat_uploads cu ON cu.upload_id = uploads.id")
         .where("cu.upload_id IS NULL")
     end
   end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'discourse-chat' do
+  before do
+    SiteSetting.clean_up_uploads = true
+    SiteSetting.clean_orphan_uploads_grace_period_hours = 1
+    Jobs::CleanUpUploads.new.reset_last_cleanup!
+  end
+
+  describe 'register_upload_unused' do
+    fab!(:chat_channel) { Fabricate(:chat_channel, chatable: Fabricate(:topic)) }
+    fab!(:user) { Fabricate(:user) }
+    fab!(:upload) { Fabricate(:upload, user: user, created_at: 1.month.ago) }
+    fab!(:unused_upload) { Fabricate(:upload, user: user, created_at: 1.month.ago) }
+
+    let!(:chat_message) do
+      DiscourseChat::ChatMessageCreator.create(
+        chat_channel: chat_channel,
+        user: user,
+        in_reply_to_id: nil,
+        content: "Hello world!",
+        upload_ids: [upload.id]
+      )
+    end
+
+    it 'marks uploads with ChatUpload in use' do
+      unused_upload
+
+      expect { Jobs::CleanUpUploads.new.execute({}) }.to change { Upload.count }.by(-1)
+      expect(Upload.exists?(id: upload.id)).to eq(true)
+      expect(Upload.exists?(id: unused_upload.id)).to eq(false)
+    end
+  end
+
+  describe 'register_upload_in_use' do
+    fab!(:chat_channel) { Fabricate(:chat_channel, chatable: Fabricate(:topic)) }
+    fab!(:user) { Fabricate(:user) }
+    fab!(:message_upload) { Fabricate(:upload, user: user, created_at: 1.month.ago) }
+    fab!(:draft_upload) { Fabricate(:upload, user: user, created_at: 1.month.ago) }
+    fab!(:unused_upload) { Fabricate(:upload, user: user, created_at: 1.month.ago) }
+
+    let!(:chat_message) do
+      DiscourseChat::ChatMessageCreator.create(
+        chat_channel: chat_channel,
+        user: user,
+        in_reply_to_id: nil,
+        content: "Hello world! #{message_upload.sha1}",
+        upload_ids: []
+      )
+    end
+
+    let!(:draft_message) do
+      ChatDraft.create!(
+        user: user,
+        chat_channel: chat_channel,
+        data: "{\"value\":\"hello world \",\"uploads\":[\"#{draft_upload.sha1}\"],\"replyToMsg\":null}"
+      )
+    end
+
+    it 'marks uploads with ChatUpload in use' do
+      draft_upload
+      unused_upload
+
+      expect { Jobs::CleanUpUploads.new.execute({}) }.to change { Upload.count }.by(-1)
+      expect(Upload.exists?(id: message_upload.id)).to eq(true)
+      expect(Upload.exists?(id: draft_upload.id)).to eq(true)
+      expect(Upload.exists?(id: unused_upload.id)).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
The core plugin API changed while it was still under development and the
plugin was not. These changes fix the issue and add tests to prevent
similar future bugs.