### PR TITLE
FIX: locale nesting for chat_default_channel_id site setting

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -9,6 +9,7 @@ en:
     chat_allowed_messages_for_other_trust_levels: "Number of messages that users with trust levels 1-4 is allowed to send in 30 seconds. Set to '0' to disable limit."
     chat_silence_user_sensitivity: "The likelihood that a user flagged in chat will be automatically silenced."
     chat_auto_silence_from_flags_duration: "Number of minutes that users will be silenced for when they are automatically silenced due to flagged chat messages."
+    chat_default_channel_id: "The chat channel that will be opened by default when a user has no unread messages or mentions in other channels."
     errors:
       chat_default_channel: "The default chat channel must be a public channel."
   system_messages:
@@ -22,7 +23,6 @@ en:
       subject_template: "Chat channel archive failed"
       text_body_template: |
         Archiving the chat channel **\#%{channel_name}** has failed. %{messages_archived} messages have been archived. Partially archived messages were copied into the topic [%{topic_title}](%{topic_url}). Visit the channel at %{channel_url} to retry.
-    chat_default_channel_id: "The chat channel that will be opened by default when a user has no unread messages or mentions in other channels."
 
   chat:
     errors:


### PR DESCRIPTION
`chat_default_channel_id` locale key was nested under `system_messages` instead of `site_settings`.