### PR TITLE
FEATURE: new setting to define default emoji reactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_Store

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -43,7 +43,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   chat: service(),
   classNames: ["chat-composer"],
   userSilenced: readOnly("details.user_silenced"),
-  emojiStore: service("emoji-store"),
+  emojiStore: service("chat-emoji-store"),
   editingMessage: null,
   fullPage: false,
   mediaOptimizationWorker: service(),

--- a/assets/javascripts/discourse/components/chat-message.js
+++ b/assets/javascripts/discourse/components/chat-message.js
@@ -28,7 +28,7 @@ export default Component.extend({
   isHovered: false,
   emojiPickerIsActive: false,
   mentionWarning: null,
-  emojiStore: service("emoji-store"),
+  emojiStore: service("chat-emoji-store"),
   adminTools: optionalService(),
   _hasSubscribedToAppEvents: false,
   tagName: "",
@@ -602,7 +602,7 @@ export default Component.extend({
 
     this.set("emojiPickerIsActive", false);
     this.react(emoji, this.REMOVE_REACTION);
-    this.notifyPropertyChange("favoritesEmojis");
+    this.notifyPropertyChange("emojiReactions");
   },
 
   @action
@@ -613,7 +613,7 @@ export default Component.extend({
 
     this.set("emojiPickerIsActive", false);
     this.react(emoji, this.ADD_REACTION);
-    this.notifyPropertyChange("favoritesEmojis");
+    this.notifyPropertyChange("emojiReactions");
   },
 
   @bind
@@ -636,7 +636,7 @@ export default Component.extend({
     this._loadingReactions.push(emoji);
     this._updateReactionsList(emoji, reactAction, this.currentUser);
     this._publishReaction(emoji, reactAction);
-    this.notifyPropertyChange("favoritesEmojis");
+    this.notifyPropertyChange("emojiReactions");
 
     if (this.site.mobileView) {
       this.toggleProperty("isHovered");
@@ -806,10 +806,10 @@ export default Component.extend({
     }, 250);
   },
 
-  @discourseComputed("emojiStore.favorites.[]")
-  favoritesEmojis(favorites) {
-    // may be a {} if no favs defined in some production builds
-    if (!favorites || !favorites.slice) {
+  @discourseComputed("emojiStore.reactions.[]")
+  emojiReactions(reactions) {
+    // may be a {} if no defaults defined in some production builds
+    if (!reactions || !reactions.slice) {
       return [];
     }
 
@@ -817,7 +817,7 @@ export default Component.extend({
       return this.message.reactions[key].reacted;
     });
 
-    return favorites.slice(0, 3).map((emoji) => {
+    return reactions.slice(0, 5).map((emoji) => {
       if (userReactions.includes(emoji)) {
         return { emoji, reacted: true };
       } else {

--- a/assets/javascripts/discourse/services/chat-emoji-store.js
+++ b/assets/javascripts/discourse/services/chat-emoji-store.js
@@ -1,0 +1,61 @@
+// This class is duplicated from emoji-store class in core with an addition of `reactions` property.
+// We want to maintain separate emoji store for chat plugin.
+// https://github.com/discourse/discourse/blob/892f7e0506f3a4d40d9a59a4c926ff0a2aa0947e/app/assets/javascripts/discourse/app/services/emoji-store.js
+
+import KeyValueStore from "discourse/lib/key-value-store";
+import Service from "@ember/service";
+
+const EMOJI_USAGE = "emojiUsage";
+const EMOJI_SELECTED_DIVERSITY = "emojiSelectedDiversity";
+const TRACKED_EMOJIS = 15;
+const STORE_NAMESPACE = "discourse_chat_emojis_";
+
+export default Service.extend({
+  init() {
+    this._super(...arguments);
+
+    this.store = new KeyValueStore(STORE_NAMESPACE);
+
+    if (!this.store.getObject(EMOJI_USAGE)) {
+      this.favorites = [];
+    }
+  },
+
+  get diversity() {
+    return this.store.getObject(EMOJI_SELECTED_DIVERSITY) || 1;
+  },
+
+  set diversity(value) {
+    this.store.setObject({ key: EMOJI_SELECTED_DIVERSITY, value: value || 1 });
+  },
+
+  get reactions() {
+    if (!this.siteSettings.default_emoji_reactions) {
+      return [];
+    }
+    return this.siteSettings.default_emoji_reactions.split("|").filter(Boolean);
+  },
+
+  get favorites() {
+    return this.store.getObject(EMOJI_USAGE) || [];
+  },
+
+  set favorites(value) {
+    this.store.setObject({ key: EMOJI_USAGE, value: value || [] });
+    this.notifyPropertyChange("favorites");
+  },
+
+  track(code) {
+    const normalizedCode = code.replace(/(^:)|(:$)/g, "");
+    const recent = this.favorites.filter((r) => r !== normalizedCode);
+    recent.unshift(normalizedCode);
+    recent.length = Math.min(recent.length, TRACKED_EMOJIS);
+    this.favorites = recent;
+  },
+
+  reset() {
+    const store = new KeyValueStore(STORE_NAMESPACE);
+    store.setObject({ key: EMOJI_USAGE, value: [] });
+    store.setObject({ key: EMOJI_SELECTED_DIVERSITY, value: 1 });
+  },
+});

--- a/assets/javascripts/discourse/templates/components/chat-message.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message.hbs
@@ -4,6 +4,7 @@
 
 <div {{on "click" this.handleClick}} class={{messageContainerClasses}} data-id={{or message.id message.stagedId}}>
   {{emoji-picker
+    emojiStore=emojiStore
     isActive=emojiPickerIsActive
     isEditorFocused=true
     usePopper=false
@@ -34,10 +35,10 @@
         {{#if showActions}}
           <div class="chat-msgactions-hover">
             <div class="chat-msgactions">
-              {{#each favoritesEmojis as |favorite|}}
+              {{#each emojiReactions as |reaction|}}
                 {{chat-message-reaction
-                  emoji=favorite.emoji
-                  reacted=favorite.reacted
+                  emoji=reaction.emoji
+                  reacted=reaction.reacted
                   react=(action "react")
                   class="show"
                 }}

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -12,6 +12,7 @@ en:
     chat_default_channel_id: "The chat channel that will be opened by default when a user has no unread messages or mentions in other channels."
     chat_duplicate_message_sensitivity: "The likelihood that a duplicate message by the same sender will be blocked in a short period. Decimal number between 0 and 1.0, with 1.0 being the highest setting (blocks messages more frequently in a shorter amount of time). Set to `0` to allow duplicate messages."
     chat_archive_destination_topic_status: "The status that the destination topic should be once a channel archive is completed. This only applies when the destination topic is a new topic, not an existing one."
+    default_emoji_reactions: "Default emoji reactions for chat messages. Add upto 5 emojis for quick reaction."
     errors:
       chat_default_channel: "The default chat channel must be a public channel."
   system_messages:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -61,4 +61,7 @@ plugins:
     default: 0.5
     min: 0
     max: 1
-
+  default_emoji_reactions:
+    type: emoji_list
+    default: +1|heart|tada
+    client: true

--- a/test/javascripts/unit/lib/chat-emoji-store-test.js
+++ b/test/javascripts/unit/lib/chat-emoji-store-test.js
@@ -1,0 +1,41 @@
+import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+
+discourseModule("Discourse Chat | Unit | chat-emoji-store", function (hooks) {
+  hooks.beforeEach(function () {
+    this.emojiStore = this.container.lookup("service:chat-emoji-store");
+    this.emojiStore.siteSettings = this.container.lookup("site-settings:main");
+    this.emojiStore.reset();
+  });
+
+  hooks.afterEach(function () {
+    this.emojiStore.reset();
+  });
+
+  test("defaults", function (assert) {
+    assert.deepEqual(this.emojiStore.favorites, []);
+    assert.strictEqual(this.emojiStore.diversity, 1);
+  });
+
+  test("diversity", function (assert) {
+    this.emojiStore.diversity = 2;
+    assert.strictEqual(this.emojiStore.diversity, 2);
+  });
+
+  test("favorites", function (assert) {
+    this.emojiStore.favorites = ["smile"];
+    assert.deepEqual(this.emojiStore.favorites, ["smile"]);
+  });
+
+  test("track", function (assert) {
+    this.emojiStore.track("woman:t4");
+    assert.deepEqual(this.emojiStore.favorites, ["woman:t4"]);
+    this.emojiStore.track("otter");
+    assert.deepEqual(this.emojiStore.favorites, ["otter", "woman:t4"]);
+  });
+
+  test("reactions", function (assert) {
+    this.emojiStore.siteSettings.default_emoji_reactions = "smile|heart|tada";
+    assert.deepEqual(this.emojiStore.reactions, ["smile", "heart", "tada"]);
+  });
+});


### PR DESCRIPTION
FEATURE: add dedicated emoji store for chat plugin

This commit adds a new setting to define default emoji reactions for chat messages. The setting defaults to 3 reactions.

<img width="388" alt="Screen Shot 2022-03-09 at 21 32 22" src="https://user-images.githubusercontent.com/5732281/157480358-bbe94789-b616-4a7a-a81a-f876437206e0.png">

This commit also adds a new emoji store for chat plugin so that the favorites (recently used) emojis in chat emoji-picker is independent of topics/posts.