### PR TITLE
FIX: Ensure online flair is shown correctly on replies

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -502,7 +502,7 @@ body.composer-open .topic-chat-float-container {
         bottom: -1px;
       }
 
-      .chat-message:not(.is-reply) & {
+      .chat-message & {
         width: 10px;
         height: 10px;
         right: 0px;


### PR DESCRIPTION
Before:
<img width="113" alt="Screenshot 2022-03-03 at 00 19 28" src="https://user-images.githubusercontent.com/6270921/156472003-0e387c53-2171-47f0-abe8-ad8cb925b74b.png">

After:

<img width="164" alt="Screenshot 2022-03-03 at 00 19 16" src="https://user-images.githubusercontent.com/6270921/156472013-5c594882-383c-42c8-b082-79033e4f3d96.png">

