### PR TITLE
FIX: Improvements to archiving tool

### DIFF
--- a/assets/javascripts/lib/discourse-markdown/discourse-chat-transcript.js
+++ b/assets/javascripts/lib/discourse-markdown/discourse-chat-transcript.js
@@ -103,9 +103,7 @@ const chatTranscriptRule = {
     // chat message because it will just result in a 404
     if (noLink) {
       let spanToken = state.push("span_open", "span", 1);
-      spanToken.attrs = [
-        ["title", messageTimeStart],
-      ];
+      spanToken.attrs = [["title", messageTimeStart]];
 
       spanToken.block = false;
       spanToken = state.push("span_close", "span", -1);

--- a/assets/javascripts/lib/discourse-markdown/discourse-chat-transcript.js
+++ b/assets/javascripts/lib/discourse-markdown/discourse-chat-transcript.js
@@ -12,12 +12,12 @@ const chatTranscriptRule = {
     }
 
     const options = state.md.options.discourse;
-    let [username, messageIdStart, messageTimeStart] =
+    const [username, messageIdStart, messageTimeStart] =
       (tagInfo.attrs.quote && tagInfo.attrs.quote.split(";")) || [];
-    let multiQuote = !!tagInfo.attrs.multiQuote;
-    let noLink = !!tagInfo.attrs.noLink;
-    let channelName = tagInfo.attrs.channel;
-    let channelLink = channelName
+    const multiQuote = !!tagInfo.attrs.multiQuote;
+    const noLink = !!tagInfo.attrs.noLink;
+    const channelName = tagInfo.attrs.channel;
+    const channelLink = channelName
       ? options.getURL(
           `/chat/chat_channels/${encodeURIComponent(channelName.toLowerCase())}`
         )

--- a/assets/javascripts/lib/discourse-markdown/discourse-chat-transcript.js
+++ b/assets/javascripts/lib/discourse-markdown/discourse-chat-transcript.js
@@ -15,6 +15,7 @@ const chatTranscriptRule = {
     let [username, messageIdStart, messageTimeStart] =
       (tagInfo.attrs.quote && tagInfo.attrs.quote.split(";")) || [];
     let multiQuote = !!tagInfo.attrs.multiQuote;
+    let noLink = !!tagInfo.attrs.noLink;
     let channelName = tagInfo.attrs.channel;
     let channelLink = channelName
       ? options.getURL(
@@ -98,15 +99,28 @@ const chatTranscriptRule = {
     let datetimeDivToken = state.push("div_chat_transcript_datetime", "div", 1);
     datetimeDivToken.attrs = [["class", "chat-transcript-datetime"]];
 
-    let linkToken = state.push("link_open", "a", 1);
-    linkToken.attrs = [
-      ["href", options.getURL(`/chat/message/${messageIdStart}`)],
-      ["title", messageTimeStart],
-    ];
+    // for some cases, like archiving, we don't want the link to the
+    // chat message because it will just result in a 404
+    if (noLink) {
+      let spanToken = state.push("span_open", "span", 1);
+      spanToken.attrs = [
+        ["title", messageTimeStart],
+      ];
 
-    linkToken.block = false;
-    linkToken = state.push("link_close", "a", -1);
-    linkToken.block = false;
+      spanToken.block = false;
+      spanToken = state.push("span_close", "span", -1);
+      spanToken.block = false;
+    } else {
+      let linkToken = state.push("link_open", "a", 1);
+      linkToken.attrs = [
+        ["href", options.getURL(`/chat/message/${messageIdStart}`)],
+        ["title", messageTimeStart],
+      ];
+
+      linkToken.block = false;
+      linkToken = state.push("link_close", "a", -1);
+      linkToken.block = false;
+    }
 
     state.push("div_chat_transcript_datetime", "div", -1);
     // end: time + link to message
@@ -151,6 +165,7 @@ export function setup(helper) {
     "div.chat-transcript-user-avatar",
     "div.chat-transcript-messages",
     "div.chat-transcript-datetime",
+    "span[title]",
     "div[data-message-id]",
     "div[data-channel-name]",
     "div[data-username]",

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -11,7 +11,7 @@ en:
     chat_auto_silence_from_flags_duration: "Number of minutes that users will be silenced for when they are automatically silenced due to flagged chat messages."
     chat_default_channel_id: "The chat channel that will be opened by default when a user has no unread messages or mentions in other channels."
     chat_duplicate_message_sensitivity: "The likelihood that a duplicate message by the same sender will be blocked in a short period. Decimal number between 0 and 1.0, with 1.0 being the highest setting (blocks messages more frequently in a shorter amount of time). Set to `0` to allow duplicate messages."
-    chat_archive_destination_topic_status: "The status that the destination topic should be once a channel archive is completed."
+    chat_archive_destination_topic_status: "The status that the destination topic should be once a channel archive is completed. This only applies when the destination topic is a new topic, not an existing one."
     errors:
       chat_default_channel: "The default chat channel must be a public channel."
   system_messages:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -11,6 +11,7 @@ en:
     chat_auto_silence_from_flags_duration: "Number of minutes that users will be silenced for when they are automatically silenced due to flagged chat messages."
     chat_default_channel_id: "The chat channel that will be opened by default when a user has no unread messages or mentions in other channels."
     chat_duplicate_message_sensitivity: "The likelihood that a duplicate message by the same sender will be blocked in a short period. Decimal number between 0 and 1.0, with 1.0 being the highest setting (blocks messages more frequently in a shorter amount of time). Set to `0` to allow duplicate messages."
+    chat_archive_destination_topic_status: "The status that the destination topic should be once a channel archive is completed."
     errors:
       chat_default_channel: "The default chat channel must be a public channel."
   system_messages:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -45,6 +45,13 @@ plugins:
     default: false
     hidden: true
     client: true
+  chat_archive_destination_topic_status:
+    type: enum
+    default: archived
+    choices:
+      - archived
+      - open
+      - closed
   chat_default_channel_id:
     default: ""
     client: true

--- a/lib/chat_channel_archive_service.rb
+++ b/lib/chat_channel_archive_service.rb
@@ -148,10 +148,15 @@ class DiscourseChat::ChatChannelArchiveService
   end
 
   def update_destination_topic_status
-    if SiteSetting.chat_archive_destination_topic_status == "archived"
-      chat_channel_archive.destination_topic.update!(archived: true)
-    elsif SiteSetting.chat_archive_destination_topic_status == "closed"
-      chat_channel_archive.destination_topic.update!(closed: true)
+    # we only want to do this when the destination topic is new, not an
+    # existing topic, because we don't want to update the status unexpectedly
+    # on an existing topic
+    if chat_channel_archive.destination_topic_title.present?
+      if SiteSetting.chat_archive_destination_topic_status == "archived"
+        chat_channel_archive.destination_topic.update!(archived: true)
+      elsif SiteSetting.chat_archive_destination_topic_status == "closed"
+        chat_channel_archive.destination_topic.update!(closed: true)
+      end
     end
   end
 

--- a/lib/chat_channel_archive_service.rb
+++ b/lib/chat_channel_archive_service.rb
@@ -68,7 +68,7 @@ class DiscourseChat::ChatChannelArchiveService
       ) do |chat_messages|
         create_post(
           ChatTranscriptService.new(
-            chat_channel, messages_or_ids: chat_messages
+            chat_channel, messages_or_ids: chat_messages, opts: { no_link: true }
           ).generate_markdown
         ) do
           delete_message_batch(chat_messages.map(&:id))
@@ -144,7 +144,15 @@ class DiscourseChat::ChatChannelArchiveService
       Rails.logger.info("Topic already exists for #{chat_channel.name} archive.")
     end
 
-    chat_channel_archive.destination_topic.update!(archived: true)
+    update_destination_topic_status
+  end
+
+  def update_destination_topic_status
+    if SiteSetting.chat_archive_destination_topic_status == "archived"
+      chat_channel_archive.destination_topic.update!(archived: true)
+    elsif SiteSetting.chat_archive_destination_topic_status == "closed"
+      chat_channel_archive.destination_topic.update!(closed: true)
+    end
   end
 
   def delete_message_batch(message_ids)

--- a/lib/extensions/topic_view_serializer_extension.rb
+++ b/lib/extensions/topic_view_serializer_extension.rb
@@ -15,7 +15,7 @@ module DiscourseChat::TopicViewSerializerExtension
   end
 
   def has_chat_live
-    true
+    chat_channel.open? || chat_channel.closed?
   end
 
   def include_has_chat_live?
@@ -23,8 +23,6 @@ module DiscourseChat::TopicViewSerializerExtension
   end
 
   def chat_channel
-    return @chat_channel if defined?(@chat_channel)
-
-    @chat_channel = object.topic.chat_channel
+    @chat_channel ||= object.topic.chat_channel
   end
 end

--- a/lib/tasks/chat_message.rake
+++ b/lib/tasks/chat_message.rake
@@ -94,7 +94,7 @@ task 'chat:make_channel_to_test_archiving', [:user_for_membership] => :environme
     topic = Fabricate(:topic, user: make_test_user, title: "Testing topic for chat archiving #{SecureRandom.hex(4)}")
     Fabricate(:post, topic: topic, user: topic.user, raw: "This is some cool first post for archive stuff")
     chat_channel = ChatChannel.create(
-      chatable: topic, chatable_type: "Topic", name: "testing channel for archiving"
+      chatable: topic, chatable_type: "Topic", name: "testing channel for archiving #{SecureRandom.hex(4)}"
     )
   end
 

--- a/spec/lib/chat_channel_archive_service_spec.rb
+++ b/spec/lib/chat_channel_archive_service_spec.rb
@@ -177,6 +177,21 @@ describe DiscourseChat::ChatChannelArchiveService do
             expect(topic.closed?).to eq(true)
           end
         end
+
+        context "when archiving to an existing topic" do
+          it "does not change the status of the topic" do
+            create_messages(3) && start_archive
+            @channel_archive.update(
+              destination_topic_title: nil,
+              destination_topic_id: Fabricate(:topic).id
+            )
+            subject.new(@channel_archive).execute
+            topic = @channel_archive.destination_topic
+            topic.reload
+            expect(topic.archived).to eq(false)
+            expect(topic.closed?).to eq(false)
+          end
+        end
       end
     end
 

--- a/spec/lib/chat_channel_archive_service_spec.rb
+++ b/spec/lib/chat_channel_archive_service_spec.rb
@@ -227,7 +227,7 @@ describe DiscourseChat::ChatChannelArchiveService do
         topic.posts.where.not(post_number: [1, 2, 3]).each do |post|
           expect(post.raw).to include("[chat")
         end
-        expect(topic.archived).to eq(true)
+        expect(topic.archived).to eq(false)
 
         expect(@channel_archive.archived_messages).to eq(50)
         expect(@channel_archive.chat_channel.status).to eq("archived")

--- a/spec/lib/chat_channel_archive_service_spec.rb
+++ b/spec/lib/chat_channel_archive_service_spec.rb
@@ -94,6 +94,7 @@ describe DiscourseChat::ChatChannelArchiveService do
         expect(topic.posts.count).to eq(11)
         topic.posts.where.not(post_number: 1).each do |post|
           expect(post.raw).to include("[chat")
+          expect(post.raw).to include("noLink=\"true\"")
         end
         expect(topic.archived).to eq(true)
 
@@ -136,6 +137,46 @@ describe DiscourseChat::ChatChannelArchiveService do
         subject.new(@channel_archive).execute
         expect(@channel_archive.reload.complete?).to eq(true)
         expect(UserChatChannelMembership.where(chat_channel: channel, following: true).count).to eq(0)
+      end
+
+      describe "chat_archive_destination_topic_status setting" do
+        context "when set to archived" do
+          before { SiteSetting.chat_archive_destination_topic_status = "archived" }
+
+          it "archives the topic" do
+            create_messages(3) && start_archive
+            subject.new(@channel_archive).execute
+            topic = @channel_archive.destination_topic
+            topic.reload
+            expect(topic.archived).to eq(true)
+          end
+        end
+
+        context "when set to open" do
+          before { SiteSetting.chat_archive_destination_topic_status = "open" }
+
+          it "leaves the topic open" do
+            create_messages(3) && start_archive
+            subject.new(@channel_archive).execute
+            topic = @channel_archive.destination_topic
+            topic.reload
+            expect(topic.archived).to eq(false)
+            expect(topic.open?).to eq(true)
+          end
+        end
+
+        context "when set to closed" do
+          before { SiteSetting.chat_archive_destination_topic_status = "closed" }
+
+          it "closes the topic" do
+            create_messages(3) && start_archive
+            subject.new(@channel_archive).execute
+            topic = @channel_archive.destination_topic
+            topic.reload
+            expect(topic.archived).to eq(false)
+            expect(topic.closed?).to eq(true)
+          end
+        end
       end
     end
 

--- a/spec/lib/chat_transcript_service_spec.rb
+++ b/spec/lib/chat_transcript_service_spec.rb
@@ -7,8 +7,8 @@ describe ChatTranscriptService do
   let(:user2) { Fabricate(:user, username: "brucechat") }
   let(:channel) { Fabricate(:chat_channel, name: "The Beam Discussions") }
 
-  def service(message_ids)
-    described_class.new(channel, messages_or_ids: Array.wrap(message_ids))
+  def service(message_ids, opts: {})
+    described_class.new(channel, messages_or_ids: Array.wrap(message_ids), opts: opts)
   end
 
   it "generates a simple chat transcript from one message" do
@@ -113,6 +113,16 @@ describe ChatTranscriptService do
     this is a cool and funny picture
 
     #{image_markdown}
+    [/chat]
+    MARKDOWN
+  end
+
+  it "generates a transcript with the noLink option" do
+    message = Fabricate(:chat_message, user: user1, chat_channel: channel, message: "an extremely insightful response :)")
+
+    expect(service(message.id, opts: { no_link: true }).generate_markdown).to eq(<<~MARKDOWN)
+    [chat quote="martinchat;#{message.id};#{message.created_at.iso8601}" channel="The Beam Discussions" noLink="true"]
+    an extremely insightful response :)
     [/chat]
     MARKDOWN
   end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -68,8 +68,8 @@ describe 'discourse-chat' do
       expect(Upload.exists?(id: draft_upload.id)).to eq(true)
       expect(Upload.exists?(id: unused_upload.id)).to eq(false)
     end
-  end 
-  
+  end
+
   describe "topic view serializer extension" do
     fab!(:topic) { Fabricate(:topic) }
     fab!(:user) { Fabricate(:user) }

--- a/test/javascripts/acceptance/chat-transcript-test.js
+++ b/test/javascripts/acceptance/chat-transcript-test.js
@@ -225,7 +225,7 @@ acceptance("Discourse Chat | discourse-chat-transcript", function () {
         datetime: "2022-01-25T05:40:39Z",
         channel: "Cool Cats Club",
         multiQuote: true,
-        noLink: true
+        noLink: true,
       }),
       "renders with the noLink attribute"
     );

--- a/test/javascripts/acceptance/chat-transcript-test.js
+++ b/test/javascripts/acceptance/chat-transcript-test.js
@@ -82,12 +82,16 @@ ${originallySent}</div>`);
         .tz(opts.datetime, "Australia/Brisbane")
         .format(I18n.t("dates.long_no_year"))
     : "";
+
+  const innerDatetimeEl = opts.noLink
+    ? `<span title=\"${opts.datetime}\">${dateTimeText}</span>`
+    : `<a href=\"/chat/message/${opts.messageId}\" title=\"${opts.datetime}\"${tabIndexHTML}>${dateTimeText}</a>`;
   transcript.push(`<div class=\"chat-transcript-user\">
 <div class=\"chat-transcript-user-avatar\"></div>
 <div class=\"chat-transcript-username\">
 ${opts.username}</div>
 <div class=\"chat-transcript-datetime\">
-<a href=\"/chat/message/${opts.messageId}\" title=\"${opts.datetime}\"${tabIndexHTML}>${dateTimeText}</a></div>`);
+${innerDatetimeEl}</div>`);
 
   if (opts.channel && !opts.multiQuote) {
     transcript.push(
@@ -208,6 +212,22 @@ acceptance("Discourse Chat | discourse-chat-transcript", function () {
         chained: true,
       }),
       "renders with the chained attribute"
+    );
+  });
+
+  test("renders with the noLink attribute to remove the links to the individual messages from the datetimes", function (assert) {
+    assert.cookedChatTranscript(
+      `[chat quote="martin;2321;2022-01-25T05:40:39Z" channel="Cool Cats Club" multiQuote="true" noLink="true"]\nThis is a chat message.\n[/chat]`,
+      { additionalOptions },
+      generateTranscriptHTML("<p>This is a chat message.</p>", {
+        messageId: "2321",
+        username: "martin",
+        datetime: "2022-01-25T05:40:39Z",
+        channel: "Cool Cats Club",
+        multiQuote: true,
+        noLink: true
+      }),
+      "renders with the noLink attribute"
     );
   });
 


### PR DESCRIPTION
* When generating markdown for the archive, do not create links
  to individual chat messages, because these will just show a
  404 message when clicked.
* Add a site setting to determine what to change the status of
  the archive destination topic to. Before it was always changed
  to archived, new options are open, archived, closed. This only
  affects new destination topics.
* Hide the chat icon next to the topic title if the related channel
  is read_only or archived.
* Fix some issues in chat-setup initializer -- we were getting the chat
  service twice, and also the chat quote datetime decorator would not
  work for users without chat enabled. This is wrong because the post
  decorations should always work.