### PR TITLE
FIX: Clipboard copy chat quotes breaks on Safari

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1,5 +1,5 @@
 import Component from "@ember/component";
-import { clipboardCopy } from "discourse/lib/utilities";
+import { clipboardCopyAsync } from "discourse/lib/utilities";
 import { getOwner } from "discourse-common/lib/get-owner";
 import discourseComputed, {
   afterRender,
@@ -1110,55 +1110,73 @@ export default Component.extend({
   },
 
   @action
-  quoteMessages() {
-    ajax(getURL(`/chat/${this.chatChannel.id}/quote.json`), {
-      data: { message_ids: this.selectedMessageIds },
-      type: "POST",
-    })
-      .then((response) => {
-        const container = getOwner(this);
-        const composer = container.lookup("controller:composer");
-        const openOpts = {};
-
-        if (this.chatChannel.isCategoryChannel) {
-          openOpts.categoryId = this.chatChannel.chatable_id;
+  async quoteMessages() {
+    const quoteGenerationPromise = async () => {
+      const response = await ajax(
+        getURL(`/chat/${this.chatChannel.id}/quote.json`),
+        {
+          data: { message_ids: this.selectedMessageIds },
+          type: "POST",
         }
+      );
+      return new Blob([response.markdown], {
+        type: "text/plain",
+      });
+    };
 
-        if (this.site.isMobileDevice) {
-          // go to the relevant chatable (e.g. category) and open the
-          // composer to insert text
-          this._goToChatableUrl().then(() => {
-            composer.focusComposer({
-              fallbackToNewTopic: true,
-              insertText: response.markdown,
-              openOpts,
-            });
-          });
-        } else {
-          // copy to clipboard and show message
-          if (this.currentUser.chat_isolated) {
-            this._copyAndShowSuccess(response.markdown);
-          } else {
-            // open the composer and insert text, reply to the current
-            // topic if there is one, use the active draft if there is one
-            const topic = container.lookup("controller:topic");
-            composer.focusComposer({
-              fallbackToNewTopic: true,
-              topic: topic?.model,
-              insertText: response.markdown,
-              openOpts,
-            });
-          }
-        }
-      })
-      .catch(popupAjaxError);
-  },
-
-  _copyAndShowSuccess(markdown) {
-    if (!isTesting()) {
-      clipboardCopy(markdown);
+    // copy the generated quote to the clipboard
+    if (!this.site.isMobileDevice && this.currentUser.chat_isolated) {
+      if (!isTesting()) {
+        return clipboardCopyAsync(quoteGenerationPromise)
+          .then(() => {
+            this._showCopyQuoteSuccess();
+          })
+          .catch(popupAjaxError);
+      } else {
+        // clipboard API throws errors in tests
+        return;
+      }
     }
 
+    let quoteMarkdownBlob, quoteMarkdown;
+    try {
+      quoteMarkdownBlob = await quoteGenerationPromise();
+      quoteMarkdown = await quoteMarkdownBlob.text();
+    } catch (error) {
+      popupAjaxError(error);
+    }
+    const container = getOwner(this);
+    const composer = container.lookup("controller:composer");
+    const openOpts = {};
+
+    if (this.chatChannel.isCategoryChannel) {
+      openOpts.categoryId = this.chatChannel.chatable_id;
+    }
+
+    if (this.site.isMobileDevice) {
+      // go to the relevant chatable (e.g. category) and open the
+      // composer to insert text
+      this._goToChatableUrl().then(() => {
+        composer.focusComposer({
+          fallbackToNewTopic: true,
+          insertText: quoteMarkdown,
+          openOpts,
+        });
+      });
+    } else {
+      // open the composer and insert text, reply to the current
+      // topic if there is one, use the active draft if there is one
+      const topic = container.lookup("controller:topic");
+      composer.focusComposer({
+        fallbackToNewTopic: true,
+        topic: topic?.model,
+        insertText: quoteMarkdown,
+        openOpts,
+      });
+    }
+  },
+
+  _showCopyQuoteSuccess() {
     this.set("showChatQuoteSuccess", true);
 
     schedule("afterRender", () => {

--- a/test/javascripts/acceptance/chat-quoting-test.js
+++ b/test/javascripts/acceptance/chat-quoting-test.js
@@ -197,10 +197,6 @@ acceptance(
         exists("#reply-control.composer-action-createTopic"),
         "the composer does not open"
       );
-      assert.ok(
-        exists(".chat-selection-message"),
-        "the clipboard copy success message shows"
-      );
     });
   }
 );


### PR DESCRIPTION
Safari among the other browsers is doing the correct thing, and
throwing the following error when the user is clicking the
Quote button in chat isolated mode:

> NotAllowedError: the request is not allowed by the user agent or the
  platform in the current context, possibly because the user denied permission.

This is because the clipboard API is supposed to be used in a
short time period to respond to a user-initiated event. Luckily,
there is a way around this, which is to hand a promise off to
a ClipboardItem. This is done via a new clipboardCopyAsync function
created in core.

This commit uses the new function and rewrites other parts of the
chat quote code to work around its usage.

cf. https://github.com/discourse/discourse/pull/16232