### PR TITLE
FEATURE: Add chat_default_channel_id site setting

### DIFF
--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -394,7 +394,7 @@ export default Service.extend({
         publicChannelWithUnread ||
         defaultChannel ||
         publicChannel ||
-        dmChannel 
+        dmChannel
       );
     });
   },
@@ -576,8 +576,9 @@ export default Service.extend({
         ].chat_message_id = busData.message_id;
       } else {
         // Message from other user. Increment trackings state
-        const trackingState =
-          this.currentUser.chat_channel_tracking_state[channel.id];
+        const trackingState = this.currentUser.chat_channel_tracking_state[
+          channel.id
+        ];
         if (busData.message_id > (trackingState.chat_message_id || 0)) {
           trackingState.unread_count = trackingState.unread_count + 1;
         }
@@ -598,8 +599,9 @@ export default Service.extend({
 
   _subscribeToMentionChannel(channel) {
     this.messageBus.subscribe(`/chat/${channel.id}/new-mentions`, () => {
-      const trackingState =
-        this.currentUser.chat_channel_tracking_state[channel.id];
+      const trackingState = this.currentUser.chat_channel_tracking_state[
+        channel.id
+      ];
       if (trackingState) {
         trackingState.unread_mentions =
           (trackingState.unread_mentions || 0) + 1;
@@ -669,8 +671,9 @@ export default Service.extend({
           return this.forceRefreshChannels();
         }
 
-        const trackingState =
-          this.currentUser.chat_channel_tracking_state[busData.chat_channel_id];
+        const trackingState = this.currentUser.chat_channel_tracking_state[
+          busData.chat_channel_id
+        ];
         if (trackingState) {
           trackingState.chat_message_id = busData.chat_message_id;
           trackingState.unread_count = 0;
@@ -688,8 +691,9 @@ export default Service.extend({
   },
 
   resetTrackingStateForChannel(channelId) {
-    const trackingState =
-      this.currentUser.chat_channel_tracking_state[channelId];
+    const trackingState = this.currentUser.chat_channel_tracking_state[
+      channelId
+    ];
     if (trackingState) {
       trackingState.unread_count = 0;
       this.userChatChannelTrackingStateChanged();

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -380,7 +380,7 @@ export default Service.extend({
             publicChannelWithUnread = channel;
           } else if (
             !defaultChannel &&
-            this.siteSettings.chat_default_channel_id == channel
+            this.siteSettings.chat_default_channel_id === parseInt(channel, 10)
           ) {
             defaultChannel = channel;
           } else if (!publicChannel) {

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -380,7 +380,7 @@ export default Service.extend({
             publicChannelWithUnread = channel;
           } else if (
             !defaultChannel &&
-            this.siteSettings.chat_default_channel_id === channel
+            this.siteSettings.chat_default_channel_id == channel
           ) {
             defaultChannel = channel;
           } else if (!publicChannel) {

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -9,6 +9,9 @@ en:
     chat_allowed_messages_for_other_trust_levels: "Number of messages that users with trust levels 1-4 is allowed to send in 30 seconds. Set to '0' to disable limit."
     chat_silence_user_sensitivity: "The likelihood that a user flagged in chat will be automatically silenced."
     chat_auto_silence_from_flags_duration: "Number of minutes that users will be silenced for when they are automatically silenced due to flagged chat messages."
+    chat_default_channel_id: "The chat channel that will be opened by default when a user has no unread messages or mentions in other channels."
+    errors:
+      chat_default_channel: "The default chat channel must be a public channel."
 
   chat:
     errors:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -41,3 +41,7 @@ plugins:
   chat_auto_silence_from_flags_duration:
     default: 60
     min: 0
+  chat_default_channel_id:
+    default: ""
+    client: true
+    validator: "ChatDefaultChannelValidator"

--- a/lib/validators/chat_default_channel_validator.rb
+++ b/lib/validators/chat_default_channel_validator.rb
@@ -6,7 +6,7 @@ class ChatDefaultChannelValidator
   end
 
   def valid_value?(value)
-    return false if !ChatChannel.public_channels.pluck(:id).include?(value.to_i)
+    return false if value != "" && !ChatChannel.public_channels.pluck(:id).include?(value.to_i)
     true
   end
 

--- a/lib/validators/chat_default_channel_validator.rb
+++ b/lib/validators/chat_default_channel_validator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ChatDefaultChannelValidator
+  def initialize(opts = {})
+    @opts = opts
+  end
+
+  def valid_value?(value)
+    return false if !ChatChannel.public_channels.pluck(:id).include?(value.to_i)
+    true
+  end
+
+  def error_message
+    I18n.t("site_settings.errors.chat_default_channel")
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -33,6 +33,9 @@ register_svg_icon "file-image"
 # route: /admin/plugins/chat
 add_admin_route 'chat.admin.title', 'chat'
 
+# Site setting validators must be loaded before initialize
+require_relative "lib/validators/chat_default_channel_validator.rb"
+
 after_initialize do
   module ::DiscourseChat
     PLUGIN_NAME = "discourse-chat"

--- a/spec/validators/chat_default_channel_validator_spec.rb
+++ b/spec/validators/chat_default_channel_validator_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ChatDefaultChannelValidator do
+  fab!(:public_channel) { Fabricate(:chat_channel) }
+
+  it "returns true if public channel id" do
+    validator = described_class.new
+    expect(validator.valid_value?(public_channel.id)).to eq(true)
+    expect(validator.error_message).to eq(I18n.t("site_settings.errors.chat_default_channel"))
+  end
+
+  it "returns true if 0" do
+    validator = described_class.new
+    expect(validator.valid_value?("")).to eq(true)
+    expect(validator.error_message).to eq(I18n.t("site_settings.errors.chat_default_channel"))
+  end
+
+  it "returns false if not a public channel and not 0" do
+    validator = described_class.new
+    expect(validator.valid_value?(420)).to eq(false)
+    expect(validator.error_message).to eq(I18n.t("site_settings.errors.chat_default_channel"))
+  end
+end


### PR DESCRIPTION
This setting will make the user navigate to the selected
public channel when opening chat IF they have no unread
messages and no mentions that they need to see. If there is
no default channel set, then the first public channel will
be shown, otherwise the first DM channel will be shown.