### PR TITLE
FIX: convert emojis to unicode in push notifications

### DIFF
--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -45,7 +45,7 @@ class ChatMessage < ActiveRecord::Base
   end
 
   def push_notification_excerpt
-    message[0...400]
+    Emoji.gsub_emoji_to_unicode(message).truncate(400)
   end
 
   def add_flag(user)

--- a/spec/models/chat_message_spec.rb
+++ b/spec/models/chat_message_spec.rb
@@ -294,4 +294,16 @@ describe ChatMessage do
       MSG
     end
   end
+
+  describe ".push_notification_excerpt" do
+    it "truncates to 400 characters" do
+      message = ChatMessage.new(message: "Hello, World!" * 40)
+      expect(message.push_notification_excerpt.size).to eq(400)
+    end
+
+    it "encodes emojis" do
+      message = ChatMessage.new(message: ":grinning:")
+      expect(message.push_notification_excerpt).to eq("😀")
+    end
+  end
 end


### PR DESCRIPTION
Also use Rails' truncate method to truncate the message down to 400 characters.