### PR TITLE
FEATURE: Include reactions in archive chat quotes

### DIFF
--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -75,15 +75,15 @@ class ChatMessage < ActiveRecord::Base
     if self.message.present?
       msg = self.message
 
-      if self.uploads.any?
+      if self.chat_uploads.any?
         markdown << msg + "\n"
       else
         markdown << msg
       end
     end
 
-    self.uploads.order(:created_at).each do |upload|
-      markdown << UploadMarkdown.new(upload).to_markdown
+    self.chat_uploads.order(:created_at).each do |chat_upload|
+      markdown << UploadMarkdown.new(chat_upload.upload).to_markdown
     end
 
     markdown.reject(&:empty?).join("\n")

--- a/assets/javascripts/lib/discourse-markdown/discourse-chat-transcript.js
+++ b/assets/javascripts/lib/discourse-markdown/discourse-chat-transcript.js
@@ -162,8 +162,7 @@ const chatTranscriptRule = {
       );
       reactionsToken.attrs = [["class", "chat-transcript-reactions"]];
 
-      const reactionsMap = reactions.split(";");
-      reactionsMap.forEach((reaction) => {
+      reactions.split(";").forEach((reaction) => {
         const split = reaction.split(":");
         const emoji = split[0];
         const usernames = split[1].split(",");
@@ -181,8 +180,9 @@ const chatTranscriptRule = {
             lazy: true,
           });
         }
-        emojiToken.content =
-          emojiHtmlCache[emoji] + " " + usernames.length.toString();
+        emojiToken.content = `${
+          emojiHtmlCache[emoji]
+        } ${usernames.length.toString()}`;
         state.push("div_chat_transcript_reaction", "div", -1);
       });
       state.push("div_chat_transcript_reactions", "div", -1);

--- a/assets/stylesheets/common/chat-message.scss
+++ b/assets/stylesheets/common/chat-message.scss
@@ -13,6 +13,43 @@
   }
 }
 
+@mixin chat-reaction {
+  align-items: center;
+  display: inline-flex;
+  padding: 0.3em 0.6em;
+  margin: 1px 0.25em 1px 0;
+  font-size: var(--font-down-2);
+  border-radius: 4px;
+  border: 1px solid var(--primary-low);
+  background: transparent;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.2s, border-color 0.2s;
+
+  &.reacted {
+    border-color: var(--tertiary-medium);
+    background: var(--tertiary-very-low);
+    color: var(--tertiary-hover);
+
+    &:hover {
+      background: var(--tertiary-low);
+    }
+  }
+
+  &:not(.reacted) {
+    &:hover {
+      background: var(--primary-low);
+      border-color: var(--primary-low-mid);
+    }
+  }
+
+  .emoji {
+    height: 15px;
+    margin-right: 4px;
+    width: auto;
+  }
+}
+
 .chat-message {
   align-items: flex-start;
   position: relative;
@@ -22,43 +59,10 @@
   min-width: 0;
 
   .chat-message-reaction {
-    align-items: center;
-    display: inline-flex;
-    padding: 0.3em 0.6em;
-    margin: 1px 0.25em 1px 0;
-    font-size: var(--font-down-2);
-    border-radius: 4px;
-    border: 1px solid var(--primary-low);
-    background: transparent;
-    cursor: pointer;
-    user-select: none;
-    transition: background 0.2s, border-color 0.2s;
-
-    &:not(.reacted) {
-      &:hover {
-        background: var(--primary-low);
-        border-color: var(--primary-low-mid);
-      }
-    }
+    @include chat-reaction;
 
     &:not(.show) {
       display: none;
-    }
-
-    &.reacted {
-      border-color: var(--tertiary-medium);
-      background: var(--tertiary-very-low);
-      color: var(--tertiary-hover);
-
-      &:hover {
-        background: var(--tertiary-low);
-      }
-    }
-
-    .emoji {
-      height: 15px;
-      margin-right: 4px;
-      width: auto;
     }
   }
 
@@ -197,7 +201,8 @@
     font-size: var(--font-down-2);
   }
 
-  .chat-message-reaction-list {
+  .chat-message-reaction-list,
+  .chat-transcript-reactions {
     position: relative;
     margin-top: 0.25em;
     display: flex;

--- a/assets/stylesheets/common/chat-transcript.scss
+++ b/assets/stylesheets/common/chat-transcript.scss
@@ -58,4 +58,12 @@
       padding-right: 0.5rem;
     }
   }
+
+  .chat-transcript-reactions {
+    margin-top: 0.5em;
+
+    .chat-transcript-reaction {
+      @include chat-reaction;
+    }
+  }
 }

--- a/lib/chat_channel_archive_service.rb
+++ b/lib/chat_channel_archive_service.rb
@@ -73,7 +73,9 @@ class DiscourseChat::ChatChannelArchiveService
       ) do |chat_messages|
         create_post(
           ChatTranscriptService.new(
-            chat_channel, messages_or_ids: chat_messages, opts: { no_link: true }
+            chat_channel,
+            messages_or_ids: chat_messages,
+            opts: { no_link: true, include_reactions: true }
           ).generate_markdown
         ) do
           delete_message_batch(chat_messages.map(&:id))

--- a/lib/chat_transcript_service.rb
+++ b/lib/chat_transcript_service.rb
@@ -60,12 +60,14 @@ class ChatTranscriptService
 
     def reactions_attr
       reaction_data = @message_data.reduce([]) do |array, msg_data|
-        next if msg_data[:reactions].empty?
-        array << msg_data[:reactions].map do |react|
-          "#{react.emoji}:#{react.usernames}"
+        if msg_data[:reactions].any?
+          array << msg_data[:reactions].map do |react|
+            "#{react.emoji}:#{react.usernames}"
+          end
         end
+        array
       end
-      return if reaction_data.blank? || reaction_data.empty?
+      return if reaction_data.empty?
       "reactions=\"#{reaction_data.join(";")}\""
     end
 
@@ -128,7 +130,9 @@ class ChatTranscriptService
   private
 
   def messages
-    @messages ||= ChatMessage.includes(:user, :uploads, :reactions).where(
+    @messages ||= ChatMessage.includes(
+      :user, chat_uploads: :upload
+    ).where(
       id: @message_ids, chat_channel_id: @channel.id
     ).order(:created_at)
   end

--- a/lib/chat_transcript_service.rb
+++ b/lib/chat_transcript_service.rb
@@ -65,7 +65,7 @@ class ChatTranscriptService
           "#{react.emoji}:#{react.usernames}"
         end
       end
-      return if reaction_data.empty?
+      return if reaction_data.blank? || reaction_data.empty?
       "reactions=\"#{reaction_data.join(";")}\""
     end
 

--- a/lib/chat_transcript_service.rb
+++ b/lib/chat_transcript_service.rb
@@ -59,12 +59,12 @@ class ChatTranscriptService
     private
 
     def reactions_attr
-      reaction_data = @message_data.map do |msg_data|
+      reaction_data = @message_data.reduce([]) do |array, msg_data|
         next if msg_data[:reactions].empty?
-        msg_data[:reactions].map do |react|
+        array << msg_data[:reactions].map do |react|
           "#{react.emoji}:#{react.usernames}"
         end
-      end.compact
+      end
       return if reaction_data.empty?
       "reactions=\"#{reaction_data.join(";")}\""
     end

--- a/lib/chat_transcript_service.rb
+++ b/lib/chat_transcript_service.rb
@@ -20,40 +20,54 @@ class ChatTranscriptService
   NO_LINK_ATTR = "noLink=\"true\""
 
   class ChatTranscriptBBCode
-    attr_reader :channel, :multiquote, :chained, :no_link
+    attr_reader :channel, :multiquote, :chained, :no_link, :include_reactions
 
     def initialize(
       channel: nil,
       multiquote: false,
       chained: false,
-      no_link: false
+      no_link: false,
+      include_reactions: false
     )
       @channel = channel
       @multiquote = multiquote
       @chained = chained
       @no_link = no_link
-      @messages = []
+      @include_reactions = include_reactions
+      @message_data = []
     end
 
-    def <<(message)
-      @messages << message
+    def add(message:, reactions: nil)
+      @message_data << { message: message, reactions: reactions }
     end
 
     def render
-      attrs = [quote_attr(@messages.first)]
+      attrs = [quote_attr(@message_data.first[:message])]
       attrs << channel_attr if channel
       attrs << MULTIQUOTE_ATTR if multiquote
       attrs << CHAINED_ATTR if chained
       attrs << NO_LINK_ATTR if no_link
+      attrs << reactions_attr if include_reactions
 
       <<~MARKDOWN
-      [chat #{attrs.join(" ")}]
-      #{@messages.map(&:to_markdown).join("\n\n")}
+      [chat #{attrs.compact.join(" ")}]
+      #{@message_data.map { |msg| msg[:message].to_markdown }.join("\n\n")}
       [/chat]
       MARKDOWN
     end
 
     private
+
+    def reactions_attr
+      reaction_data = @message_data.map do |msg_data|
+        next if msg_data[:reactions].empty?
+        msg_data[:reactions].map do |react|
+          "#{react.emoji}:#{react.usernames}"
+        end
+      end.compact
+      return if reaction_data.empty?
+      "reactions=\"#{reaction_data.join(";")}\""
+    end
 
     def quote_attr(message)
       "quote=\"#{message.user.username};#{message.id};#{message.created_at.iso8601}\""
@@ -83,7 +97,8 @@ class ChatTranscriptService
       channel: @channel,
       multiquote: messages.length > 1,
       chained: !all_messages_same_user,
-      no_link: @opts[:no_link]
+      no_link: @opts[:no_link],
+      include_reactions: @opts[:include_reactions]
     )
 
     messages.each.with_index do |message, idx|
@@ -92,11 +107,16 @@ class ChatTranscriptService
 
         open_bbcode_tag = ChatTranscriptBBCode.new(
           chained: !all_messages_same_user,
-          no_link: @opts[:no_link]
+          no_link: @opts[:no_link],
+          include_reactions: @opts[:include_reactions]
         )
       end
 
-      open_bbcode_tag << message
+      if @opts[:include_reactions]
+        open_bbcode_tag.add(message: message, reactions: reactions_for_message(message))
+      else
+        open_bbcode_tag.add(message: message)
+      end
       previous_message = message
     end
 
@@ -108,8 +128,31 @@ class ChatTranscriptService
   private
 
   def messages
-    @messages ||= ChatMessage.includes(:user, :uploads).where(
+    @messages ||= ChatMessage.includes(:user, :uploads, :reactions).where(
       id: @message_ids, chat_channel_id: @channel.id
     ).order(:created_at)
+  end
+
+  ##
+  # Queries reactions and returns them in this format
+  #
+  # emoji   |  usernames  |  chat_message_id
+  # ----------------------------------------
+  # +1      | foo,bar,baz | 102
+  # heart   | foo         | 102
+  # sob     | bar,baz     | 103
+  def reactions
+    @reactions ||= DB.query(<<~SQL, @messages.map(&:id))
+    SELECT emoji, STRING_AGG(DISTINCT users.username, ',') AS usernames, chat_message_id
+    FROM chat_message_reactions
+    INNER JOIN users on users.id = chat_message_reactions.user_id
+    WHERE chat_message_id IN (?)
+    GROUP BY emoji, chat_message_id
+    ORDER BY chat_message_id, emoji
+    SQL
+  end
+
+  def reactions_for_message(message)
+    reactions.select { |react| react.chat_message_id == message.id }
   end
 end

--- a/spec/lib/chat_channel_archive_service_spec.rb
+++ b/spec/lib/chat_channel_archive_service_spec.rb
@@ -80,6 +80,7 @@ describe DiscourseChat::ChatChannelArchiveService do
 
       it "makes a topic, deletes all the messages, creates posts for batches of messages, and changes the channel to archived" do
         create_messages(50) && start_archive
+        ChatMessageReaction.create!(chat_message: ChatMessage.first, user: Fabricate(:user), emoji: "+1")
         stub_const(DiscourseChat::ChatChannelArchiveService, "ARCHIVED_MESSAGES_PER_POST", 5) do
           subject.new(@channel_archive).execute
         end
@@ -95,6 +96,7 @@ describe DiscourseChat::ChatChannelArchiveService do
         topic.posts.where.not(post_number: 1).each do |post|
           expect(post.raw).to include("[chat")
           expect(post.raw).to include("noLink=\"true\"")
+          expect(post.raw).to include("reactions=")
         end
         expect(topic.archived).to eq(true)
 

--- a/spec/lib/chat_transcript_service_spec.rb
+++ b/spec/lib/chat_transcript_service_spec.rb
@@ -132,11 +132,11 @@ describe ChatTranscriptService do
     message2 = Fabricate(:chat_message, user: user1, chat_channel: channel, message: "wow so tru")
     message3 = Fabricate(:chat_message, user: user2, chat_channel: channel, message: "a new perspective")
 
-    ChatMessageReaction.create(chat_message: message, user: Fabricate(:user, username: "bjorn"), emoji: "heart")
-    ChatMessageReaction.create(chat_message: message, user: Fabricate(:user, username: "sigurd"), emoji: "heart")
-    ChatMessageReaction.create(chat_message: message, user: Fabricate(:user, username: "hvitserk"), emoji: "+1")
-    ChatMessageReaction.create(chat_message: message2, user: Fabricate(:user, username: "ubbe"), emoji: "money_mouth_face")
-    ChatMessageReaction.create(chat_message: message3, user: Fabricate(:user, username: "ivar"), emoji: "sob")
+    ChatMessageReaction.create!(chat_message: message, user: Fabricate(:user, username: "bjorn"), emoji: "heart")
+    ChatMessageReaction.create!(chat_message: message, user: Fabricate(:user, username: "sigurd"), emoji: "heart")
+    ChatMessageReaction.create!(chat_message: message, user: Fabricate(:user, username: "hvitserk"), emoji: "+1")
+    ChatMessageReaction.create!(chat_message: message2, user: Fabricate(:user, username: "ubbe"), emoji: "money_mouth_face")
+    ChatMessageReaction.create!(chat_message: message3, user: Fabricate(:user, username: "ivar"), emoji: "sob")
 
     expect(service([message.id, message2.id, message3.id], opts: { include_reactions: true }).generate_markdown).to eq(<<~MARKDOWN)
     [chat quote="martinchat;#{message.id};#{message.created_at.iso8601}" channel="The Beam Discussions" multiQuote="true" chained="true" reactions="+1:hvitserk;heart:bjorn,sigurd;money_mouth_face:ubbe"]

--- a/spec/lib/chat_transcript_service_spec.rb
+++ b/spec/lib/chat_transcript_service_spec.rb
@@ -126,4 +126,28 @@ describe ChatTranscriptService do
     [/chat]
     MARKDOWN
   end
+
+  it "generates reaction data for single and subsequent messages" do
+    message = Fabricate(:chat_message, user: user1, chat_channel: channel, message: "an extremely insightful response :)")
+    message2 = Fabricate(:chat_message, user: user1, chat_channel: channel, message: "wow so tru")
+    message3 = Fabricate(:chat_message, user: user2, chat_channel: channel, message: "a new perspective")
+
+    ChatMessageReaction.create(chat_message: message, user: Fabricate(:user, username: "bjorn"), emoji: "heart")
+    ChatMessageReaction.create(chat_message: message, user: Fabricate(:user, username: "sigurd"), emoji: "heart")
+    ChatMessageReaction.create(chat_message: message, user: Fabricate(:user, username: "hvitserk"), emoji: "+1")
+    ChatMessageReaction.create(chat_message: message2, user: Fabricate(:user, username: "ubbe"), emoji: "money_mouth_face")
+    ChatMessageReaction.create(chat_message: message3, user: Fabricate(:user, username: "ivar"), emoji: "sob")
+
+    expect(service([message.id, message2.id, message3.id], opts: { include_reactions: true }).generate_markdown).to eq(<<~MARKDOWN)
+    [chat quote="martinchat;#{message.id};#{message.created_at.iso8601}" channel="The Beam Discussions" multiQuote="true" chained="true" reactions="+1:hvitserk;heart:bjorn,sigurd;money_mouth_face:ubbe"]
+    an extremely insightful response :)
+
+    wow so tru
+    [/chat]
+
+    [chat quote="brucechat;#{message3.id};#{message3.created_at.iso8601}" chained="true" reactions="sob:ivar"]
+    a new perspective
+    [/chat]
+    MARKDOWN
+  end
 end


### PR DESCRIPTION
This commit introduces a new reactions attribute to
the [chat] BBcode in the format `emoji:user1,user2;emoji2:user1`.
When included, we store this data in a data-reactions attr
on the wrapping chat transcript div, and also construct
reaction indicators at the bottom of each [chat] quoted
set of messages.

We have intentionally left off the following:

* Fidelity is only per-group of messages. For example, if there
  are 3 messages from a single user grouped into one [chat]
  block, and each individual message has a reaction, all 3
  reactions are placed at the bottom of the set of messages.
* When hovering the reactions, we do not show which username
  reacted to what, we should be easily able to do this in
  V2 of this feature.

Regular quoting of chat messages will not include
reaction metadata, only when the messages are archived.

![image](https://user-images.githubusercontent.com/920448/158521381-2c0b7d4a-6261-4c7b-a941-2ecfb508714c.png)
