### PR TITLE
FIX: Use chatEventPrefix to handle composer insert-text events

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -57,7 +57,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
 
   // Composer Uppy values
   ready: true,
-  eventPrefix: "chat-composer",
+  composerEventPrefix: "chat-composer",
   canAttachUploads: or(
     "siteSettings.chat_allow_uploads",
     "chatChannel.isDirectMessageChannel"
@@ -156,6 +156,11 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
     }
     this.appEvents.on("chat:focus-composer", this, "_focusTextArea");
     this.appEvents.on("chat:insert-text", this, "insertText");
+    this.appEvents.on(
+      `${this.composerEventPrefix}:insert-text`,
+      this,
+      "insertText"
+    );
 
     if (!this.site.mobileView) {
       this._focusTextArea();
@@ -226,6 +231,11 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
 
     this.appEvents.off("chat:focus-composer", this, "_focusTextArea");
     this.appEvents.off("chat:insert-text", this, "insertText");
+    this.appEvents.off(
+      `${this.composerEventPrefix}:insert-text`,
+      this,
+      "insertText"
+    );
     this.appEvents.off("chat:modify-selection", this, "_modifySelection");
     this.appEvents.off(
       "chat:open-insert-link-modal",


### PR DESCRIPTION
This will allow the composer in chat to handle HTML and other
rich text pasting, which has been broken due to recent core
changes.

The core PR https://github.com/discourse/discourse/pull/16262 must
be merged before this.

Note: I tried to add UI tests here but it seems to be extremely difficult
to consistently fire the `paste` event manually. We are able to in a few
core tests, but it does not seem to work at all for the chat composer --
I tried variations for a couple of hours and I don't think its worth persuing
any further.