### PR TITLE
FIX: Move channel settings button to channel browse list

### DIFF
--- a/assets/javascripts/discourse/components/chat-channel-row.js
+++ b/assets/javascripts/discourse/components/chat-channel-row.js
@@ -19,11 +19,6 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    this.set("options", this.options || {});
-    this.set(
-      "showSettingsButton",
-      this.options.settingsButton && this.currentUser.staff
-    );
   },
 
   @discourseComputed("active", "channel.{id,muted}", "channel.focused")

--- a/assets/javascripts/discourse/components/chat-channel-status.js
+++ b/assets/javascripts/discourse/components/chat-channel-status.js
@@ -2,10 +2,22 @@ import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "I18n";
 import Component from "@ember/component";
 import { CHANNEL_STATUSES } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
+import {
+  channelStatusName,
+  channelStatusIcon,
+} from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 
 export default Component.extend({
   tagName: "",
   channel: null,
+  format: null,
+
+  init() {
+    this._super(...arguments);
+    if (!["short", "long"].includes(this.format)) {
+      this.set("format", "long");
+    }
+  },
 
   @discourseComputed("channel.status")
   channelStatusMessage(channelStatus) {
@@ -13,38 +25,32 @@ export default Component.extend({
       return null;
     }
 
+    if (this.format === "long") {
+      return this._longStatusMessage(channelStatus);
+    } else {
+      return this._shortStatusMessage(channelStatus);
+    }
+  },
+
+  @discourseComputed("channel.status")
+  channelStatusIcon(channelStatus) {
+    return channelStatusIcon(channelStatus);
+  },
+
+  _shortStatusMessage(channelStatus) {
+    return channelStatusName(channelStatus);
+  },
+
+  _longStatusMessage(channelStatus) {
     switch (channelStatus) {
       case CHANNEL_STATUSES.closed:
-        if (this.currentUser.staff) {
-          return I18n.t("chat.channel_status.closed_staff_header");
-        } else {
-          return I18n.t("chat.channel_status.closed_header");
-        }
+        return I18n.t("chat.channel_status.closed_header");
         break;
       case CHANNEL_STATUSES.readOnly:
         return I18n.t("chat.channel_status.read_only_header");
         break;
       case CHANNEL_STATUSES.archived:
         return I18n.t("chat.channel_status.archived_header");
-        break;
-    }
-  },
-
-  @discourseComputed("channel.status")
-  channelStatusIcon(channelStatus) {
-    if (channelStatus === CHANNEL_STATUSES.open) {
-      return null;
-    }
-
-    switch (channelStatus) {
-      case CHANNEL_STATUSES.closed:
-        return "lock";
-        break;
-      case CHANNEL_STATUSES.readOnly:
-        return "comment-slash";
-        break;
-      case CHANNEL_STATUSES.archived:
-        return "archive";
         break;
     }
   },

--- a/assets/javascripts/discourse/components/chat-channel-status.js
+++ b/assets/javascripts/discourse/components/chat-channel-status.js
@@ -1,10 +1,10 @@
 import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "I18n";
 import Component from "@ember/component";
-import { CHANNEL_STATUSES } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 import {
-  channelStatusName,
+  CHANNEL_STATUSES,
   channelStatusIcon,
+  channelStatusName,
 } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 
 export default Component.extend({

--- a/assets/javascripts/discourse/models/chat-channel.js
+++ b/assets/javascripts/discourse/models/chat-channel.js
@@ -26,6 +26,24 @@ export function channelStatusName(channelStatus) {
   }
 }
 
+export function channelStatusIcon(channelStatus) {
+  if (channelStatus === CHANNEL_STATUSES.open) {
+    return null;
+  }
+
+  switch (channelStatus) {
+    case CHANNEL_STATUSES.closed:
+      return "lock";
+      break;
+    case CHANNEL_STATUSES.readOnly:
+      return "comment-slash";
+      break;
+    case CHANNEL_STATUSES.archived:
+      return "archive";
+      break;
+  }
+}
+
 const STAFF_READONLY_STATUSES = [
   CHANNEL_STATUSES.readOnly,
   CHANNEL_STATUSES.archived,

--- a/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
@@ -11,10 +11,6 @@
   {{chat-channel-title channel=channel}}
   {{chat-channel-unread-indicator channel=channel}}
 
-  {{#if showSettingsButton}}
-    {{chat-channel-settings-btn channel=channel}}
-  {{/if}}
-
   {{#if options.leaveButton}}
     {{chat-channel-leave-btn
       channel=channel

--- a/assets/javascripts/discourse/templates/components/chat-channel-settings-row.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-settings-row.hbs
@@ -1,4 +1,4 @@
-<div class="{{chatChannelClass}} chat-channel-settings-row">
+<div class="{{chatChannelClass}} chat-channel-settings-row chat-channel-settings-row-{{channel.id}}">
   <div class="chat-channel-info">
     <div class="channel-title-container">
       {{#if editingName}}

--- a/assets/javascripts/discourse/templates/components/chat-channel-settings-row.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-settings-row.hbs
@@ -24,6 +24,9 @@
           {{#if currentUser.staff}}
             {{d-button icon="pencil-alt" class="edit-btn" action=(action "startEditingName")}}
           {{/if}}
+          {{#if currentUser.staff}}
+            {{chat-channel-settings-btn channel=channel}}
+          {{/if}}
           {{#if channel.following}}
             {{d-button
               class="chat-channel-expand-settings"
@@ -98,6 +101,7 @@
           • {{html-safe channel.description}}
         </div>
       {{/if}}
+      {{chat-channel-status channel=channel format="short"}}
     </div>
   </div>
 

--- a/assets/javascripts/discourse/templates/components/chat-channel-status.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-status.hbs
@@ -1,5 +1,5 @@
 {{#if channelStatusMessage}}
-  <div class="chat-channel-header-status">
+  <div class="chat-channel-status">
     {{d-icon channelStatusIcon}} {{channelStatusMessage}}
   </div>
 {{/if}}

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -378,8 +378,7 @@ body.composer-open .topic-chat-float-container {
     width: calc(100% - 75px);
   }
 
-  .edit-channels-dropdown,
-  .chat-channel-settings-btn {
+  .edit-channels-dropdown {
     .select-kit-header {
       background: none;
       border: none;
@@ -871,8 +870,7 @@ body.composer-open .topic-chat-float-container {
     opacity: 0;
   }
 
-  .chat-channel-leave-btn.btn-icon,
-  .chat-channel-settings-btn {
+  .chat-channel-leave-btn.btn-icon {
     margin-left: auto;
     visibility: hidden;
 
@@ -890,8 +888,7 @@ body.composer-open .topic-chat-float-container {
   }
 
   &:hover {
-    .chat-channel-leave-btn,
-    .chat-channel-settings-btn {
+    .chat-channel-leave-btn {
       visibility: visible;
 
       > * {
@@ -1107,7 +1104,8 @@ body.composer-open .topic-chat-float-container {
         align-items: center;
         font-weight: 500;
         .chat-channel-expand-settings,
-        .edit-btn {
+        .edit-btn,
+        .chat-channel-settings-btn {
           border: none;
           background-color: var(--secondary);
           &:hover {
@@ -1117,6 +1115,9 @@ body.composer-open .topic-chat-float-container {
           }
           .d-icon {
             color: var(--primary-medium);
+          }
+          .select-kit-header {
+            background-color: var(--secondary);
           }
         }
       }

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -161,7 +161,8 @@
 .chat-browse .chat-channel-settings-row {
   .edit-btn,
   .chat-channel-expand-settings,
-  .btn-container {
+  .btn-container,
+  .chat-channel-settings-btn {
     opacity: 0;
     transition: opacity 0.1s;
   }
@@ -169,7 +170,8 @@
   &:hover {
     .edit-btn,
     .chat-channel-expand-settings,
-    .btn-container {
+    .btn-container,
+    .chat-channel-settings-btn {
       opacity: 1;
     }
   }

--- a/assets/stylesheets/mobile/mobile.scss
+++ b/assets/stylesheets/mobile/mobile.scss
@@ -142,7 +142,7 @@ body.has-full-page-chat {
     flex-flow: row wrap;
     flex-direction: row;
 
-    .chat-channel-header-status {
+    .chat-channel-status {
       flex-basis: 100%;
       flex-grow: 0;
       margin: 0 0 0 10px;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -25,7 +25,7 @@ en:
       channel_archive:
         title: "Archive Channel"
         instructions: "<p>Archiving a channel puts it into read-only mode and moves all messages from the channel into a new or existing topic. No new messages can be sent, and no existing messages can be edited or deleted.</p><p>Are you sure you want to archive the <strong>#%{channelTitle}</strong> channel?</p>"
-        process_started: "Archiving process has started. This channel will be reloaded shortly, and you will receive a personal message when the archive process is complete."
+        process_started: "Archiving process has started. This page will be reloaded shortly, and you will receive a personal message when the archive process is complete."
       channel_list_popup:
         browse: "Browse channels"
         create: "Create a channel"
@@ -112,12 +112,11 @@ en:
       you_flagged: "You flagged this message"
       exit: "back"
       channel_status:
-        read_only_header: "Channel is read only. No new messages can be sent, and no existing messages can be edited or deleted."
+        read_only_header: "Channel is read only."
         read_only: "Read Only"
-        archived_header: "Channel is archived. No new messages can be sent, and no existing messages can be edited or deleted."
+        archived_header: "Channel is archived."
         archived: "Archived"
-        closed_header: "Channel is closed. No new messages can be sent, and no existing messages can be edited or deleted."
-        closed_staff_header: "Channel is closed."
+        closed_header: "Channel is closed."
         closed: "Closed"
         open_header: "Channel is open."
         open: "Open"

--- a/test/javascripts/acceptance/archive-channel-test.js
+++ b/test/javascripts/acceptance/archive-channel-test.js
@@ -60,11 +60,11 @@ acceptance("Discourse Chat - Archive channel", function (needs) {
     );
   });
 
-  test("it allows admins to archive the chat channel", async function (assert) {
-    await visit("/chat/channel/7/Uncategorized");
+  test("it allows admins to archive the chat channel from the chat browse page", async function (assert) {
+    await visit("/chat/browse");
 
     await click(
-      "#chat-channel-row-7 .chat-channel-settings-btn .select-kit-header-wrapper"
+      ".chat-channel-settings-row-7 .chat-channel-settings-btn .select-kit-header-wrapper"
     );
     await click("li[data-value='archiveChannel']");
     assert.ok(exists("#chat-channel-archive-modal-inner"));

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -1564,7 +1564,7 @@ acceptance(
     test("read only channel header status shows correct information", async function (assert) {
       await visit("/chat/channel/7/Uncategorized");
       assert.strictEqual(
-        query(".chat-channel-header-status").innerText.trim(),
+        query(".chat-channel-status").innerText.trim(),
         I18n.t("chat.channel_status.read_only_header")
       );
     });
@@ -1620,7 +1620,7 @@ acceptance(
     test("closed channel header status shows correct information", async function (assert) {
       await visit("/chat/channel/7/Uncategorized");
       assert.strictEqual(
-        query(".chat-channel-header-status").innerText.trim(),
+        query(".chat-channel-status").innerText.trim(),
         I18n.t("chat.channel_status.closed_header")
       );
     });


### PR DESCRIPTION
This commit moves the setting button out of the chat sidebar
on hover and into the channel browse list, because it is not
an often used action. Also shortens the status message at the
top of the channel, and adds a status indicator for the channel
in the browse list.

**Old Way**

![image](https://user-images.githubusercontent.com/920448/157154822-bcb7b053-1829-46d3-8ee3-149457678886.png)

**New Way**

![image](https://user-images.githubusercontent.com/920448/157154866-461fa0bc-ad86-4fff-83ff-22bd49edbc43.png)
