### PR TITLE
DEV: Add .discourse-compatibility

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,0 +1,1 @@
+2.9.0.beta2: f05f5629573d48ef91f02f0f00fcb3d5e9a693fd


### PR DESCRIPTION
The commit 6f88f8b41315d683783c116a2c56125aff6b7627 introduces
a new function from core which will not be available in
the current beta version of core.