### PR TITLE
FIX: Use similar styles for chat-emoji-avatar as chat-user-avatar

### DIFF
--- a/assets/stylesheets/common/chat-message.scss
+++ b/assets/stylesheets/common/chat-message.scss
@@ -260,6 +260,12 @@
       cursor: pointer;
     }
   }
+
+  .chat-user-avatar .chat-user-avatar-container .avatar,
+  .chat-emoji-avatar .chat-emoji-avatar-container {
+    width: 28px;
+    height: 28px;
+  }
 }
 
 .chat-message-container.highlighted .chat-message {

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -451,9 +451,13 @@ body.composer-open .topic-chat-float-container {
 
 .chat-emoji-avatar {
   width: var(--message-left-width);
-  display: flex;
   align-items: center;
-  justify-content: center;
+
+  img {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 .chat-user-avatar {
@@ -484,11 +488,6 @@ body.composer-open .topic-chat-float-container {
 
     .avatar {
       padding: 1px;
-
-      .chat-message & {
-        width: 28px;
-        height: 28px;
-      }
 
       .chat-message.is-reply .tc-reply-display & {
         width: 20px;


### PR DESCRIPTION
Before:

<img width="154" alt="Screenshot 2022-03-17 at 11 14 07 AM" src="https://user-images.githubusercontent.com/1555215/158729782-aca3e95d-3328-4dbf-8dd3-5a6dd845199c.png">

After:
<img width="130" alt="Screenshot 2022-03-17 at 11 15 40 AM" src="https://user-images.githubusercontent.com/1555215/158729791-a0c383e3-815a-43a1-b201-87ff68358f10.png">

