### PR TITLE
FIX: Show deleted messages if can moderate

### DIFF
--- a/app/serializers/chat_view_serializer.rb
+++ b/app/serializers/chat_view_serializer.rb
@@ -17,7 +17,8 @@ class ChatViewSerializer < ApplicationSerializer
     meta_hash = {
       can_flag: scope.can_flag_in_chat_channel?(object.chat_channel),
       channel_status: object.chat_channel.status,
-      user_silenced: !scope.can_create_chat_message?
+      user_silenced: !scope.can_create_chat_message?,
+      can_moderate: scope.can_moderate_chat?(object.chat_channel.chatable)
     }
     meta_hash[:can_load_more_past] = object.can_load_more_past unless object.can_load_more_past.nil?
     meta_hash[:can_load_more_future] = object.can_load_more_future unless object.can_load_more_future.nil?

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -286,6 +286,7 @@ export default Component.extend({
         can_delete_others: this.currentUser.staff,
         can_flag: messages.resultSetMeta.can_flag,
         user_silenced: messages.resultSetMeta.user_silenced,
+        can_moderate: messages.resultSetMeta.can_moderate,
       },
       registeredChatChannelId: this.chatChannel.id,
     });

--- a/assets/javascripts/discourse/components/chat-message.js
+++ b/assets/javascripts/discourse/components/chat-message.js
@@ -208,12 +208,13 @@ export default Component.extend({
     this[value].call();
   },
 
-  @discourseComputed("message")
-  show(message) {
+  @discourseComputed("message", "details.can_moderate")
+  show(message, canModerate) {
     return (
       !message.deleted_at ||
       this.currentUser === this.message.user.id ||
-      this.currentUser.staff
+      this.currentUser.staff ||
+      canModerate
     );
   },
 

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -62,6 +62,21 @@ RSpec.describe DiscourseChat::ChatController do
       expect(response.parsed_body["meta"]["can_flag"]).to be false
     end
 
+    it "returns `can_moderate=true` based on whether the user can moderate the chatable" do
+      user.update!(trust_level: 1)
+      get "/chat/#{chat_channel.id}/messages.json", params: { page_size: page_size }
+      expect(response.parsed_body["meta"]["can_moderate"]).to be false
+      user.update!(trust_level: 4)
+      get "/chat/#{chat_channel.id}/messages.json", params: { page_size: page_size }
+      expect(response.parsed_body["meta"]["can_moderate"]).to be true
+      chat_channel.update!(chatable: Fabricate(:category))
+      get "/chat/#{chat_channel.id}/messages.json", params: { page_size: page_size }
+      expect(response.parsed_body["meta"]["can_moderate"]).to be false
+      user.update!(admin: true)
+      get "/chat/#{chat_channel.id}/messages.json", params: { page_size: page_size }
+      expect(response.parsed_body["meta"]["can_moderate"]).to be true
+    end
+
     it "serializes `user_flag_status` for user who has a pending flag" do
       chat_message = chat_channel.chat_messages.last
       chat_message.add_flag(user)


### PR DESCRIPTION
When a user can moderate a channel, we allow the API to
return deleted messages in the JSON payload, but we do
not show the messages in the UI with the "A message was
deleted" message and [view] button. This PR corrects this
by providing the can_moderate boolean in the chat view
meta payload, and using that to determine whether to
show the message alongside existing conditions.