### PR TITLE
FEATURE: Deleting chat channels

### DIFF
--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -262,6 +262,31 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
     render json: success_json
   end
 
+  def delete
+    params.require(:chat_channel_id)
+    params.require(:channel_name_confirmation)
+
+    chat_channel = ChatChannel.find_by(id: params[:chat_channel_id])
+    raise Discourse::NotFound if chat_channel.blank?
+
+    guardian.ensure_can_delete_chat_channel!
+
+    if chat_channel.name.downcase != params[:channel_name_confirmation].downcase
+      raise Discourse::InvalidParameters
+    end
+
+    chat_channel.trash!(current_user)
+    StaffActionLogger.new(current_user).log_custom(
+      "chat_channel_delete",
+      {
+        chat_channel_id: chat_channel.id,
+        chat_channel_name: chat_channel.name
+      }
+    )
+    Jobs.enqueue(:chat_channel_delete, { chat_channel_id: chat_channel.id })
+    render json: success_json
+  end
+
   private
 
   def render_channel_for_chatable(channel)

--- a/app/jobs/regular/chat_channel_delete.rb
+++ b/app/jobs/regular/chat_channel_delete.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Jobs
+  class ChatChannelDelete < ::Jobs::Base
+    def execute(args = {})
+      chat_channel = ::ChatChannel.with_deleted.find_by(id: args[:chat_channel_id])
+
+      # this should not really happen, but better to do this than throw an error
+      if chat_channel.blank?
+        Rails.logger.warn("Chat channel #{args[:chat_channel_id]} could not be found, aborting delete job.")
+        return
+      end
+
+      DistributedMutex.synchronize(
+        "delete_chat_channel_#{chat_channel.id}",
+        validity: 20.minutes
+      ) do
+        Rails.logger.debug("Deleting webhooks and events for channel #{chat_channel.id}")
+        ChatMessage.transaction do
+          webhooks = IncomingChatWebhook.where(chat_channel: chat_channel)
+          ChatWebhookEvent.where(incoming_chat_webhook_id: webhooks.pluck(:id)).delete_all
+          webhooks.delete_all
+        end
+
+        Rails.logger.debug("Deleting drafts and memberships for channel #{chat_channel.id}")
+        ChatDraft.where(chat_channel: chat_channel).delete_all
+        UserChatChannelMembership.where(chat_channel: chat_channel).delete_all
+
+        Rails.logger.debug("Deleting chat messages, mentions, revisions, and uploads for channel #{chat_channel.id}")
+        ChatMessage.transaction do
+          chat_messages = ChatMessage.where(chat_channel: chat_channel)
+          ChatMention.where(chat_message_id: chat_messages.pluck(:id)).delete_all
+          ChatMessageRevision.where(chat_message_id: chat_messages.pluck(:id)).delete_all
+
+          # if the uploads are not used anywhere else they will be deleted
+          # by the CleanUpUploads job in core
+          ChatUpload.where(chat_message_id: chat_messages.pluck(:id)).delete_all
+
+          # only the messages and the channel are Trashable, everything else gets
+          # permanently destroyed
+          chat_messages.update_all(
+            deleted_by_id: chat_channel.deleted_by_id, deleted_at: Time.zone.now
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/regular/chat_channel_delete.rb
+++ b/app/jobs/regular/chat_channel_delete.rb
@@ -29,12 +29,14 @@ module Jobs
         Rails.logger.debug("Deleting chat messages, mentions, revisions, and uploads for channel #{chat_channel.id}")
         ChatMessage.transaction do
           chat_messages = ChatMessage.where(chat_channel: chat_channel)
-          ChatMention.where(chat_message_id: chat_messages.select(:id)).delete_all
-          ChatMessageRevision.where(chat_message_id: chat_messages.select(:id)).delete_all
+          message_ids = chat_messages.select(:id)
+          ChatMention.where(chat_message_id: message_ids).delete_all
+          ChatMessageRevision.where(chat_message_id: message_ids).delete_all
+          ChatMessageReaction.where(chat_message_id: message_ids).delete_all
 
           # if the uploads are not used anywhere else they will be deleted
           # by the CleanUpUploads job in core
-          ChatUpload.where(chat_message_id: chat_messages.select(:id)).delete_all
+          ChatUpload.where(chat_message_id: message_ids).delete_all
 
           # only the messages and the channel are Trashable, everything else gets
           # permanently destroyed

--- a/app/jobs/regular/chat_channel_delete.rb
+++ b/app/jobs/regular/chat_channel_delete.rb
@@ -13,7 +13,7 @@ module Jobs
 
       DistributedMutex.synchronize(
         "delete_chat_channel_#{chat_channel.id}",
-        validity: 20.minutes
+        validity: 1.minute
       ) do
         Rails.logger.debug("Deleting webhooks and events for channel #{chat_channel.id}")
         ChatMessage.transaction do

--- a/app/jobs/regular/chat_channel_delete.rb
+++ b/app/jobs/regular/chat_channel_delete.rb
@@ -18,7 +18,7 @@ module Jobs
         Rails.logger.debug("Deleting webhooks and events for channel #{chat_channel.id}")
         ChatMessage.transaction do
           webhooks = IncomingChatWebhook.where(chat_channel: chat_channel)
-          ChatWebhookEvent.where(incoming_chat_webhook_id: webhooks.pluck(:id)).delete_all
+          ChatWebhookEvent.where(incoming_chat_webhook_id: webhooks.select(:id)).delete_all
           webhooks.delete_all
         end
 
@@ -29,12 +29,12 @@ module Jobs
         Rails.logger.debug("Deleting chat messages, mentions, revisions, and uploads for channel #{chat_channel.id}")
         ChatMessage.transaction do
           chat_messages = ChatMessage.where(chat_channel: chat_channel)
-          ChatMention.where(chat_message_id: chat_messages.pluck(:id)).delete_all
-          ChatMessageRevision.where(chat_message_id: chat_messages.pluck(:id)).delete_all
+          ChatMention.where(chat_message_id: chat_messages.select(:id)).delete_all
+          ChatMessageRevision.where(chat_message_id: chat_messages.select(:id)).delete_all
 
           # if the uploads are not used anywhere else they will be deleted
           # by the CleanUpUploads job in core
-          ChatUpload.where(chat_message_id: chat_messages.pluck(:id)).delete_all
+          ChatUpload.where(chat_message_id: chat_messages.select(:id)).delete_all
 
           # only the messages and the channel are Trashable, everything else gets
           # permanently destroyed

--- a/app/jobs/regular/chat_channel_delete.rb
+++ b/app/jobs/regular/chat_channel_delete.rb
@@ -11,10 +11,7 @@ module Jobs
         return
       end
 
-      DistributedMutex.synchronize(
-        "delete_chat_channel_#{chat_channel.id}",
-        validity: 1.minute
-      ) do
+      DistributedMutex.synchronize("delete_chat_channel_#{chat_channel.id}") do
         Rails.logger.debug("Deleting webhooks and events for channel #{chat_channel.id}")
         ChatMessage.transaction do
           webhooks = IncomingChatWebhook.where(chat_channel: chat_channel)

--- a/assets/javascripts/discourse/components/chat-channel-archive-modal-inner.js
+++ b/assets/javascripts/discourse/components/chat-channel-archive-modal-inner.js
@@ -13,6 +13,7 @@ import {
   EXISTING_TOPIC_SELECTION,
   NEW_TOPIC_SELECTION,
 } from "discourse/plugins/discourse-chat/discourse/components/chat-to-topic-selector";
+import { CHANNEL_STATUSES } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 
 export default Component.extend({
   chat: service(),
@@ -43,9 +44,10 @@ export default Component.extend({
           text: I18n.t("chat.channel_archive.process_started"),
           messageClass: "success",
         });
+        this.chatChannel.set("status", CHANNEL_STATUSES.archived);
         later(() => {
           if (!isTesting()) {
-            window.location.reload();
+            this.closeModal();
           }
         }, 3000);
       })

--- a/assets/javascripts/discourse/components/chat-channel-delete-modal-inner.js
+++ b/assets/javascripts/discourse/components/chat-channel-delete-modal-inner.js
@@ -43,9 +43,10 @@ export default Component.extend({
           text: I18n.t("chat.channel_delete.process_started"),
           messageClass: "success",
         });
+        this.appEvents.trigger("chat-channel:deleted", this.chatChannel);
         later(() => {
           if (!isTesting()) {
-            window.location.reload();
+            this.closeModal();
           }
         }, 3000);
       })

--- a/assets/javascripts/discourse/components/chat-channel-delete-modal-inner.js
+++ b/assets/javascripts/discourse/components/chat-channel-delete-modal-inner.js
@@ -14,10 +14,12 @@ export default Component.extend({
   tagName: "",
   chatChannel: null,
   channelNameConfirmation: null,
+  deleting: false,
+  confirmed: false,
 
-  @discourseComputed("deleting", "channelNameConfirmation")
-  buttonDisabled(deleting, channelNameConfirmation) {
-    if (deleting) {
+  @discourseComputed("deleting", "channelNameConfirmation", "confirmed")
+  buttonDisabled(deleting, channelNameConfirmation, confirmed) {
+    if (deleting || confirmed) {
       return true;
     }
 
@@ -39,6 +41,7 @@ export default Component.extend({
       data: { channel_name_confirmation: this.channelNameConfirmation },
     })
       .then(() => {
+        this.set("confirmed", true);
         this.appEvents.trigger("modal-body:flash", {
           text: I18n.t("chat.channel_delete.process_started"),
           messageClass: "success",

--- a/assets/javascripts/discourse/components/chat-channel-delete-modal-inner.js
+++ b/assets/javascripts/discourse/components/chat-channel-delete-modal-inner.js
@@ -1,0 +1,58 @@
+import Component from "@ember/component";
+import { isTesting } from "discourse-common/config/environment";
+import { later } from "@ember/runloop";
+import { isEmpty } from "@ember/utils";
+import { CHANNEL_STATUSES } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
+import I18n from "I18n";
+import discourseComputed from "discourse-common/utils/decorators";
+import { action } from "@ember/object";
+import { ajax } from "discourse/lib/ajax";
+import { inject as service } from "@ember/service";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+
+export default Component.extend({
+  chat: service(),
+  tagName: "",
+  chatChannel: null,
+  channelNameConfirmation: null,
+
+  @discourseComputed("deleting", "channelNameConfirmation")
+  buttonDisabled(deleting, channelNameConfirmation) {
+    if (deleting) {
+      return true;
+    }
+
+    if (
+      isEmpty(channelNameConfirmation) ||
+      channelNameConfirmation.toLowerCase() !== this.chatChannel.title.toLowerCase()
+    ) {
+      return true;
+    }
+    return false;
+  },
+
+  @action
+  deleteChannel() {
+    this.set("deleting", true);
+    return ajax(
+      `/chat/chat_channels/${this.chatChannel.id}.json`,
+      {
+        method: "DELETE",
+        data: { channel_name_confirmation: this.channelNameConfirmation },
+      }
+    )
+      .then(() => {
+        this.appEvents.trigger("modal-body:flash", {
+          text: I18n.t("chat.channel_delete.process_started"),
+          messageClass: "success",
+        });
+        later(() => {
+          if (!isTesting()) {
+            window.location.reload();
+          }
+        }, 3000);
+      })
+      .catch(popupAjaxError)
+      .finally(() => this.set("deleting", false));
+  },
+});

--- a/assets/javascripts/discourse/components/chat-channel-delete-modal-inner.js
+++ b/assets/javascripts/discourse/components/chat-channel-delete-modal-inner.js
@@ -2,7 +2,6 @@ import Component from "@ember/component";
 import { isTesting } from "discourse-common/config/environment";
 import { later } from "@ember/runloop";
 import { isEmpty } from "@ember/utils";
-import { CHANNEL_STATUSES } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 import I18n from "I18n";
 import discourseComputed from "discourse-common/utils/decorators";
 import { action } from "@ember/object";
@@ -24,7 +23,8 @@ export default Component.extend({
 
     if (
       isEmpty(channelNameConfirmation) ||
-      channelNameConfirmation.toLowerCase() !== this.chatChannel.title.toLowerCase()
+      channelNameConfirmation.toLowerCase() !==
+        this.chatChannel.title.toLowerCase()
     ) {
       return true;
     }
@@ -34,13 +34,10 @@ export default Component.extend({
   @action
   deleteChannel() {
     this.set("deleting", true);
-    return ajax(
-      `/chat/chat_channels/${this.chatChannel.id}.json`,
-      {
-        method: "DELETE",
-        data: { channel_name_confirmation: this.channelNameConfirmation },
-      }
-    )
+    return ajax(`/chat/chat_channels/${this.chatChannel.id}.json`, {
+      method: "DELETE",
+      data: { channel_name_confirmation: this.channelNameConfirmation },
+    })
       .then(() => {
         this.appEvents.trigger("modal-body:flash", {
           text: I18n.t("chat.channel_delete.process_started"),

--- a/assets/javascripts/discourse/components/chat-channel-settings-btn.js
+++ b/assets/javascripts/discourse/components/chat-channel-settings-btn.js
@@ -26,6 +26,12 @@ export default Component.extend({
       });
     }
 
+    options.push({
+      id: "deleteChannel",
+      name: I18n.t("chat.channel_settings.delete_channel"),
+      icon: "trash-alt",
+    });
+
     if (this.channel.isOpen) {
       options.push({
         id: "showToggleOpenModal",
@@ -52,6 +58,10 @@ export default Component.extend({
       throw new Error(`The action ${id} is not allowed`);
     }
     this[id]();
+  },
+
+  deleteChannel() {
+    showModal("chat-channel-delete-modal").set("chatChannel", this.channel);
   },
 
   archiveChannel() {

--- a/assets/javascripts/discourse/controllers/chat-browse.js
+++ b/assets/javascripts/discourse/controllers/chat-browse.js
@@ -6,6 +6,25 @@ export default Controller.extend({
   creatingDm: false,
   router: service(),
 
+  init() {
+    this._super(...arguments);
+    this.appEvents.on("chat-channel:deleted", (chatChannel) => {
+      if (chatChannel.isCategoryChannel) {
+        this.set(
+          "model.categoryChannels",
+          this.model.categoryChannels.filter(
+            (chan) => chan.id !== chatChannel.id
+          )
+        );
+      } else {
+        this.set(
+          "model.topicChannels",
+          this.model.topicChannels.filter((chan) => chan.id !== chatChannel.id)
+        );
+      }
+    });
+  },
+
   @discourseComputed("model.categoryChannels", "model.topicChannels")
   noChannelsAvailable(categoryChannels, topicChannels) {
     return !categoryChannels.length && !topicChannels.length;

--- a/assets/javascripts/discourse/controllers/chat-channel-delete-modal.js
+++ b/assets/javascripts/discourse/controllers/chat-channel-delete-modal.js
@@ -1,0 +1,6 @@
+import Controller from "@ember/controller";
+import ModalFunctionality from "discourse/mixins/modal-functionality";
+
+export default Controller.extend(ModalFunctionality, {
+  chatChannel: null,
+});

--- a/assets/javascripts/discourse/services/chat-emoji-reaction-store.js
+++ b/assets/javascripts/discourse/services/chat-emoji-reaction-store.js
@@ -28,13 +28,6 @@ export default Service.extend({
     this.store.setObject({ key: EMOJI_SELECTED_DIVERSITY, value: value || 1 });
   },
 
-  get reactions() {
-    if (!this.siteSettings.default_emoji_reactions) {
-      return [];
-    }
-    return this.siteSettings.default_emoji_reactions.split("|").filter(Boolean);
-  },
-
   get favorites() {
     if (this.store.getObject(EMOJI_USAGE).length < 1) {
       if (!this.siteSettings.default_emoji_reactions) {

--- a/assets/javascripts/discourse/templates/components/chat-channel-delete-modal-inner.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-delete-modal-inner.hbs
@@ -1,0 +1,28 @@
+{{#d-modal-body title="chat.channel_delete.title"}}
+  <div id="chat-channel-delete-modal-inner" class="chat-channel-delete-modal-inner">
+    <p>{{html-safe (i18n "chat.channel_delete.instructions" name=chatChannel.title)}}</p>
+  </div>
+
+  {{text-field
+    value=channelNameConfirmation
+    id="channel-delete-confirm-name"
+    placeholderKey="chat.channel_delete.confirm_channel_name"
+    autocorrect="off"
+    autocapitalize="off"
+  }}
+{{/d-modal-body}}
+
+<div class="modal-footer">
+  {{d-button
+    disabled=buttonDisabled
+    class="btn-primary"
+    action=(action "deleteChannel")
+    label="chat.channel_delete.confirm"
+    id="chat-confirm-delete-channel"}}
+
+  {{d-button
+    label="cancel"
+    class="btn-flat"
+    action=(route-action "closeModal")
+  }}
+</div>

--- a/assets/javascripts/discourse/templates/components/chat-channel-delete-modal-inner.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-delete-modal-inner.hbs
@@ -15,7 +15,7 @@
 <div class="modal-footer">
   {{d-button
     disabled=buttonDisabled
-    class="btn-primary"
+    class="btn-danger"
     action=(action "deleteChannel")
     label="chat.channel_delete.confirm"
     id="chat-confirm-delete-channel"}}

--- a/assets/javascripts/discourse/templates/modal/chat-channel-delete-modal.hbs
+++ b/assets/javascripts/discourse/templates/modal/chat-channel-delete-modal.hbs
@@ -1,0 +1,1 @@
+{{chat-channel-delete-modal-inner chatChannel=chatChannel closeModal=(action "closeModal")}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -37,11 +37,11 @@ en:
         instructions: "Closing the channel prevents non-staff users from sending new messages or editing existing messages. Are you sure you want to close this channel?"
       channel_delete:
         title: "Delete Channel"
-        instructions: "<p>Deletes the <strong>%{name}</strong> channel and chat history. All messages and related data, such as reactions and uploads, will be permanently deleted. If you want to preserve the channel history and decomission it, you may want to Archive the channel instead.</p>
+        instructions: "<p>Deletes the <strong>%{name}</strong> channel and chat history. All messages and related data, such as reactions and uploads, will be permanently deleted. If you want to preserve the channel history and decomission it, you may want to archive the channel instead.</p>
         <p>Are you sure you want to <strong>permanently delete</strong> the channel? To confirm, type the name of the channel in the box below.</p>"
         confirm: "I understand the consequences, delete the channel"
         confirm_channel_name: "Enter channel name"
-        process_started: "Deleting process has started. This page will be reloaded shortly, you will no longer see the deleted channel anywhere."
+        process_started: "The process to delete the channel has started. This page will be reloaded shortly, you will no longer see the deleted channel anywhere."
       channel_list_popup:
         browse: "Browse channels"
         create: "Create a channel"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -27,7 +27,7 @@ en:
       channel_archive:
         title: "Archive Channel"
         instructions: "<p>Archiving a channel puts it into read-only mode and moves all messages from the channel into a new or existing topic. No new messages can be sent, and no existing messages can be edited or deleted.</p><p>Are you sure you want to archive the <strong>#%{channelTitle}</strong> channel?</p>"
-        process_started: "Archiving process has started. This page will be reloaded shortly, and you will receive a personal message when the archive process is complete."
+        process_started: "Archiving process has started. This modal will close shortly, and you will receive a personal message when the archive process is complete."
         retry: "Retry"
       channel_open:
         title: "Open Channel"
@@ -41,7 +41,7 @@ en:
         <p>Are you sure you want to <strong>permanently delete</strong> the channel? To confirm, type the name of the channel in the box below.</p>"
         confirm: "I understand the consequences, delete the channel"
         confirm_channel_name: "Enter channel name"
-        process_started: "The process to delete the channel has started. This page will be reloaded shortly, you will no longer see the deleted channel anywhere."
+        process_started: "The process to delete the channel has started. This modal will close shortly, you will no longer see the deleted channel anywhere."
       channel_list_popup:
         browse: "Browse channels"
         create: "Create a channel"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5,6 +5,7 @@ en:
         staff_actions:
           actions:
             chat_channel_status_change: "Chat channel status changed"
+            chat_channel_delete: "Chat channel deleted"
     chat:
       dates:
         time_tiny: "h:mm"
@@ -19,10 +20,10 @@ en:
       leave: "Leave channel"
       channel_settings:
         title: "Channel settings"
-        close_channel: "Close Channel"
-        open_channel: "Open Channel"
-        archive_channel: "Archive Channel"
-        delete_channel: "Delete Channel"
+        close_channel: "Close Channel..."
+        open_channel: "Open Channel..."
+        archive_channel: "Archive Channel..."
+        delete_channel: "Delete Channel..."
       channel_archive:
         title: "Archive Channel"
         instructions: "<p>Archiving a channel puts it into read-only mode and moves all messages from the channel into a new or existing topic. No new messages can be sent, and no existing messages can be edited or deleted.</p><p>Are you sure you want to archive the <strong>#%{channelTitle}</strong> channel?</p>"
@@ -34,6 +35,13 @@ en:
       channel_close:
         title: "Close Channel"
         instructions: "Closing the channel prevents non-staff users from sending new messages or editing existing messages. Are you sure you want to close this channel?"
+      channel_delete:
+        title: "Delete Channel"
+        instructions: "<p>Deletes the <strong>%{name}</strong> channel and chat history. All messages and related data, such as reactions and uploads, will be permanently deleted. If you want to preserve the channel history and decomission it, you may want to Archive the channel instead.</p>
+        <p>Are you sure you want to <strong>permanently delete</strong> the channel? To confirm, type the name of the channel in the box below.</p>"
+        confirm: "I understand the consequences, delete the channel"
+        confirm_channel_name: "Enter channel name"
+        process_started: "Deleting process has started. This page will be reloaded shortly, you will no longer see the deleted channel anywhere."
       channel_list_popup:
         browse: "Browse channels"
         create: "Create a channel"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -38,6 +38,7 @@ en:
       auto_silence_from_flags: "Chat message flagged with score high enough to silence user."
       channel_cannot_be_archived: "The channel cannot be archived at this time, it must be either closed or open to archive."
       duplicate_message: "You posted an identical message too recently."
+      delete_channel_failed: "Delete channel failed, please try again."
     reviewables:
       actions:
         agree:

--- a/lib/guardian_extensions.rb
+++ b/lib/guardian_extensions.rb
@@ -28,6 +28,10 @@ module DiscourseChat::GuardianExtensions
     is_staff?
   end
 
+  def can_delete_chat_channel?
+    is_staff?
+  end
+
   # Channel status intentionally has no bearing on whether the channel
   # name and description can be edited.
   def can_edit_chat_channel?

--- a/plugin.rb
+++ b/plugin.rb
@@ -383,7 +383,7 @@ after_initialize do
     put '/chat_channels/:chat_channel_id/archive' => 'chat_channels#archive'
     put '/chat_channels/:chat_channel_id/retry_archive' => 'chat_channels#retry_archive'
     put '/chat_channels/:chat_channel_id/change_status' => 'chat_channels#change_status'
-    delete '/chat_channels/:chat_channel_id' => 'chat_channels#delete'
+    delete '/chat_channels/:chat_channel_id' => 'chat_channels#destroy'
 
     # chat_controller routes
     get '/' => 'chat#respond'

--- a/plugin.rb
+++ b/plugin.rb
@@ -107,6 +107,7 @@ after_initialize do
   load File.expand_path('../lib/post_notification_handler.rb', __FILE__)
   load File.expand_path('../app/jobs/regular/process_chat_message.rb', __FILE__)
   load File.expand_path('../app/jobs/regular/chat_channel_archive.rb', __FILE__)
+  load File.expand_path('../app/jobs/regular/chat_channel_delete.rb', __FILE__)
   load File.expand_path('../app/jobs/regular/create_chat_mention_notifications.rb', __FILE__)
   load File.expand_path('../app/jobs/regular/notify_users_watching_chat.rb', __FILE__)
   load File.expand_path('../app/jobs/scheduled/delete_old_chat_messages.rb', __FILE__)
@@ -381,8 +382,8 @@ after_initialize do
     get '/chat_channels/:chat_channel_id' => 'chat_channels#show'
     put '/chat_channels/:chat_channel_id/archive' => 'chat_channels#archive'
     put '/chat_channels/:chat_channel_id/retry_archive' => 'chat_channels#retry_archive'
-
     put '/chat_channels/:chat_channel_id/change_status' => 'chat_channels#change_status'
+    delete '/chat_channels/:chat_channel_id' => 'chat_channels#delete'
 
     # chat_controller routes
     get '/' => 'chat#respond'

--- a/spec/jobs/chat_channel_delete_spec.rb
+++ b/spec/jobs/chat_channel_delete_spec.rb
@@ -51,14 +51,24 @@ describe Jobs::ChatChannelDelete do
   end
 
   it "deletes all of the messages and related records completely" do
-    described_class.new.execute(chat_channel_id: chat_channel.id)
-    expect(IncomingChatWebhook.where(chat_channel_id: chat_channel.id).count).to eq(0)
-    expect(ChatWebhookEvent.where(incoming_chat_webhook_id: @incoming_chat_webhook_id).count).to eq(0)
-    expect(ChatDraft.where(chat_channel: chat_channel).count).to eq(0)
-    expect(UserChatChannelMembership.where(chat_channel: chat_channel).count).to eq(0)
-    expect(ChatMessageRevision.where(chat_message_id: @message_ids).count).to eq(0)
-    expect(ChatMention.where(chat_message_id: @message_ids).count).to eq(0)
-    expect(ChatUpload.where(chat_message_id: @message_ids).count).to eq(0)
-    expect(ChatMessage.where(id: @message_ids).count).to eq(0)
+    expect { described_class.new.execute(chat_channel_id: chat_channel.id) }.to change {
+      IncomingChatWebhook.where(chat_channel_id: chat_channel.id).count
+    }.by(-1).and change {
+      ChatWebhookEvent.where(incoming_chat_webhook_id: @incoming_chat_webhook_id).count
+    }.by(-1).and change {
+      ChatDraft.where(chat_channel: chat_channel).count
+    }.by(-1).and change {
+      UserChatChannelMembership.where(chat_channel: chat_channel).count
+    }.by(-3).and change {
+      ChatMessageRevision.where(chat_message_id: @message_ids).count
+    }.by(-1).and change {
+      ChatMention.where(chat_message_id: @message_ids).count
+    }.by(-1).and change {
+      ChatUpload.where(chat_message_id: @message_ids).count
+    }.by(-10).and change {
+      ChatMessage.where(id: @message_ids).count
+    }.by(-20).and change {
+      ChatMessageReaction.where(chat_message_id: @message_ids).count
+    }.by(-10)
   end
 end

--- a/spec/jobs/chat_channel_delete_spec.rb
+++ b/spec/jobs/chat_channel_delete_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 describe Jobs::ChatChannelDelete do
   fab!(:chat_channel) { Fabricate(:chat_channel) }
   fab!(:user1) { Fabricate(:user) }

--- a/spec/jobs/chat_channel_delete_spec.rb
+++ b/spec/jobs/chat_channel_delete_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Jobs::ChatChannelDelete do
+  fab!(:chat_channel) { Fabricate(:chat_channel) }
+  fab!(:user1) { Fabricate(:user) }
+  fab!(:user2) { Fabricate(:user) }
+  fab!(:user3) { Fabricate(:user) }
+  let(:users) { [user1, user2, user3] }
+
+  before do
+    messages = []
+    20.times do
+      messages << Fabricate(:chat_message, chat_channel: chat_channel, user: users.sample)
+    end
+    @message_ids = messages.map(&:id)
+
+    10.times do
+      ChatMessageReaction.create(chat_message: messages.sample, user: users.sample)
+    end
+
+    10.times do
+      ChatUpload.create(upload: Fabricate(:upload, user: users.sample), chat_message: messages.sample)
+    end
+
+    ChatMention.create(
+      user: user2,
+      chat_message: messages.sample,
+      notification: Fabricate(:notification)
+    )
+
+    @incoming_chat_webhook_id = Fabricate(:incoming_chat_webhook, chat_channel: chat_channel)
+    ChatWebhookEvent.create(
+      incoming_chat_webhook: @incoming_chat_webhook_id,
+      chat_message: messages.sample
+    )
+
+    revision_message = messages.sample
+    ChatMessageRevision.create(
+      chat_message: revision_message,
+      old_message: "some old message",
+      new_message: revision_message.message
+    )
+
+    ChatDraft.create(chat_channel: chat_channel, user: users.sample, data: "wow some draft")
+
+    Fabricate(:user_chat_channel_membership, chat_channel: chat_channel, user: user1)
+    Fabricate(:user_chat_channel_membership, chat_channel: chat_channel, user: user2)
+    Fabricate(:user_chat_channel_membership, chat_channel: chat_channel, user: user3)
+
+    chat_channel.trash!
+  end
+
+  it "deletes all of the messages and related records completely" do
+    described_class.new.execute(chat_channel_id: chat_channel.id)
+    expect(IncomingChatWebhook.where(chat_channel_id: chat_channel.id).count).to eq(0)
+    expect(ChatWebhookEvent.where(incoming_chat_webhook_id: @incoming_chat_webhook_id).count).to eq(0)
+    expect(ChatDraft.where(chat_channel: chat_channel).count).to eq(0)
+    expect(UserChatChannelMembership.where(chat_channel: chat_channel).count).to eq(0)
+    expect(ChatMessageRevision.where(chat_message_id: @message_ids).count).to eq(0)
+    expect(ChatMention.where(chat_message_id: @message_ids).count).to eq(0)
+    expect(ChatUpload.where(chat_message_id: @message_ids).count).to eq(0)
+    expect(ChatMessage.where(id: @message_ids).count).to eq(0)
+  end
+end 

--- a/spec/jobs/chat_channel_delete_spec.rb
+++ b/spec/jobs/chat_channel_delete_spec.rb
@@ -63,4 +63,4 @@ describe Jobs::ChatChannelDelete do
     expect(ChatUpload.where(chat_message_id: @message_ids).count).to eq(0)
     expect(ChatMessage.where(id: @message_ids).count).to eq(0)
   end
-end 
+end

--- a/spec/requests/chat_channel_controller_spec.rb
+++ b/spec/requests/chat_channel_controller_spec.rb
@@ -499,7 +499,7 @@ RSpec.describe DiscourseChat::ChatChannelsController do
     let(:new_topic_params) { { type: "newTopic", title: "This is a test archive topic", category_id: category.id } }
     let(:existing_topic_params) { { type: "existingTopic", topic_id: Fabricate(:topic).id } }
 
-    it "returns error if user is not admin" do
+    it "returns error if user is not staff" do
       sign_in(user)
       put "/chat/chat_channels/#{channel.id}/archive.json", params: new_topic_params
       expect(response.status).to eq(403)
@@ -574,7 +574,7 @@ RSpec.describe DiscourseChat::ChatChannelsController do
       )
     end
 
-    it "returns error if user is not admin" do
+    it "returns error if user is not staff" do
       sign_in(user)
       put "/chat/chat_channels/#{channel.id}/retry_archive.json"
       expect(response.status).to eq(403)
@@ -621,7 +621,7 @@ RSpec.describe DiscourseChat::ChatChannelsController do
       )
     end
 
-    it "returns error if user is not admin" do
+    it "returns error if user is not staff" do
       sign_in(user)
       put "/chat/chat_channels/#{channel.id}/change_status.json", params: { status: "closed" }
       expect(response.status).to eq(403)
@@ -667,7 +667,7 @@ RSpec.describe DiscourseChat::ChatChannelsController do
       )
     end
 
-    it "returns error if user is not admin" do
+    it "returns error if user is not staff" do
       sign_in(user)
       delete "/chat/chat_channels/#{channel.id}.json", params: { channel_name_confirmation: "ambrose channel" }
       expect(response.status).to eq(403)

--- a/spec/requests/chat_channel_controller_spec.rb
+++ b/spec/requests/chat_channel_controller_spec.rb
@@ -709,7 +709,7 @@ RSpec.describe DiscourseChat::ChatChannelsController do
       sign_in(admin)
       delete "/chat/chat_channels/#{channel.id}.json", params: { channel_name_confirmation: "ambrose channel" }
       expect(response.status).to eq(200)
-      expect(ChatChannel.find_by(id: channel.id)).to eq(nil)
+      expect(channel.reload.trashed?).to eq(true)
       expect(job_enqueued?(job: :chat_channel_delete, args: { chat_channel_id: channel.id })).to eq(true)
       expect(
         UserHistory.exists?(

--- a/test/javascripts/acceptance/archive-channel-test.js
+++ b/test/javascripts/acceptance/archive-channel-test.js
@@ -20,7 +20,7 @@ const baseChatPretenders = (server, helper) => {
   server.post("/chat/:chatChannelId.json", () => {
     return helper.response({ success: "OK" });
   });
-  server.get("/chat/lookup/:message_id.json", () => helper.response(chatView));
+  server.get("/chat/lookup/:messageId.json", () => helper.response(chatView));
   server.post("/uploads/lookup-urls", () => {
     return helper.response([]);
   });

--- a/test/javascripts/acceptance/chat-status-test.js
+++ b/test/javascripts/acceptance/chat-status-test.js
@@ -22,7 +22,7 @@ const baseChatPretenders = (server, helper) => {
   server.post("/chat/:chatChannelId.json", () => {
     return helper.response({ success: "OK" });
   });
-  server.get("/chat/lookup/:message_id.json", () => helper.response(chatView));
+  server.get("/chat/lookup/:messageId.json", () => helper.response(chatView));
   server.post("/uploads/lookup-urls", () => {
     return helper.response([]);
   });

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -123,7 +123,7 @@ const baseChatPretenders = (server, helper) => {
       seen_notification_id: null,
     });
   });
-  server.get("/chat/lookup/:message_id.json", () => helper.response(chatView));
+  server.get("/chat/lookup/:messageId.json", () => helper.response(chatView));
   server.post("/uploads/lookup-urls", () => {
     return helper.response([]);
   });
@@ -214,7 +214,7 @@ acceptance("Discourse Chat - without unread", function (needs) {
     });
 
     server.put(
-      "/chat/:chat_channel_id/react/:message_id.json",
+      "/chat/:chat_channel_id/react/:messageId.json",
       helper.response
     );
 

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -213,10 +213,7 @@ acceptance("Discourse Chat - without unread", function (needs) {
       });
     });
 
-    server.put(
-      "/chat/:chat_channel_id/react/:messageId.json",
-      helper.response
-    );
+    server.put("/chat/:chat_channel_id/react/:messageId.json", helper.response);
 
     server.put("/chat/:chat_channel_id/invite", helper.response);
     server.post("/chat/direct_messages/create.json", () => {

--- a/test/javascripts/acceptance/close-open-channel-test.js
+++ b/test/javascripts/acceptance/close-open-channel-test.js
@@ -19,7 +19,7 @@ const baseChatPretenders = (server, helper) => {
   server.post("/chat/:chatChannelId.json", () => {
     return helper.response({ success: "OK" });
   });
-  server.get("/chat/lookup/:message_id.json", () => helper.response(chatView));
+  server.get("/chat/lookup/:messageId.json", () => helper.response(chatView));
   server.post("/uploads/lookup-urls", () => {
     return helper.response([]);
   });

--- a/test/javascripts/acceptance/delete-channel-test.js
+++ b/test/javascripts/acceptance/delete-channel-test.js
@@ -1,0 +1,113 @@
+import { click, fillIn, visit } from "@ember/test-helpers";
+import {
+  allChannels,
+  chatChannels,
+  chatView,
+} from "discourse/plugins/discourse-chat/chat-fixtures";
+import {
+  acceptance,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+
+const baseChatPretenders = (server, helper) => {
+  server.get("/chat/:chatChannelId/messages.json", () =>
+    helper.response(chatView)
+  );
+  server.post("/chat/:chatChannelId.json", () => {
+    return helper.response({ success: "OK" });
+  });
+  server.get("/chat/lookup/:message_id.json", () => helper.response(chatView));
+  server.post("/uploads/lookup-urls", () => {
+    return helper.response([]);
+  });
+  server.get("/chat/chat_channels/all.json", () => {
+    return helper.response(allChannels());
+  });
+  server.get("/chat/chat_channels.json", () => {
+    return helper.response(chatChannels);
+  });
+};
+
+acceptance("Discourse Chat - Delete channel", function (needs) {
+  let deletePayload = null;
+
+  needs.user({
+    admin: true,
+    moderator: true,
+    username: "tomtom",
+    id: 1,
+    can_chat: true,
+    has_chat_enabled: true,
+  });
+
+  needs.settings({
+    chat_enabled: true,
+  });
+
+  needs.pretender((server, helper) => {
+    baseChatPretenders(server, helper);
+    server.delete(
+      "/chat/chat_channels/:chat_channel_id.json",
+      (fakeRequest) => {
+        deletePayload = fakeRequest.requestBody;
+        return helper.response([]);
+      }
+    );
+  });
+
+  test("it allows staff to delete the chat channel", async function (assert) {
+    await visit("/chat/browse");
+
+    await click(
+      ".chat-channel-settings-row-7 .chat-channel-settings-btn .select-kit-header-wrapper"
+    );
+    await click("li[data-value='deleteChannel']");
+    assert.ok(exists("#chat-channel-delete-modal-inner"));
+    assert.ok(
+      query("#chat-confirm-delete-channel").disabled,
+      "delete confirmation should be disabled until channel name confirmation is filled in"
+    );
+    await fillIn("#channel-delete-confirm-name", "Uncategorized");
+    assert.notOk(query("#chat-confirm-delete-channel").disabled);
+
+    await click("#chat-confirm-delete-channel");
+    assert.strictEqual(
+      deletePayload,
+      "channel_name_confirmation=Uncategorized"
+    );
+
+    assert.notOk(
+      exists(".chat-channel-settings-row-7 .chat-channel-status"),
+      "channel is removed from browse list after deleting"
+    );
+  });
+});
+
+acceptance("Discourse Chat - Delete channel for non-staff", function (needs) {
+  needs.user({
+    admin: false,
+    moderator: false,
+    username: "tomtom",
+    id: 1,
+    can_chat: true,
+    has_chat_enabled: true,
+  });
+
+  needs.settings({
+    chat_enabled: true,
+  });
+
+  needs.pretender((server, helper) => {
+    baseChatPretenders(server, helper);
+  });
+
+  test("it does not allow non-staff to delete chat channels", async function (assert) {
+    await visit("/chat/browse");
+
+    assert.notOk(
+      exists(".chat-channel-settings-row-7 .chat-channel-settings-btn")
+    );
+  });
+});

--- a/test/javascripts/acceptance/delete-channel-test.js
+++ b/test/javascripts/acceptance/delete-channel-test.js
@@ -18,7 +18,7 @@ const baseChatPretenders = (server, helper) => {
   server.post("/chat/:chatChannelId.json", () => {
     return helper.response({ success: "OK" });
   });
-  server.get("/chat/lookup/:message_id.json", () => helper.response(chatView));
+  server.get("/chat/lookup/:messageId.json", () => helper.response(chatView));
   server.post("/uploads/lookup-urls", () => {
     return helper.response([]);
   });


### PR DESCRIPTION
This commit introduces the delete functionality for chat
channels. This will trash the chat channel and its messages,
and permanently delete all related records like chat uploads,
chat reactions, and so on.

![image](https://user-images.githubusercontent.com/920448/158920293-21e8dc6c-dd64-43cd-98fd-31cd375fa285.png)
