### PR TITLE
FIX: Chat channel selector was broken for incoming webhooks.

### DIFF
--- a/assets/javascripts/discourse/routes/admin-plugins-chat.js
+++ b/assets/javascripts/discourse/routes/admin-plugins-chat.js
@@ -1,5 +1,6 @@
 import DiscourseRoute from "discourse/routes/discourse";
 import EmberObject from "@ember/object";
+import ChatChannel from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 import { ajax } from "discourse/lib/ajax";
 
 export default DiscourseRoute.extend({
@@ -12,6 +13,11 @@ export default DiscourseRoute.extend({
       model.incoming_chat_webhooks = model.incoming_chat_webhooks.map(
         (webhook) => EmberObject.create(webhook)
       );
+
+      model.chat_channels = model.chat_channels.map((channel) => {
+        return ChatChannel.create(channel);
+      });
+
       return model;
     });
   },

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -959,7 +959,6 @@ body.composer-open .topic-chat-float-container {
   grid-column-gap: 0.5em;
   align-items: center;
   cursor: pointer;
-  margin: 0.6rem 0;
 
   .category-chat-private .d-icon {
     background-color: var(--secondary);
@@ -1168,6 +1167,10 @@ body.composer-open .topic-chat-float-container {
       .chat-channel-description {
         color: var(--primary-high);
       }
+    }
+
+    .chat-channel-title {
+      margin: 0.6rem 0;
     }
   }
   .btn-container {


### PR DESCRIPTION
A follow-up to #644. When creating or editing an incoming webhook, the channel selector doesn't work unless each `chat_channel` is a ChatChannel object.