### PR TITLE
UX: Much more specific chat mention notifications

### DIFF
--- a/app/jobs/regular/create_chat_mention_notifications.rb
+++ b/app/jobs/regular/create_chat_mention_notifications.rb
@@ -22,19 +22,7 @@ module Jobs
             :chat_group_mention :
             :chat_mention
 
-          # A user might be directly mentioned by username, or mentioned with @here, @all or BOTH.
-          # Here we need to set the identifier if the user wasn't mentioned directly so that both
-          # OS notifications and core notifications can correctly display what identifier they were
-          # mentioned by.
-          mention_identifier = nil
-          if !args[:directly_mentioned_users_ids]&.include?(membership.user_id)
-            if args[:global_mentioned_users_ids]&.include?(membership.user_id)
-              mention_identifier = :global
-            elsif args[:here_mentioned_users_ids]&.include?(membership.user_id)
-              mention_identifier = :here
-            end
-          end
-
+          mention_identifier = (args["user_ids_to_identifier_map"] || {})[membership.user_id.to_s]
           send_mention_notification_to_user(membership.user, mention_type, group_name, mention_identifier)
           send_os_notifications(membership, mention_type, group_name, mention_identifier)
         end

--- a/app/jobs/regular/create_chat_mention_notifications.rb
+++ b/app/jobs/regular/create_chat_mention_notifications.rb
@@ -81,9 +81,6 @@ module Jobs
         excerpt: @chat_message.push_notification_excerpt,
         post_url: "/chat/channel/#{@chat_channel.id}/#{@chat_channel.title(membership.user).to_s.strip}?messageId=#{@chat_message.id}"
       }
-      puts '#################'
-      puts payload.inspect
-      puts '#################'
 
       unless membership.desktop_notifications_never?
         MessageBus.publish("/chat/notification-alert/#{membership.user.id}", payload, user_ids: [membership.user.id])

--- a/app/jobs/regular/create_chat_mention_notifications.rb
+++ b/app/jobs/regular/create_chat_mention_notifications.rb
@@ -21,42 +21,62 @@ module Jobs
           mention_type = group_name.present? ?
             :chat_group_mention :
             :chat_mention
-          send_mention_notification_to_user(membership.user, mention_type, group_name)
-          send_os_notifications(membership, mention_type, group_name)
+
+          # mention identifier is used by frontend to determine
+          mention_identifier = nil
+          if !args[:directly_mentioned_users_ids]&.include?(membership.user_id)
+            if args[:global_mentioned_users_ids]&.include?(membership.user_id)
+              mention_identifier = :global
+            elsif args[:here_mentioned_users_ids]&.include?(membership.user_id)
+              mention_identifier = :here
+            end
+          end
+
+          send_mention_notification_to_user(membership.user, mention_type, group_name, mention_identifier)
+          send_os_notifications(membership, mention_type, group_name, mention_identifier)
         end
       end
     end
 
-    def send_mention_notification_to_user(user, mention_type, group_name)
+    def send_mention_notification_to_user(user, mention_type, group_name, mention_identifier)
+      data = {
+        chat_message_id: @chat_message.id,
+        chat_channel_id: @chat_channel.id,
+        chat_channel_title: @chat_channel.title_for_mention(user),
+        mentioned_by_username: @creator.username,
+      }
+      data[:identifier] = mention_identifier if mention_identifier.present?
+      data[:group_name] = group_name if group_name.present?
+
       notification = Notification.create!(
         notification_type: Notification.types[mention_type],
         user_id: user.id,
         high_priority: true,
-        data: {
-          message: "notifications.popup.#{mention_type}",
-          group_name: group_name,
-          chat_message_id: @chat_message.id,
-          chat_channel_id: @chat_channel.id,
-          chat_channel_title: @chat_channel.title(user),
-          mentioned_by_username: @creator.username,
-        }.to_json
+        data: data.to_json
       )
       ChatMention.create!(notification: notification, user: user, chat_message: @chat_message)
     end
 
-    def send_os_notifications(membership, mention_type, group_name)
+    def send_os_notifications(membership, mention_type, group_name, mention_identifier)
       return if membership.desktop_notifications_never? && membership.mobile_notifications_never?
+
+      i18n_key = "discourse_push_notifications.popup.#{mention_type}"
+      if mention_type == :chat_mention
+        i18n_key += ".#{mention_identifier}"
+      end
 
       payload = {
         notification_type: Notification.types[mention_type],
         username: @creator.username,
-        translated_title: I18n.t("discourse_push_notifications.popup.#{mention_type}",
+        translated_title: I18n.t(i18n_key_for_os_notifications(mention_type, mention_identifier),
                                  username: @creator.username,
-                                 group_name: group_name
+                                 group_name: group_name,
+                                 identifier: transform_identifier(mention_identifier),
+                                 channel: @chat_channel.title_for_mention(membership.user)
                                 ),
         tag: DiscourseChat::ChatNotifier.push_notification_tag(:mention, @chat_channel.id),
         excerpt: @chat_message.push_notification_excerpt,
-        post_url: "/chat/channel/#{@chat_channel.id}/#{@chat_channel.title(membership.user)}?messageId=#{@chat_message.id}"
+        post_url: "/chat/channel/#{@chat_channel.id}/#{@chat_channel.title(membership.user).to_s.strip}?messageId=#{@chat_message.id}"
       }
 
       unless membership.desktop_notifications_never?
@@ -66,6 +86,19 @@ module Jobs
       unless membership.mobile_notifications_never?
         PostAlerter.push_notification(membership.user, payload)
       end
+    end
+
+    def transform_identifier(identifier)
+      # Translated `:global -> @all` and `:here -> @here`
+      "@#{identifier.to_s.sub('global', 'all')}"
+    end
+
+    def i18n_key_for_os_notifications(mention_type, identifier)
+      if mention_type == :chat_group_mention
+        return "discourse_push_notifications.popup.chat_group_mention"
+      end
+
+      "discourse_push_notifications.popup.chat_mention.#{identifier.present? ? 'other' : 'you'}"
     end
   end
 end

--- a/app/jobs/regular/notify_users_watching_chat.rb
+++ b/app/jobs/regular/notify_users_watching_chat.rb
@@ -36,7 +36,7 @@ module Jobs
       translated_title = @chat_channel.group_direct_message_channel? ?
         I18n.t("discourse_push_notifications.popup.group_chat_message") :
         I18n.t("discourse_push_notifications.popup.chat_message",
-               chat_channel_title: @chat_channel.title(user)
+               channel: @chat_channel.title_for_mention(user)
               )
 
       payload = {

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -103,6 +103,20 @@ class ChatChannel < ActiveRecord::Base
   end
 
   def title(user)
+    return chatable.chat_channel_title_for_user(self, user) if direct_message_channel?
+    return name if name.present?
+
+    title_from_chatable
+  end
+
+  def title_for_mention(user)
+    return I18n.t("chat.personal_chat") if direct_message_channel?
+    return name if name.present?
+
+    title_from_chatable
+  end
+
+  def title_from_chatable
     case chatable_type
     when "Topic"
       chatable.fancy_title

--- a/assets/javascripts/discourse/widgets/chat-mention-notification-items.js
+++ b/assets/javascripts/discourse/widgets/chat-mention-notification-items.js
@@ -13,7 +13,32 @@ const chatNotificationItem = {
   services: ["chat", "router"],
   text(notificationName, data) {
     const username = formatUsername(data.mentioned_by_username);
-    return I18n.t(data.message, { username, groupName: data.group_name });
+    if (data.group_name) {
+      return I18n.t("notifications.popup.chat_group_mention", {
+        username,
+        groupName: data.group_name,
+        channel: data.chat_channel_title,
+      });
+    }
+
+    let identifier;
+    if (data.identifier) {
+      identifier = this.transformIdentifier(data.identifier);
+    }
+    console.log(identifier, data.identifier);
+    const i18nKey = identifier
+      ? "notifications.popup.chat_mention.other"
+      : "notifications.popup.chat_mention.you";
+
+    return I18n.t(i18nKey, {
+      username,
+      identifier: identifier,
+      channel: data.chat_channel_title,
+    });
+  },
+
+  transformIdentifier(identifier) {
+    return `<b>@${identifier.replace("global", "all")}</b>`;
   },
 
   html(attrs) {
@@ -24,7 +49,7 @@ const chatNotificationItem = {
     const title = this.notificationTitle(notificationName, data);
     const text = this.text(notificationName, data);
     const html = new RawHtml({ html: `<div>${text}</div>` });
-    const icon = notificationName === "chat_mention" ? "at" : "users";
+    const icon = notificationName === "chat_mention" ? "comment" : "users";
     const contents = [iconNode(icon), html];
 
     return h("a", { attributes: { title } }, contents);

--- a/assets/javascripts/discourse/widgets/chat-mention-notification-items.js
+++ b/assets/javascripts/discourse/widgets/chat-mention-notification-items.js
@@ -28,7 +28,7 @@ const chatNotificationItem = {
     console.log(identifier, data.identifier);
     const i18nKey = identifier
       ? "notifications.popup.chat_mention.other"
-      : "notifications.popup.chat_mention.you";
+      : "notifications.popup.chat_mention.direct";
 
     return I18n.t(i18nKey, {
       username,

--- a/assets/javascripts/discourse/widgets/chat-mention-notification-items.js
+++ b/assets/javascripts/discourse/widgets/chat-mention-notification-items.js
@@ -13,32 +13,29 @@ const chatNotificationItem = {
   services: ["chat", "router"],
   text(notificationName, data) {
     const username = formatUsername(data.mentioned_by_username);
-    if (data.group_name) {
-      return I18n.t("notifications.popup.chat_group_mention", {
-        username,
-        groupName: data.group_name,
-        channel: data.chat_channel_title,
-      });
-    }
-
-    let identifier;
-    if (data.identifier) {
-      identifier = this.transformIdentifier(data.identifier);
-    }
-    console.log(identifier, data.identifier);
+    const identifier = this.transformIdentifier(data);
     const i18nKey = identifier
       ? "notifications.popup.chat_mention.other"
       : "notifications.popup.chat_mention.direct";
 
     return I18n.t(i18nKey, {
       username,
-      identifier: identifier,
+      identifier,
       channel: data.chat_channel_title,
     });
   },
 
-  transformIdentifier(identifier) {
-    return `<b>@${identifier.replace("global", "all")}</b>`;
+  transformIdentifier(data) {
+    if (!data.identifier) {
+      return;
+    }
+
+    let identifier = data.identifier;
+    if (!data.is_group_mention) {
+      identifier = identifier.replace("global", "all");
+    }
+
+    return `@${identifier}`;
   },
 
   html(attrs) {
@@ -49,8 +46,7 @@ const chatNotificationItem = {
     const title = this.notificationTitle(notificationName, data);
     const text = this.text(notificationName, data);
     const html = new RawHtml({ html: `<div>${text}</div>` });
-    const icon = notificationName === "chat_mention" ? "comment" : "users";
-    const contents = [iconNode(icon), html];
+    const contents = [iconNode("comment"), html];
 
     return h("a", { attributes: { title } }, contents);
   },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -259,8 +259,11 @@ en:
       chat_quoted: "<span>%{username}</span> %{description}"
 
       popup:
-        chat_mention: "<span>%{username}</span> <span>mentioned you in chat</span>"
+        chat_mention:
+          you: "<span>%{username}</span> <span>mentioned you in %{channel}</span>"
+          other: "<span>%{username}</span> <span>mentioned %{identifier} in %{channel}</span>"
         chat_group_mention: "<span>%{username}</span> <span>mentioned @%{groupName} in chat</span>"
+
         chat_message: "New chat message"
         chat_quoted: "%{username} quoted your chat message"
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -262,8 +262,6 @@ en:
         chat_mention:
           direct: "<span>%{username}</span> <span>mentioned you in %{channel}</span>"
           other: "<span>%{username}</span> <span>mentioned %{identifier} in %{channel}</span>"
-        chat_group_mention: "<span>%{username}</span> <span>mentioned @%{groupName} in chat</span>"
-
         chat_message: "New chat message"
         chat_quoted: "%{username} quoted your chat message"
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -260,7 +260,7 @@ en:
 
       popup:
         chat_mention:
-          you: "<span>%{username}</span> <span>mentioned you in %{channel}</span>"
+          direct: "<span>%{username}</span> <span>mentioned you in %{channel}</span>"
           other: "<span>%{username}</span> <span>mentioned %{identifier} in %{channel}</span>"
         chat_group_mention: "<span>%{username}</span> <span>mentioned @%{groupName} in chat</span>"
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -83,7 +83,7 @@ en:
   discourse_push_notifications:
     popup:
       chat_mention:
-        you: "@%{username} mentioned you in %{channel}"
+        direct: "@%{username} mentioned you in %{channel}"
         other: "@%{username} mentioned %{identifier} in %{channel}"
 
       chat_group_mention: "@%{username} mentioned @%{group_name} in %{channel}"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -85,10 +85,7 @@ en:
       chat_mention:
         direct: "@%{username} mentioned you in %{channel}"
         other: "@%{username} mentioned %{identifier} in %{channel}"
-
-      chat_group_mention: "@%{username} mentioned @%{group_name} in %{channel}"
-      chat_message: "New chat message in %{chat_channel_title}"
-      group_chat_message: "New chat message in a personal chat channel"
+      chat_message: "New chat message in %{channel}"
 
   discourse_automation:
     scriptables:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -78,10 +78,15 @@ en:
       archive:
         first_post_raw: "This topic is an archive of the [%{channel_name}](%{channel_url}) chat channel."
 
+    personal_chat: "personal chat"
+
   discourse_push_notifications:
     popup:
-      chat_mention: "@%{username} mentioned you in chat"
-      chat_group_mention: "@%{username} mentioned @%{group_name} in chat"
+      chat_mention:
+        you: "@%{username} mentioned you in %{channel}"
+        other: "@%{username} mentioned %{identifier} in %{channel}"
+
+      chat_group_mention: "@%{username} mentioned @%{group_name} in %{channel}"
       chat_message: "New chat message in %{chat_channel_title}"
       group_chat_message: "New chat message in a personal chat channel"
 

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -74,7 +74,6 @@ const baseChatPretenders = (server, helper) => {
           topic_id: null,
           slug: null,
           data: {
-            message: "notifications.popup.chat_mention",
             chat_message_id: 174,
             chat_channel_id: 9,
             chat_channel_title: "Site",
@@ -84,17 +83,37 @@ const baseChatPretenders = (server, helper) => {
         {
           id: 43,
           user_id: 1,
-          notification_type: 32,
+          notification_type: 29,
           read: false,
           high_priority: true,
           created_at: "2021-01-01 12:00:00 UTC",
-          fancy_title: "First notification",
+          fancy_title: "Second notification",
           post_number: null,
           topic_id: null,
           slug: null,
           data: {
-            message: "notifications.popup.chat_group_mention",
-            group_name: "engineers",
+            identifier: "engineers",
+            is_group: true,
+            chat_message_id: 174,
+            chat_channel_id: 9,
+            chat_channel_title: "Site",
+            mentioned_by_username: "hawk",
+          },
+        },
+        {
+          id: 43,
+          user_id: 1,
+          notification_type: 29,
+          read: false,
+          high_priority: true,
+          created_at: "2021-01-01 12:00:00 UTC",
+          fancy_title: "Third notification",
+          post_number: null,
+          topic_id: null,
+          slug: null,
+          data: {
+            identifier: "global",
+            is_group: true,
             chat_message_id: 174,
             chat_channel_id: 9,
             chat_channel_title: "Site",
@@ -255,17 +274,38 @@ acceptance("Discourse Chat - without unread", function (needs) {
     assert.equal(currentURL(), `/chat/channel/9/Site`);
   });
 
-  test("Regular mention uses the `@` icon", async function (assert) {
+  test("Mention notifications contain the correct text and icon", async function (assert) {
     await visit("/chat/channel/75/@hawk");
     await click(".header-dropdown-toggle.current-user");
-    assert.ok(exists("#quick-access-notifications .chat-mention .d-icon-at"));
-  });
+    const notifications = queryAll("#quick-access-notifications .chat-mention");
 
-  test("Group mention uses the users icon", async function (assert) {
-    await visit("/chat/channel/75/@hawk");
-    await click(".header-dropdown-toggle.current-user");
-    assert.ok(
-      exists("#quick-access-notifications .chat-group-mention .d-icon-users")
+    // First is a direct mention from @hawk in #Site
+    assert.equal(
+      notifications[0].innerText,
+      I18n.t("notifications.popup.chat_mention.direct", {
+        username: "hawk",
+        identifier: null,
+        channel: "Site",
+      })
+    );
+
+    // Second is a group mention from @hawk in #Site
+    assert.equal(
+      notifications[1].innerText,
+      I18n.t("notifications.popup.chat_mention.other", {
+        username: "hawk",
+        identifier: "@engineers",
+        channel: "Site",
+      })
+    );
+
+    assert.equal(
+      notifications[2].innerText,
+      I18n.t("notifications.popup.chat_mention.other", {
+        username: "hawk",
+        identifier: "@all",
+        channel: "Site",
+      })
     );
   });
 


### PR DESCRIPTION
This no longer uses the `chat_group_mention` notification type and uses `chat_mention` for everything is `is_group` and `identifier` stored in the `data` column. This makes for a much more logical code path with fewer options.

It doesn't look very tested, but all the existing mention tests break if something in this code breaks :)

![image](https://user-images.githubusercontent.com/16214023/158426700-440cf1a3-fea6-4f76-ab96-c2ce22085fef.png)
