### PR TITLE
DEV: Drop chat_message_post_connections

### DIFF
--- a/db/post_migrate/20220321235638_drop_chat_message_post_connections_table.rb
+++ b/db/post_migrate/20220321235638_drop_chat_message_post_connections_table.rb
@@ -3,14 +3,8 @@
 require 'migration/table_dropper'
 
 class DropChatMessagePostConnectionsTable < ActiveRecord::Migration[6.1]
-  DROPPED_TABLES ||= %i{
-    chat_message_post_connections
-  }
-
   def up
-    DROPPED_TABLES.each do |table|
-      Migration::TableDropper.execute_drop(table)
-    end
+    Migration::TableDropper.execute_drop("chat_message_post_connections")
   end
 
   def down

--- a/db/post_migrate/20220321235638_drop_chat_message_post_connections_table.rb
+++ b/db/post_migrate/20220321235638_drop_chat_message_post_connections_table.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'migration/table_dropper'
+
+class DropChatMessagePostConnectionsTable < ActiveRecord::Migration[6.1]
+  DROPPED_TABLES ||= %i{
+    chat_message_post_connections
+  }
+
+  def up
+    DROPPED_TABLES.each do |table|
+      Migration::TableDropper.execute_drop(table)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Since 613ff279c3c396fb84ca2911efe68aeaaa739bc0 we
no longer need this table.