### PR TITLE
FEATURE: Insert link with shortcut in composer

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -1,4 +1,5 @@
 import Component from "@ember/component";
+import showModal from "discourse/lib/show-modal";
 import UppyMediaOptimization from "discourse/lib/uppy-media-optimization-plugin";
 import ComposerUploadUppy from "discourse/mixins/composer-upload-uppy";
 import discourseComputed, {
@@ -167,6 +168,11 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
     );
 
     this.appEvents.on("chat:modify-selection", this, "_modifySelection");
+    this.appEvents.on(
+      "chat:open-insert-link-modal",
+      this,
+      "_openInsertLinkModal"
+    );
   },
 
   _modifySelection(opts = { type: null }) {
@@ -178,6 +184,17 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
     } else if (opts.type === "code") {
       this.applySurround(sel, "`", "`", "code_text");
     }
+  },
+
+  _openInsertLinkModal() {
+    const selected = this.getSelected("", { lineVal: true });
+    const linkText = selected?.value;
+    showModal("insert-hyperlink").setProperties({
+      linkText,
+      toolbarEvent: {
+        addText: (text) => this.addText(selected, text),
+      },
+    });
   },
 
   willDestroyElement() {
@@ -210,6 +227,11 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
     this.appEvents.off("chat:focus-composer", this, "_focusTextArea");
     this.appEvents.off("chat:insert-text", this, "insertText");
     this.appEvents.off("chat:modify-selection", this, "_modifySelection");
+    this.appEvents.off(
+      "chat:open-insert-link-modal",
+      this,
+      "_openInsertLinkModal"
+    );
   },
 
   _insertUpload(_, upload) {
@@ -539,13 +561,6 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
     return {
       target: targetEl,
     };
-  },
-
-  addText(text) {
-    const selected = this.getSelected(null, {
-      lineVal: true,
-    });
-    this._addText(selected, text);
   },
 
   @action

--- a/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
+++ b/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
@@ -101,7 +101,17 @@ export default {
       api.addKeyboardShortcut(
         `${mod}+l`,
         (event) => openInsertLinkModal(event),
-        { global: true }
+        {
+          global: true,
+          help: {
+            category: "chat",
+            name: "chat.keyboard_shortcuts.open_insert_link_modal",
+            definition: {
+              keys1: ["meta", "l"],
+              keysDelimiter: "plus",
+            },
+          },
+        }
       );
     });
   },

--- a/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
+++ b/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
@@ -42,6 +42,15 @@ export default {
       appEvents.trigger("chat:modify-selection", { type });
     };
 
+    const openInsertLinkModal = (event) => {
+      if (!isChatComposer(event.target)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      appEvents.trigger("chat:open-insert-link-modal", { event });
+    };
+
     withPluginApi("0.12.1", (api) => {
       const mac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
       const mod = mac ? "meta" : "ctrl";
@@ -87,6 +96,11 @@ export default {
       api.addKeyboardShortcut(
         `${mod}+e`,
         (event) => modifyComposerSelection(event, "code"),
+        { global: true }
+      );
+      api.addKeyboardShortcut(
+        `${mod}+l`,
+        (event) => openInsertLinkModal(event),
         { global: true }
       );
     });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -310,3 +310,4 @@ en:
         keyboard_shortcuts:
           switch_channel_arrows: "%{shortcut} Switch channel"
           open_quick_channel_selector: "%{shortcut} Open quick channel selector"
+          open_insert_link_modal: "%{shortcut} Insert hyperlink"


### PR DESCRIPTION
This commit adds the ctrl+l shortcut to open the
insert link modal in the chat composer (ctrl+k
was already taken by channel switcher)

![image](https://user-images.githubusercontent.com/920448/159391238-b13a3ed8-b85a-460e-80a4-010f6d84502b.png)

This shortcut only works if the chat composer is
focused.