### PR TITLE
FIX: displays unread-indicator only when needed

### DIFF
--- a/assets/javascripts/discourse/components/chat-channel-title.js
+++ b/assets/javascripts/discourse/components/chat-channel-title.js
@@ -9,6 +9,7 @@ export default Component.extend({
   multiDm: gt("users.length", 1),
   onClick: null,
   users: reads("channel.chatable.users.[]"),
+  unreadIndicator: false,
 
   @discourseComputed("users")
   usernames(users) {

--- a/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
@@ -8,7 +8,7 @@
   tabindex="0"
   data-chat-channel-id={{channel.id}}
 >
-  {{chat-channel-title channel=channel}}
+  {{chat-channel-title channel=channel unreadIndicator=true}}
 
   {{#if options.leaveButton}}
     {{chat-channel-leave-btn

--- a/assets/javascripts/discourse/templates/components/chat-channel-selection-row.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-selection-row.hbs
@@ -12,6 +12,6 @@
       {{model.username}}
     </span>
   {{else}}
-    {{chat-channel-title channel=model}}
+    {{chat-channel-title channel=model unreadIndicator=true}}
   {{/if}}
 </div>

--- a/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-title.hbs
@@ -37,5 +37,8 @@
     </span>
     <p class="topic-chat-name">{{replace-emoji channel.title}}</p>
   {{/if}}
-  {{chat-channel-unread-indicator channel=channel}}
+
+  {{#if unreadIndicator}}
+    {{chat-channel-unread-indicator channel=channel}}
+  {{/if}}
 </div>

--- a/test/javascripts/components/chat-channel-title-test.js
+++ b/test/javascripts/components/chat-channel-title-test.js
@@ -10,6 +10,7 @@ import {
 import hbs from "htmlbars-inline-precompile";
 import fabricate from "../helpers/fabricators";
 import { CHATABLE_TYPES } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
+import { set } from "@ember/object";
 
 discourseModule(
   "Discourse Chat | Component | chat-channel-title",
@@ -182,6 +183,34 @@ discourseModule(
           query(".dm-usernames").innerText,
           users.mapBy("username").join(", ")
         );
+      },
+    });
+
+    componentTest("unreadIndicator", {
+      template: hbs`{{chat-channel-title channel=channel unreadIndicator=unreadIndicator}}`,
+
+      beforeEach() {
+        const channel = fabricate("chat-channel", {
+          chatable_type: CHATABLE_TYPES.directMessageChannel,
+        });
+
+        const state = {};
+        state[channel.id] = {
+          unread_count: 1,
+        };
+        set(this.currentUser, "chat_channel_tracking_state", state);
+
+        this.set("channel", channel);
+      },
+
+      async test(assert) {
+        this.set("unreadIndicator", true);
+
+        assert.ok(exists(".chat-channel-unread-indicator"));
+
+        this.set("unreadIndicator", false);
+
+        assert.notOk(exists(".chat-channel-unread-indicator"));
       },
     });
   }

--- a/test/javascripts/components/chat-channel-title-test.js
+++ b/test/javascripts/components/chat-channel-title-test.js
@@ -10,7 +10,6 @@ import {
 import hbs from "htmlbars-inline-precompile";
 import fabricate from "../helpers/fabricators";
 import { CHATABLE_TYPES } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
-import { set } from "@ember/object";
 
 discourseModule(
   "Discourse Chat | Component | chat-channel-title",
@@ -198,7 +197,7 @@ discourseModule(
         state[channel.id] = {
           unread_count: 1,
         };
-        set(this.currentUser, "chat_channel_tracking_state", state);
+        this.currentUser.set("chat_channel_tracking_state", state);
 
         this.set("channel", channel);
       },


### PR DESCRIPTION
https://github.com/discourse/discourse-chat/commit/aed2d84add728edcb49b4719948292ef136fd02c made it appear on places where its interest is very limited due to the fact it becomes instantly read and as a result just flashes the dot.