### PR TITLE
FIX: minor tweaks

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-message-actions-mobile.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message-actions-mobile.hbs
@@ -1,5 +1,5 @@
 <div class="chat-msgactions-backdrop">
-  <div role="button" class="collapse-area" {{on "click" this.collapseMenu}}></div>
+  <div role="button" class="collapse-area" {{on "touchstart" this.collapseMenu}}></div>
   <div class="chat-msgactions">
     <div class="selected-message-container">
       <div class="selected-message">

--- a/assets/stylesheets/mobile/chat-message.scss
+++ b/assets/stylesheets/mobile/chat-message.scss
@@ -58,13 +58,12 @@
       border-radius: 8px;
 
       .selected-message-reply {
-        @include user-select(text);
-
         &:not(.is-expanded) {
           @include ellipsis;
         }
 
         &.is-expanded {
+          @include user-select(text);
           max-height: 80px;
           overflow-y: scroll;
         }

--- a/assets/stylesheets/mobile/chat-message.scss
+++ b/assets/stylesheets/mobile/chat-message.scss
@@ -7,7 +7,8 @@
 
 .chat-message *,
 .chat-message-separator *,
-.chat-composer-row {
+.chat-composer-row,
+.tc-reply-display {
   @include user-select(none);
 }
 


### PR DESCRIPTION
- prevents selection from long press before expansion
- collapse menu on background touch instead of click, that will make a scroll gesture close the menu
- ensure tc-reply-display will not be selected if present when doing long press