### PR TITLE
FIX: DOM operations should happen after render

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1286,7 +1286,7 @@ export default Component.extend({
       return;
     }
 
-    next(() => {
+    schedule("afterRender", () => {
       document.querySelector(".chat-composer-input")?.focus();
     });
   },


### PR DESCRIPTION
I'm also concerned we have a _focusComposer and focusComposer functions with slightly different implementations, but can't think of a simple fix for now.