### PR TITLE
FIX: Don't error when user no longer exists

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -804,7 +804,7 @@ export default Component.extend({
           messageId = this.messages[this.messages.length - 1]?.id;
         }
         const hasUnreadMessage =
-          messageId && messageId !== this.lastSendReadMessageId;
+          messageId && messageId > this.lastSendReadMessageId;
 
         if (
           !hasUnreadMessage &&

--- a/assets/javascripts/discourse/components/chat-message.js
+++ b/assets/javascripts/discourse/components/chat-message.js
@@ -221,7 +221,7 @@ export default Component.extend({
   show(message, canModerate) {
     return (
       !message.deleted_at ||
-      this.currentUser === this.message.user.id ||
+      this.currentUser === this.message.user?.id ||
       this.currentUser.staff ||
       canModerate
     );
@@ -291,6 +291,9 @@ export default Component.extend({
 
   @discourseComputed("message.user")
   name(user) {
+    if (!user) {
+      return I18n.t("chat.user_deleted");
+    }
     return this.prioritizeName ? user.name : user.username;
   },
 
@@ -304,6 +307,10 @@ export default Component.extend({
     const classes = this.prioritizeName
       ? ["full-name names first"]
       : ["username names first"];
+
+    if (!user) {
+      return classes;
+    }
     if (user.staff) {
       classes.push("staff");
     }
@@ -324,7 +331,7 @@ export default Component.extend({
     return (
       !message.action_code &&
       !deletedAt &&
-      this.currentUser.id === message.user.id &&
+      this.currentUser.id === message.user?.id &&
       this.chatChannel.canModifyMessages(this.currentUser)
     );
   },
@@ -337,7 +344,7 @@ export default Component.extend({
   )
   canFlagMessage(message, userFlagStatus, canFlag, deletedAt) {
     return (
-      this.currentUser?.id !== message.user.id &&
+      this.currentUser?.id !== message.user?.id &&
       userFlagStatus === undefined &&
       canFlag &&
       !message.chat_webhook_event &&
@@ -349,7 +356,7 @@ export default Component.extend({
   showSilenceButton(message) {
     return (
       this.currentUser?.staff &&
-      this.currentUser?.id !== message.user.id &&
+      this.currentUser?.id !== message.user?.id &&
       !message.chat_webhook_event
     );
   },
@@ -358,7 +365,7 @@ export default Component.extend({
   canManageDeletion(message) {
     return (
       !message.action_code &&
-      (this.currentUser?.id === message.user.id
+      (this.currentUser?.id === message.user?.id
         ? this.details.can_delete_self
         : this.details.can_delete_others)
     );
@@ -713,7 +720,7 @@ export default Component.extend({
   flag() {
     bootbox.confirm(
       I18n.t("chat.confirm_flag", {
-        username: this.message.user.username,
+        username: this.message.user?.username,
       }),
       (confirmed) => {
         if (confirmed) {

--- a/assets/javascripts/discourse/templates/components/chat-message.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message.hbs
@@ -81,7 +81,11 @@
             {{#if message.in_reply_to.chat_webhook_event.emoji}}
               {{chat-emoji-avatar emoji=message.in_reply_to.chat_webhook_event.emoji}}
             {{else}}
-              {{chat-user-avatar user=message.in_reply_to.user}}
+              {{#if message.in_reply_to.user}}
+                {{chat-user-avatar user=message.in_reply_to.user}}
+              {{else}}
+                {{chat-emoji-avatar emoji=":wastebasket:"}}
+              {{/if}}
             {{/if}}
 
             <span class="tc-reply-msg">
@@ -108,7 +112,11 @@
           {{#if message.chat_webhook_event.emoji}}
             {{chat-emoji-avatar emoji=message.chat_webhook_event.emoji}}
           {{else}}
-            {{chat-user-avatar user=message.user avatarSize="medium"}}
+            {{#if message.user}}
+              {{chat-user-avatar user=message.user avatarSize="medium"}}
+            {{else}}
+              {{chat-emoji-avatar emoji=":wastebasket:"}}
+            {{/if}}
           {{/if}}
         {{/if}}
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -117,6 +117,7 @@ en:
         one: "%{count} file"
         other: "%{count} files"
       you_flagged: "You flagged this message"
+      user_deleted: "deleted"
       exit: "back"
       channel_status:
         read_only_header: "Channel is read only."

--- a/test/javascripts/components/chat-message-test.js
+++ b/test/javascripts/components/chat-message-test.js
@@ -36,12 +36,6 @@ discourseModule("Discourse Chat | Component | chat-message", function (hooks) {
     template,
 
     async beforeEach() {
-      emojiReactionStore = this.container.lookup(
-        "service:chat-emoji-reaction-store"
-      );
-      emojiReactionStore.siteSettings =
-        this.container.lookup("site-settings:main");
-
       const chatChannel = ChatChannel.create({
         chatable: { id: 1 },
         chatable_type: "Category",
@@ -84,9 +78,6 @@ discourseModule("Discourse Chat | Component | chat-message", function (hooks) {
         fullPage: false,
         afterReactionAdded: () => {},
       });
-    },
-    async afterEach() {
-      emojiReactionStore.reset();
     },
 
     async test(assert) {

--- a/test/javascripts/components/chat-message-test.js
+++ b/test/javascripts/components/chat-message-test.js
@@ -13,6 +13,7 @@ import I18n from "I18n";
 
 discourseModule("Discourse Chat | Component | chat-message", function (hooks) {
   setupRenderingTest(hooks);
+
   const template = hbs`{{chat-message
       message=message
       canInteractWithChat=canInteractWithChat
@@ -29,19 +30,27 @@ discourseModule("Discourse Chat | Component | chat-message", function (hooks) {
       fullPage=fullPage
       afterReactionAdded=reStickScrollIfNeeded
     }}`;
-
-  const chatChannel = ChatChannel.create({
-    chatable: { id: 1 },
-    chatable_type: "Category",
-    id: 9,
-    title: "Site",
-    unread_count: 0,
-    muted: false,
-  });
+  let emojiReactionStore;
 
   componentTest("Message with deleted user", {
     template,
+
     async beforeEach() {
+      emojiReactionStore = this.container.lookup(
+        "service:chat-emoji-reaction-store"
+      );
+      emojiReactionStore.siteSettings =
+        this.container.lookup("site-settings:main");
+
+      const chatChannel = ChatChannel.create({
+        chatable: { id: 1 },
+        chatable_type: "Category",
+        id: 9,
+        title: "Site",
+        unread_count: 0,
+        muted: false,
+      });
+
       this.setProperties({
         message: EmberObject.create({
           id: 178,
@@ -75,6 +84,9 @@ discourseModule("Discourse Chat | Component | chat-message", function (hooks) {
         fullPage: false,
         afterReactionAdded: () => {},
       });
+    },
+    async afterEach() {
+      emojiReactionStore.reset();
     },
 
     async test(assert) {

--- a/test/javascripts/components/chat-message-test.js
+++ b/test/javascripts/components/chat-message-test.js
@@ -1,0 +1,92 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import {
+  discourseModule,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+import hbs from "htmlbars-inline-precompile";
+import ChatChannel from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
+import EmberObject from "@ember/object";
+import I18n from "I18n";
+
+discourseModule("Discourse Chat | Component | chat-message", function (hooks) {
+  setupRenderingTest(hooks);
+  const template = hbs`{{chat-message
+      message=message
+      canInteractWithChat=canInteractWithChat
+      details=this.details
+      chatChannel=chatChannel
+      setReplyTo=setReplyTo
+      replyMessageClicked=replyMessageClicked
+      editButtonClicked=editButtonClicked
+      afterExpand=decorateMessages
+      selectingMessages=selectingMessages
+      onStartSelectingMessages=onStartSelectingMessages
+      onSelectMessage=onSelectMessage
+      bulkSelectMessages=bulkSelectMessages
+      fullPage=fullPage
+      afterReactionAdded=reStickScrollIfNeeded
+    }}`;
+
+  const chatChannel = ChatChannel.create({
+    chatable: { id: 1 },
+    chatable_type: "Category",
+    id: 9,
+    title: "Site",
+    unread_count: 0,
+    muted: false,
+  });
+
+  componentTest("Message with deleted user", {
+    template,
+    async beforeEach() {
+      this.setProperties({
+        message: EmberObject.create({
+          id: 178,
+          message: "from deleted user",
+          cooked: "<p>from deleted user</p>",
+          excerpt: "<p>from deleted user</p>",
+          action_code: null,
+          created_at: "2021-07-22T08:14:16.950Z",
+          flag_count: 0,
+          user: null,
+        }),
+        canInteractWithChat: true,
+        details: {
+          chat_channel_id: chatChannel.id,
+          chatable_type: chatChannel.chatable_type,
+          can_delete_self: true,
+          can_delete_others: true,
+          can_flag: true,
+          user_silenced: false,
+          can_moderate: true,
+        },
+        chatChannel,
+        setReplyTo: () => {},
+        replyMessageClicked: () => {},
+        editButtonClicked: () => {},
+        afterExpand: () => {},
+        selectingMessages: false,
+        onStartSelectingMessages: () => {},
+        onSelectMessage: () => {},
+        bulkSelectMessages: () => {},
+        fullPage: false,
+        afterReactionAdded: () => {},
+      });
+    },
+
+    async test(assert) {
+      assert.equal(
+        query(
+          ".chat-message .chat-message-sender-data .username"
+        ).innerText.trim(),
+        I18n.t("chat.user_deleted")
+      );
+      assert.ok(
+        exists(".chat-message .chat-emoji-avatar .emoji[title='wastebasket']")
+      );
+    },
+  });
+});

--- a/test/javascripts/components/chat-message-test.js
+++ b/test/javascripts/components/chat-message-test.js
@@ -30,7 +30,6 @@ discourseModule("Discourse Chat | Component | chat-message", function (hooks) {
       fullPage=fullPage
       afterReactionAdded=reStickScrollIfNeeded
     }}`;
-  let emojiReactionStore;
 
   componentTest("Message with deleted user", {
     template,


### PR DESCRIPTION
1. If a user no longer exists in the DB, do not completely error all of chat.
2. Make sure that we don't update `last_read_message_id` to a message that has already been read

![Screen Shot 2022-03-16 at 11 34 45 AM](https://user-images.githubusercontent.com/16214023/158640832-ec69e834-b94f-4300-8f5b-e82dfb7c8f93.png)
