### PR TITLE
UX: Revert margin changes to .chat-channel-title

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -959,6 +959,7 @@ body.composer-open .topic-chat-float-container {
   grid-column-gap: 0.5em;
   align-items: center;
   cursor: pointer;
+  margin: 0.6rem 0;
 
   .category-chat-private .d-icon {
     background-color: var(--secondary);
@@ -1167,10 +1168,6 @@ body.composer-open .topic-chat-float-container {
       .chat-channel-description {
         color: var(--primary-high);
       }
-    }
-
-    .chat-channel-title {
-      margin: 0.6rem 0;
     }
   }
   .btn-container {

--- a/assets/stylesheets/mobile/mobile.scss
+++ b/assets/stylesheets/mobile/mobile.scss
@@ -98,10 +98,6 @@ body.has-full-page-chat {
 .chat-channels .chat-channel-row {
   padding: 0 0.5em 0 0.25em;
 
-  .chat-channel-title {
-    margin: 0.6rem 0;
-  }
-
   .category-chat-private .d-icon {
     background-color: var(--secondary);
   }


### PR DESCRIPTION
This CSS class is used in a lot of places, so changing where the margin is applied has a lot of unintended side-effects.

Revert "UX: Re-apply channels margin on mobile. (#683)"

This reverts commit 2aeb5b84c065172db62969ac3c5ba945e7fdc7ff.