### PR TITLE
FIX: Do not autofocus chat composer when ? pressed

### DIFF
--- a/assets/javascripts/discourse/components/full-page-chat.js
+++ b/assets/javascripts/discourse/components/full-page-chat.js
@@ -55,31 +55,35 @@ export default Component.extend({
   },
 
   @bind
-  _autoFocusChatComposer(e) {
+  _autoFocusChatComposer(event) {
     if (
-      !e.key ||
-      e.key.length > 1 ||
-      e.metaKey ||
-      e.ctrlKey ||
-      e.code === "Space"
+      !event.key ||
+      // Handles things like Enter, Tab, Shift
+      event.key.length > 1 ||
+      // Don't need to focus if the user is beginning a shortcut.
+      event.metaKey ||
+      event.ctrlKey ||
+      // Space's key comes through as ' ' so it's not covered by event.key
+      event.code === "Space" ||
+      // ? is used for the keyboard shortcut modal
+      event.key === "?"
     ) {
-      return; // Only care about single characters, unlike `Escape`
-    }
-    const target = e.target;
-    if (!target) {
       return;
     }
 
-    if (/^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName)) {
+    if (
+      !event.target ||
+      /^(INPUT|TEXTAREA|SELECT)$/.test(event.target.tagName)
+    ) {
       return;
     }
 
-    e.preventDefault();
-    e.stopPropagation();
+    event.preventDefault();
+    event.stopPropagation();
 
     const composer = document.querySelector(".chat-composer-input");
     if (composer) {
-      this.appEvents.trigger("chat:insert-text", e.key);
+      this.appEvents.trigger("chat:insert-text", event.key);
       composer.focus();
     }
   },

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -1119,11 +1119,23 @@ Widget.triangulate(arg: "test")
     document.activeElement.blur();
     await triggerKeyEvent(document.body, "keydown", 65);
     assert.equal(composer.value, "aa");
+    assert.equal(document.activeElement, composer);
+
+    document.activeElement.blur();
+    await triggerKeyEvent(document.body, "keydown", 191); // 191 is ?
+    assert.notEqual(
+      document.activeElement,
+      composer,
+      "? is a special case and should not focus"
+    );
 
     document.activeElement.blur();
     await triggerKeyEvent(document.body, "keydown", 13); // 13 is `Enter` keycode
-    // Composer is not focused because `Enter` isn't a key that causes focus.
-    assert.notEqual(document.activeElement, composer);
+    assert.notEqual(
+      document.activeElement,
+      composer,
+      "enter is a special case and should not focus"
+    );
   });
 });
 


### PR DESCRIPTION
The ? key is used to show the keyboard shortcuts in the
app, we want this to work rather than autofocusing the chat
composer.