### PR TITLE
FIX: Clear unread when channel archived

### DIFF
--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -1,5 +1,4 @@
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import { CHANNEL_STATUSES } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 import Service, { inject as service } from "@ember/service";
 import Site from "discourse/models/site";
 import { addChatToolbarButton } from "discourse/plugins/discourse-chat/discourse/components/chat-composer";
@@ -9,6 +8,7 @@ import { generateCookFunction } from "discourse/lib/text";
 import { next } from "@ember/runloop";
 import { Promise } from "rsvp";
 import ChatChannel, {
+  CHANNEL_STATUSES,
   CHATABLE_TYPES,
 } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 import simpleCategoryHashMentionTransform from "discourse/plugins/discourse-chat/discourse/lib/simple-category-hash-mention-transform";

--- a/lib/chat_channel_archive_service.rb
+++ b/lib/chat_channel_archive_service.rb
@@ -58,7 +58,6 @@ class DiscourseChat::ChatChannelArchiveService
 
       Rails.logger.info("Creating posts from message batches for #{chat_channel.name} archive, #{chat_channel_archive.total_messages} messages to archive (#{chat_channel_archive.total_messages / ARCHIVED_MESSAGES_PER_POST} posts).")
 
-      last_message_id = chat_channel.chat_messages.last.id
       # a batch should be idempotent, either the post is created and the
       # messages are deleted or we roll back the whole thing.
       #
@@ -81,7 +80,7 @@ class DiscourseChat::ChatChannelArchiveService
         end
       end
 
-      kick_all_users(last_message_id)
+      kick_all_users
       complete_archive
     rescue => err
       notify_archiver(:failed, error: err)
@@ -226,9 +225,9 @@ class DiscourseChat::ChatChannelArchiveService
     )
   end
 
-  def kick_all_users(last_message_id)
+  def kick_all_users
     UserChatChannelMembership.where(chat_channel: chat_channel).update_all(
-      following: false, last_read_message_id: last_message_id
+      following: false, last_read_message_id: chat_channel.chat_messages.last&.id
     )
   end
 end

--- a/spec/lib/chat_channel_archive_service_spec.rb
+++ b/spec/lib/chat_channel_archive_service_spec.rb
@@ -131,7 +131,7 @@ describe DiscourseChat::ChatChannelArchiveService do
         before do
           create_messages(3)
           channel.chat_messages.map(&:user).each do |user|
-            UserChatChannelMembership.create(chat_channel: channel, user: user, following: true)
+            UserChatChannelMembership.create!(chat_channel: channel, user: user, following: true)
           end
         end
 

--- a/spec/lib/chat_channel_archive_service_spec.rb
+++ b/spec/lib/chat_channel_archive_service_spec.rb
@@ -127,16 +127,29 @@ describe DiscourseChat::ChatChannelArchiveService do
         expect(pm_topic.title).to eq(I18n.t("system_messages.chat_channel_archive_complete.subject_template"))
       end
 
-      it "unfollows (leaves) the channel for all users" do
-        create_messages(3)
-        channel.chat_messages.map(&:user).each do |user|
-          UserChatChannelMembership.create(chat_channel: channel, user: user, following: true)
+      describe "channel members" do
+        before do
+          create_messages(3)
+          channel.chat_messages.map(&:user).each do |user|
+            UserChatChannelMembership.create(chat_channel: channel, user: user, following: true)
+          end
         end
-        expect(UserChatChannelMembership.where(chat_channel: channel, following: true).count).to eq(3)
-        start_archive
-        subject.new(@channel_archive).execute
-        expect(@channel_archive.reload.complete?).to eq(true)
-        expect(UserChatChannelMembership.where(chat_channel: channel, following: true).count).to eq(0)
+
+        it "unfollows (leaves) the channel for all users" do
+          expect(UserChatChannelMembership.where(chat_channel: channel, following: true).count).to eq(3)
+          start_archive
+          subject.new(@channel_archive).execute
+          expect(@channel_archive.reload.complete?).to eq(true)
+          expect(UserChatChannelMembership.where(chat_channel: channel, following: true).count).to eq(0)
+        end
+
+        it "resets unread state for all users" do
+          UserChatChannelMembership.last.update!(last_read_message_id: channel.chat_messages.first.id)
+          start_archive
+          subject.new(@channel_archive).execute
+          expect(@channel_archive.reload.complete?).to eq(true)
+          expect(UserChatChannelMembership.last.last_read_message_id).to eq(channel.chat_messages.last.id)
+        end
       end
 
       describe "chat_archive_destination_topic_status setting" do

--- a/test/javascripts/acceptance/chat-status-test.js
+++ b/test/javascripts/acceptance/chat-status-test.js
@@ -1,0 +1,124 @@
+import { click, fillIn, settled, visit } from "@ember/test-helpers";
+import { cloneJSON } from "discourse-common/lib/object";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
+import {
+  allChannels,
+  chatChannels,
+  chatView,
+  siteChannel,
+} from "discourse/plugins/discourse-chat/chat-fixtures";
+import {
+  acceptance,
+  exists,
+  publishToMessageBus,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+import I18n from "I18n";
+import { test } from "qunit";
+
+const baseChatPretenders = (server, helper) => {
+  server.get("/chat/:chatChannelId/messages.json", () =>
+    helper.response(chatView)
+  );
+  server.post("/chat/:chatChannelId.json", () => {
+    return helper.response({ success: "OK" });
+  });
+  server.get("/chat/lookup/:message_id.json", () => helper.response(chatView));
+  server.post("/uploads/lookup-urls", () => {
+    return helper.response([]);
+  });
+  server.get("/chat/chat_channels/all.json", () => {
+    return helper.response(allChannels());
+  });
+  server.get("/chat/chat_channels.json", () => {
+    let copy = cloneJSON(chatChannels);
+    let topicChannel = copy.public_channels.find((pc) => pc.id === 4);
+    topicChannel.unread_count = 2;
+    return helper.response(copy);
+  });
+
+  // this is only fetched on channel-status change; when expanding on
+  // this test we may want to introduce some counter to track when
+  // this is fetched if we want to return different statuses
+  server.get("/chat/chat_channels/4", () => {
+    let channel = cloneJSON(
+      chatChannels.public_channels.find((pc) => pc.id === 4)
+    );
+    channel.status = "archived";
+    return helper.response({
+      chat_channel: channel,
+    });
+  });
+};
+
+function siteChannelPretender(
+  server,
+  helper,
+  opts = { unread_count: 0, muted: false }
+) {
+  let copy = cloneJSON(siteChannel);
+  copy.chat_channel.unread_count = opts.unread_count;
+  server.get("/chat/chat_channels/9.json", () => helper.response(copy));
+}
+
+acceptance(
+  "Discourse Chat - Respond to /chat/channel-status archive message",
+  function (needs) {
+    needs.user({
+      admin: true,
+      moderator: true,
+      username: "tomtom",
+      id: 1,
+      can_chat: true,
+      has_chat_enabled: true,
+    });
+
+    needs.settings({
+      chat_enabled: true,
+      chat_allow_archiving_channels: true,
+    });
+
+    needs.pretender((server, helper) => {
+      baseChatPretenders(server, helper);
+    });
+
+    test("it clears any unread messages in the sidebar for the archived channel", async function (assert) {
+      await visit("/chat/channel/7/Uncategorized");
+      assert.ok(
+        exists("#chat-channel-row-4 .chat-channel-unread-indicator"),
+        "unread indicator shows for channel"
+      );
+
+      publishToMessageBus("/chat/channel-status", {
+        chat_channel_id: 4,
+        status: "archived",
+      });
+      await settled();
+      assert.notOk(
+        exists("#chat-channel-row-4 .chat-channel-unread-indicator"),
+        "unread indicator should not show after archive status change"
+      );
+    });
+
+    test("it changes the channel status in the header to archived", async function (assert) {
+      await visit("/chat/channel/4/Topic");
+      assert.notOk(
+        exists(".chat-channel-title-with-status .chat-channel-status"),
+        "channel status does not show if the channel is open"
+      );
+
+      publishToMessageBus("/chat/channel-status", {
+        chat_channel_id: 4,
+        status: "archived",
+      });
+      await settled();
+      assert.strictEqual(
+        query(
+          ".chat-channel-title-with-status .chat-channel-status"
+        ).innerText.trim(),
+        I18n.t("chat.channel_status.archived_header"),
+        "channel status changes to archived"
+      );
+    });
+  }
+);

--- a/test/javascripts/acceptance/chat-status-test.js
+++ b/test/javascripts/acceptance/chat-status-test.js
@@ -4,7 +4,6 @@ import {
   allChannels,
   chatChannels,
   chatView,
-  siteChannel,
 } from "discourse/plugins/discourse-chat/chat-fixtures";
 import {
   acceptance,

--- a/test/javascripts/acceptance/chat-status-test.js
+++ b/test/javascripts/acceptance/chat-status-test.js
@@ -1,6 +1,5 @@
-import { click, fillIn, settled, visit } from "@ember/test-helpers";
+import { settled, visit } from "@ember/test-helpers";
 import { cloneJSON } from "discourse-common/lib/object";
-import selectKit from "discourse/tests/helpers/select-kit-helper";
 import {
   allChannels,
   chatChannels,
@@ -50,16 +49,6 @@ const baseChatPretenders = (server, helper) => {
     });
   });
 };
-
-function siteChannelPretender(
-  server,
-  helper,
-  opts = { unread_count: 0, muted: false }
-) {
-  let copy = cloneJSON(siteChannel);
-  copy.chat_channel.unread_count = opts.unread_count;
-  server.get("/chat/chat_channels/9.json", () => helper.response(copy));
-}
 
 acceptance(
   "Discourse Chat - Respond to /chat/channel-status archive message",

--- a/test/javascripts/acceptance/chat-status-test.js
+++ b/test/javascripts/acceptance/chat-status-test.js
@@ -1,4 +1,5 @@
 import { settled, visit } from "@ember/test-helpers";
+import { isLegacyEmber } from "discourse-common/config/environment";
 import { cloneJSON } from "discourse-common/lib/object";
 import {
   allChannels,
@@ -49,64 +50,67 @@ const baseChatPretenders = (server, helper) => {
   });
 };
 
-acceptance(
-  "Discourse Chat - Respond to /chat/channel-status archive message",
-  function (needs) {
-    needs.user({
-      admin: true,
-      moderator: true,
-      username: "tomtom",
-      id: 1,
-      can_chat: true,
-      has_chat_enabled: true,
-    });
-
-    needs.settings({
-      chat_enabled: true,
-      chat_allow_archiving_channels: true,
-    });
-
-    needs.pretender((server, helper) => {
-      baseChatPretenders(server, helper);
-    });
-
-    test("it clears any unread messages in the sidebar for the archived channel", async function (assert) {
-      await visit("/chat/channel/7/Uncategorized");
-      assert.ok(
-        exists("#chat-channel-row-4 .chat-channel-unread-indicator"),
-        "unread indicator shows for channel"
-      );
-
-      publishToMessageBus("/chat/channel-status", {
-        chat_channel_id: 4,
-        status: "archived",
+// TODO: Uncomment when we get rid of legacy ember
+if (!isLegacyEmber()) {
+  acceptance(
+    "Discourse Chat - Respond to /chat/channel-status archive message",
+    function (needs) {
+      needs.user({
+        admin: true,
+        moderator: true,
+        username: "tomtom",
+        id: 1,
+        can_chat: true,
+        has_chat_enabled: true,
       });
-      await settled();
-      assert.notOk(
-        exists("#chat-channel-row-4 .chat-channel-unread-indicator"),
-        "unread indicator should not show after archive status change"
-      );
-    });
 
-    test("it changes the channel status in the header to archived", async function (assert) {
-      await visit("/chat/channel/4/Topic");
-      assert.notOk(
-        exists(".chat-channel-title-with-status .chat-channel-status"),
-        "channel status does not show if the channel is open"
-      );
-
-      publishToMessageBus("/chat/channel-status", {
-        chat_channel_id: 4,
-        status: "archived",
+      needs.settings({
+        chat_enabled: true,
+        chat_allow_archiving_channels: true,
       });
-      await settled();
-      assert.strictEqual(
-        query(
-          ".chat-channel-title-with-status .chat-channel-status"
-        ).innerText.trim(),
-        I18n.t("chat.channel_status.archived_header"),
-        "channel status changes to archived"
-      );
-    });
-  }
-);
+
+      needs.pretender((server, helper) => {
+        baseChatPretenders(server, helper);
+      });
+
+      test("it clears any unread messages in the sidebar for the archived channel", async function (assert) {
+        await visit("/chat/channel/7/Uncategorized");
+        assert.ok(
+          exists("#chat-channel-row-4 .chat-channel-unread-indicator"),
+          "unread indicator shows for channel"
+        );
+
+        publishToMessageBus("/chat/channel-status", {
+          chat_channel_id: 4,
+          status: "archived",
+        });
+        await settled();
+        assert.notOk(
+          exists("#chat-channel-row-4 .chat-channel-unread-indicator"),
+          "unread indicator should not show after archive status change"
+        );
+      });
+
+      test("it changes the channel status in the header to archived", async function (assert) {
+        await visit("/chat/channel/4/Topic");
+        assert.notOk(
+          exists(".chat-channel-title-with-status .chat-channel-status"),
+          "channel status does not show if the channel is open"
+        );
+
+        publishToMessageBus("/chat/channel-status", {
+          chat_channel_id: 4,
+          status: "archived",
+        });
+        await settled();
+        assert.strictEqual(
+          query(
+            ".chat-channel-title-with-status .chat-channel-status"
+          ).innerText.trim(),
+          I18n.t("chat.channel_status.archived_header"),
+          "channel status changes to archived"
+        );
+      });
+    }
+  );
+}


### PR DESCRIPTION
When the channel was archived some users could end
up with an unclearable unread indicator. This commit
fixes the issue but for now the user still needs to
reload for the channel to drop off the list.