### PR TITLE
FIX: Fix missing app event bindings

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -54,6 +54,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
   timer: null,
   value: "",
   composerFocusSelector: ".chat-composer-input",
+  useUploadPlaceholders: false,
 
   // Composer Uppy values
   ready: true,
@@ -167,7 +168,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
     }
 
     this.appEvents.on(
-      `${this.eventPrefix}:upload-success`,
+      `${this.composerEventPrefix}:upload-success`,
       this,
       "_insertUpload"
     );
@@ -224,7 +225,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
     });
 
     this.appEvents.off(
-      `${this.eventPrefix}:upload-success`,
+      `${this.composerEventPrefix}:upload-success`,
       this,
       "_insertUpload"
     );
@@ -762,7 +763,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
 
   @action
   cancelUploading(upload) {
-    this.appEvents.trigger(`${this.eventPrefix}:cancel-upload`, {
+    this.appEvents.trigger(`${this.composerEventPrefix}:cancel-upload`, {
       fileId: upload.id,
     });
     this.onValueChange?.(this.value, this.uploads, this.replyToMsg);


### PR DESCRIPTION
In  https://github.com/discourse/discourse/commit/1341baaebaf9932952cf3fd65448564473188525 in core
I added composerEventPrefix for composer app events,
but I only changed a few of them. Also using the
useUploadPlaceholders: false option to avoid any text
being inserted into the chat composer as result
of uploads, introduced in:

https://github.com/discourse/discourse/pull/16272