### PR TITLE
DEV: Fixing TextareaTextManipulation deprecations

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -274,7 +274,7 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
       if (!event.ctrlKey) {
         // if we are inside a code block just insert newline
         const { pre } = this.getSelected(null, { lineVal: true });
-        if (this._isInside(pre, /(^|\n)```/g)) {
+        if (this.isInside(pre, /(^|\n)```/g)) {
           return;
         }
       }


### PR DESCRIPTION
We are changing to the non-underscore version of
many TextareaTextManipulation methods in core, see
https://github.com/discourse/discourse/pull/16285