### PR TITLE
FIX: Incorrectly ignoring sticky scrolling after fetching messages

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1241,7 +1241,6 @@ export default Component.extend({
     this.set("stickyScroll", true);
     this._stickScrollToBottom();
     evt.preventDefault();
-    return false;
   },
 
   @bind

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -258,7 +258,7 @@ export default Component.extend({
           return;
         }
         this.set(loadingMoreKey, false);
-        this.ignoreStickyScrolling = true;
+        this.ignoreStickyScrolling = false;
       });
   },
 
@@ -1241,6 +1241,7 @@ export default Component.extend({
     this.set("stickyScroll", true);
     this._stickScrollToBottom();
     evt.preventDefault();
+    return false;
   },
 
   @bind


### PR DESCRIPTION
`ignoreStickyScrolling` is important when loading messages, but once they're loaded we set it back to `false`. In a previous commit this was accidentally set to `true` instead of `false` in `finally`