### PR TITLE
FIX: Use system user for archive topics and posts

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-channel-archive-status.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-archive-status.hbs
@@ -8,5 +8,5 @@
     </div>
   </div>
 {{else if (and channel.archive_completed currentUser.admin)}}
-  {{html-safe channelArchiveCompletedMessage}}
+  <div class="chat-channel-archive-status">{{html-safe channelArchiveCompletedMessage}}</div>
 {{/if}}

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1295,7 +1295,13 @@ body.has-full-page-chat {
     .chat-channel-title-with-status {
       flex-grow: 1;
       display: flex;
-      align-items: center;
+      flex-direction: column;
+      min-width: 50%;
+    }
+
+    .chat-channel-archive-status {
+      text-align: right;
+      padding-right: 1em;
     }
   }
   .chat-channel-title {

--- a/lib/chat_channel_archive_service.rb
+++ b/lib/chat_channel_archive_service.rb
@@ -96,7 +96,7 @@ class DiscourseChat::ChatChannelArchiveService
     pc = nil
     Post.transaction do
       pc = PostCreator.new(
-        chat_channel_archive.archived_by,
+        Discourse.system_user,
         raw: raw,
 
         # we must skip these because the posts are created in a big transaction,
@@ -126,7 +126,7 @@ class DiscourseChat::ChatChannelArchiveService
       Rails.logger.info("Creating topic for #{chat_channel.name} archive.")
       Topic.transaction do
         topic_creator = TopicCreator.new(
-          chat_channel_archive.archived_by,
+          Discourse.system_user,
           Guardian.new(chat_channel_archive.archived_by),
           {
             title: chat_channel_archive.destination_topic_title,

--- a/spec/lib/chat_channel_archive_service_spec.rb
+++ b/spec/lib/chat_channel_archive_service_spec.rb
@@ -89,7 +89,7 @@ describe DiscourseChat::ChatChannelArchiveService do
         @channel_archive.reload
         expect(@channel_archive.destination_topic.title).to eq("This will be a new topic")
         expect(@channel_archive.destination_topic.category).to eq(category)
-        expect(@channel_archive.destination_topic.user).to eq(user)
+        expect(@channel_archive.destination_topic.user).to eq(Discourse.system_user)
         expect(@channel_archive.destination_topic.tags.map(&:name)).to match_array(["news", "gossip"])
 
         topic = @channel_archive.destination_topic
@@ -97,6 +97,7 @@ describe DiscourseChat::ChatChannelArchiveService do
         topic.posts.where.not(post_number: 1).each do |post|
           expect(post.raw).to include("[chat")
           expect(post.raw).to include("noLink=\"true\"")
+          expect(post.user).to eq(Discourse.system_user)
 
           if post.raw.include?(";#{reaction_message.id};")
             expect(post.raw).to include("reactions=")
@@ -230,6 +231,8 @@ describe DiscourseChat::ChatChannelArchiveService do
 
       it "deletes all the messages, creates posts for batches of messages, and changes the channel to archived" do
         create_messages(50) && start_archive
+        reaction_message = ChatMessage.last
+        ChatMessageReaction.create!(chat_message: reaction_message, user: Fabricate(:user), emoji: "+1")
         stub_const(DiscourseChat::ChatChannelArchiveService, "ARCHIVED_MESSAGES_PER_POST", 5) do
           subject.new(@channel_archive).execute
         end
@@ -245,6 +248,12 @@ describe DiscourseChat::ChatChannelArchiveService do
         expect(topic.posts.count).to eq(13)
         topic.posts.where.not(post_number: [1, 2, 3]).each do |post|
           expect(post.raw).to include("[chat")
+          expect(post.raw).to include("noLink=\"true\"")
+          expect(post.user).to eq(Discourse.system_user)
+
+          if post.raw.include?(";#{reaction_message.id};")
+            expect(post.raw).to include("reactions=")
+          end
         end
         expect(topic.archived).to eq(false)
 


### PR DESCRIPTION
When creating channel archive topics and posts previously
we used the archiving user as the creator of new topics and
posts to store the archive content. This commit changes this
to use the Discourse System user, because it is an automated
action. Also includes a few minor CSS fixes for the archive
status title.