### PR TITLE
FIX: Archive channel refinements

### DIFF
--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -8,6 +8,7 @@ import { generateCookFunction } from "discourse/lib/text";
 import { next } from "@ember/runloop";
 import { Promise } from "rsvp";
 import ChatChannel, {
+  CHANNEL_STATUSES,
   CHATABLE_TYPES,
 } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 import simpleCategoryHashMentionTransform from "discourse/plugins/discourse-chat/discourse/lib/simple-category-hash-mention-transform";
@@ -61,6 +62,7 @@ export default Service.extend({
       this._subscribeToNewDmChannelUpdates();
       this._subscribeToUserTrackingChannel();
       this._subscribeToChannelEdits();
+      this._subscribeToChannelStatusChange();
       this.presenceChannel = this.presence.getChannel("/chat/online");
       this.draftStore = {};
 
@@ -80,6 +82,7 @@ export default Service.extend({
       this._unsubscribeFromNewDmChannelUpdates();
       this._unsubscribeFromUserTrackingChannel();
       this._unsubscribeFromChannelEdits();
+      this._unsubscribeFromChannelStatusChange();
       this._unsubscribeFromAllChatChannels();
     }
   },
@@ -543,6 +546,27 @@ export default Service.extend({
         }
       });
     });
+  },
+
+  _subscribeToChannelStatusChange() {
+    this.messageBus.subscribe("/chat/channel-status", (busData) => {
+      let activeChannel = this.getActiveChannel();
+      if (
+        busData.chat_channel_id === activeChannel?.id &&
+        (busData.status === CHANNEL_STATUSES.readOnly ||
+          busData.status === CHANNEL_STATUSES.archived)
+      ) {
+        // This is not very elegant. Ideally at some point we want to have
+        // a nice reactive magical transformation of the channel status
+        // before the user's very eyes...but for now let's just reload so
+        // they can see they are no longer allowed to chat.
+        window.location.reload();
+      }
+    });
+  },
+
+  _unsubscribeFromChannelStatusChange() {
+    this.messageBus.unsubscribe("/chat/channel-status");
   },
 
   _unsubscribeFromChannelEdits() {

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -1,4 +1,5 @@
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { isTesting } from "discourse-common/config/environment";
 import Service, { inject as service } from "@ember/service";
 import Site from "discourse/models/site";
 import { addChatToolbarButton } from "discourse/plugins/discourse-chat/discourse/components/chat-composer";
@@ -560,7 +561,9 @@ export default Service.extend({
         // a nice reactive magical transformation of the channel status
         // before the user's very eyes...but for now let's just reload so
         // they can see they are no longer allowed to chat.
-        window.location.reload();
+        if (!isTesting()) {
+          window.location.reload();
+        }
       }
     });
   },

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -9,9 +9,10 @@
         }}
       {{/if}}
 
-      {{chat-channel-title onClick=(action "onChannelTitleClick") channel=chatChannel}}
-
-      {{chat-channel-status channel=chatChannel}}
+      <div class="chat-channel-title-with-status">
+        {{chat-channel-title onClick=(action "onChannelTitleClick") channel=chatChannel}}
+        {{chat-channel-status channel=chatChannel}}
+      </div>
 
       {{#if previewing}}
         {{d-button

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1260,7 +1260,7 @@ body.has-full-page-chat {
 
     &.previewing {
       .chat-channel-title {
-        max-width: calc(100% - 200px);
+        max-width: calc(100% - 50px);
       }
       .join-channel-btn {
         margin-left: auto;
@@ -1281,7 +1281,11 @@ body.has-full-page-chat {
 .chat-full-page-header {
   .chat-channel-header-details {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+
+    .chat-channel-title-with-status {
+      flex-grow: 1;
+    }
   }
   .chat-channel-title {
     margin: 0;

--- a/assets/stylesheets/mobile/mobile.scss
+++ b/assets/stylesheets/mobile/mobile.scss
@@ -145,7 +145,7 @@ body.has-full-page-chat {
     .chat-channel-status {
       flex-basis: 100%;
       flex-grow: 0;
-      margin: 0 0 0 10px;
+      margin: 0;
     }
   }
 }

--- a/lib/chat_channel_archive_service.rb
+++ b/lib/chat_channel_archive_service.rb
@@ -75,6 +75,7 @@ class DiscourseChat::ChatChannelArchiveService
         end
       end
 
+      kick_all_users
       complete_archive
     rescue => err
       notify_archiver(:failed, error: err)
@@ -196,5 +197,9 @@ class DiscourseChat::ChatChannelArchiveService
         chat_channel_archive.archived_by, :chat_channel_archive_complete, base_translation_params
       )
     end
+  end
+
+  def kick_all_users
+    UserChatChannelMembership.where(chat_channel: chat_channel).update_all(following: false)
   end
 end

--- a/spec/lib/chat_channel_archive_service_spec.rb
+++ b/spec/lib/chat_channel_archive_service_spec.rb
@@ -125,6 +125,18 @@ describe DiscourseChat::ChatChannelArchiveService do
         expect(pm_topic.topic_allowed_users.first.user).to eq(@channel_archive.archived_by)
         expect(pm_topic.title).to eq(I18n.t("system_messages.chat_channel_archive_complete.subject_template"))
       end
+
+      it "unfollows (leaves) the channel for all users" do
+        create_messages(3)
+        channel.chat_messages.map(&:user).each do |user|
+          UserChatChannelMembership.create(chat_channel: channel, user: user, following: true)
+        end
+        expect(UserChatChannelMembership.where(chat_channel: channel, following: true).count).to eq(3)
+        start_archive
+        subject.new(@channel_archive).execute
+        expect(@channel_archive.reload.complete?).to eq(true)
+        expect(UserChatChannelMembership.where(chat_channel: channel, following: true).count).to eq(0)
+      end
     end
 
     context "when archiving to an existing topic" do


### PR DESCRIPTION
* Make all users leave the channel when it gets archived
* Reload the channel window when the message bus channel
  status change comes through, but only for the active
  channel and only when the change is to read only or archived