### PR TITLE
FIX: moves unread indicator to chat-channel-title

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
@@ -9,7 +9,6 @@
   data-chat-channel-id={{channel.id}}
 >
   {{chat-channel-title channel=channel}}
-  {{chat-channel-unread-indicator channel=channel}}
 
   {{#if options.leaveButton}}
     {{chat-channel-leave-btn

--- a/assets/javascripts/discourse/templates/components/chat-channel-selection-row.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-selection-row.hbs
@@ -13,6 +13,5 @@
     </span>
   {{else}}
     {{chat-channel-title channel=model}}
-    {{chat-channel-unread-indicator channel=channel}}
   {{/if}}
 </div>

--- a/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
@@ -37,4 +37,5 @@
     </span>
     <p class="topic-chat-name">{{replace-emoji channel.title}}</p>
   {{/if}}
+  {{chat-channel-unread-indicator channel=channel}}
 </div>

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -327,7 +327,6 @@ body.composer-open .topic-chat-float-container {
   .chat-channel-unread-indicator {
     width: 10px;
     height: 10px;
-    margin-left: 0.5em;
     border-radius: 10px;
     border: 0;
     right: 7px;
@@ -965,7 +964,7 @@ body.composer-open .topic-chat-float-container {
 .chat-channel-title {
   position: relative;
   display: grid;
-  grid-template-columns: 22px 1fr;
+  grid-template-columns: 22px 1fr 10px;
   grid-column-gap: 0.5em;
   align-items: center;
   cursor: pointer;


### PR DESCRIPTION
This way it's included in the grid of chat-channel-title and ensures we have enough space.