### PR TITLE
FIX: Guardian can_rebake? was breaking core post rebake endpoint

### DIFF
--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -231,7 +231,7 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
   end
 
   def rebake
-    guardian.ensure_can_rebake!(@message)
+    guardian.ensure_can_rebake_chat_message!(@message)
     @message.rebake!(invalidate_oneboxes: true)
     render json: success_json
   end

--- a/lib/guardian_extensions.rb
+++ b/lib/guardian_extensions.rb
@@ -68,7 +68,7 @@ module DiscourseChat::GuardianExtensions
     is_staff? && can_modify_channel_message?(chat_channel)
   end
 
-  def can_rebake?(message)
+  def can_rebake_chat_message?(message)
     return false if !can_modify_channel_message?(message.chat_channel)
     is_staff? || @user.has_trust_level?(TrustLevel[4])
   end

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -370,6 +370,15 @@ RSpec.describe DiscourseChat::ChatController do
         end
       end
 
+      it "does not interfere with core's guardian can_rebake? for posts" do
+        sign_in(Fabricate(:admin))
+        put "/chat/#{chat_channel.id}/#{chat_message.id}/rebake.json"
+        expect(response.status).to eq(200)
+        post = Fabricate(:post)
+        put "/posts/#{post.id}/rebake.json"
+        expect(response.status).to eq(200)
+      end
+
       it "does not rebake the post when channel is read_only" do
         chat_message.chat_channel.update!(status: :read_only)
         sign_in(Fabricate(:admin))


### PR DESCRIPTION
In the guardian extension we added a can_rebake? method with
a chat message as an argument. This causes a 500 error in the
core /post/:id/rebake endpoint, because guardian.ensure_can_rebake!
and guardian.can_rebake? are now expecting a chat message argument.
This commit just changes the chat guardian extension to be
can_rebake_chat_message?