### PR TITLE
DEV: Fix chat_channel timestamp migrations

### DIFF
--- a/db/migrate/20210813141741_add_timestamps_to_chat_channels.rb
+++ b/db/migrate/20210813141741_add_timestamps_to_chat_channels.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 class AddTimestampsToChatChannels < ActiveRecord::Migration[6.1]
   def change
-    add_column :chat_channels, :created_at, :timestamp, null: false
-    add_column :chat_channels, :updated_at, :timestamp, null: false
+    add_column :chat_channels, :created_at, :timestamp
+    add_column :chat_channels, :updated_at, :timestamp
+
+    DB.exec("UPDATE chat_channels SET created_at = NOW() WHERE created_at IS NULL")
+    DB.exec("UPDATE chat_channels SET updated_at = NOW() WHERE updated_at IS NULL")
+
+    change_column_null :chat_channels, :created_at, false
+    change_column_null :chat_channels, :updated_at, false
   end
 end

--- a/db/migrate/20210813141741_add_timestamps_to_chat_channels.rb
+++ b/db/migrate/20210813141741_add_timestamps_to_chat_channels.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class AddTimestampsToChatChannels < ActiveRecord::Migration[6.1]
   def change
-    add_column :chat_channels, :created_at, :datetime, null: false, default: Time.now
-    add_column :chat_channels, :updated_at, :datetime, null: false, default: Time.now
+    add_column :chat_channels, :created_at, :timestamp, null: false
+    add_column :chat_channels, :updated_at, :timestamp, null: false
   end
 end

--- a/db/post_migrate/20220104051326_change_chat_channels_timestamp_columns_to_timestamp_type.rb
+++ b/db/post_migrate/20220104051326_change_chat_channels_timestamp_columns_to_timestamp_type.rb
@@ -4,7 +4,16 @@ class ChangeChatChannelsTimestampColumnsToTimestampType < ActiveRecord::Migratio
   def change
     change_column_default :chat_channels, :created_at, nil
     change_column_default :chat_channels, :updated_at, nil
-    change_column :chat_channels, :created_at, :timestamp
-    change_column :chat_channels, :updated_at, :timestamp
+
+    # the earlier AddTimestampsToChatChannels migration has been modified,
+    # originally it added the columns as :datetime types, now it has been
+    # changed to use the correct :timestamp type, this exists check is here so
+    # we only try and make this change on old tables created before
+    if !column_exists?(:chat_channels, :created_at, :timestamp)
+      change_column :chat_channels, :created_at, :timestamp
+    end
+    if !column_exists?(:chat_channels, :updated_at, :timestamp)
+      change_column :chat_channels, :updated_at, :timestamp
+    end
   end
 end


### PR DESCRIPTION
The way the fix from 31de9ae70a021e32fee92b343f392e524f32c9b5
was applied for sites that have never had chat enabled left
ActiveRecord in a weird state until the next deploy, where
there were errors raised saying "created_at can not be null".
Presumably this is because of "Rails Magic TM" that is fixed
on a subsequent deploy. This commit attempts to fix the original
migration even further, so we should not encounter this again
when turning on chat for sites in future.