### PR TITLE
FIX: Error when anon viewing another user when chat is enabled

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -183,8 +183,10 @@ after_initialize do
   end
 
   add_to_serializer(:user_card, :can_chat_user) do
-    SiteSetting.chat_enabled &&
-      scope.user.id != object.id &&
+    return false if !SiteSetting.chat_enabled
+    return false if scope.user.blank?
+
+    scope.user.id != object.id &&
       scope.can_chat?(scope.user) &&
       scope.can_chat?(object)
   end

--- a/test/javascripts/acceptance/user-card-chat-test.js
+++ b/test/javascripts/acceptance/user-card-chat-test.js
@@ -82,7 +82,7 @@ if (!isLegacyEmber()) {
       });
     });
 
-    test("User card has chat button that opens the correct channel", async function (assert) {
+    test("user card has chat button that opens the correct channel", async function (assert) {
       this.chatService.set("sidebarActive", false);
       await visit("/latest");
       this.appEvents.trigger("chat:toggle-open");
@@ -98,4 +98,23 @@ if (!isLegacyEmber()) {
       );
     });
   });
+
+  acceptance(
+    "Discourse Chat - Anon user viewing user card test",
+    function (needs) {
+      needs.settings({
+        chat_enabled: true,
+      });
+
+      test("user card has no chat button", async function (assert) {
+        await visit("/t/internationalization-localization/280");
+        await click('a[data-user-card="charlie"]');
+
+        assert.notOk(
+          exists(".user-card-chat-btn"),
+          "anon user should not be able to chat with anyone via the user card"
+        );
+      });
+    }
+  );
 }


### PR DESCRIPTION
In 7b21a51120888caae9902c67536aaf2d78dd6964 we added a UserCardSerializer
extension for can_chat_user, which is used to show a button to initiate
a chat from the user card. However this is causing errors for anon
users viewing other users when chat is enabled, since scope.user
is nil for anon users.

This commit fixes the issue and adds tests exercising the can_chat_user
extension for the UserCardSerializer