### PR TITLE
DEV: Add date button, use cleaner `applyLocalDates` import

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -434,9 +434,10 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
       treatAsTextarea: true,
 
       onKeyUp: (text, cp) => {
-        const matches = /(?:^|[\s.\?,@\/#!%&*;:\[\]{}=\-_()])(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi.exec(
-          text.substring(0, cp)
-        );
+        const matches =
+          /(?:^|[\s.\?,@\/#!%&*;:\[\]{}=\-_()])(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi.exec(
+            text.substring(0, cp)
+          );
 
         if (matches && matches[1]) {
           return [matches[1]];

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -31,10 +31,10 @@ import { channelStatusName } from "discourse/plugins/discourse-chat/discourse/mo
 const THROTTLE_MS = 150;
 let outsideToolbarClick;
 
-const toolbarButtons = [];
+const toolbarExtraButtons = [];
 
 export function addChatToolbarButton(toolbarButton) {
-  toolbarButtons.push(toolbarButton);
+  toolbarExtraButtons.push(toolbarButton);
 }
 
 export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
@@ -108,22 +108,28 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
     });
     outsideToolbarClick = this.toggleToolbar.bind(this);
 
+    const toolbarBtns = [];
+
     if (this.canAttachUploads) {
-      this.set(
-        "toolbarButtons",
-        [
-          {
-            action: this.uploadClicked,
-            class: "upload-btn",
-            id: this.mobileFileUploaderId,
-            icon: "far-image",
-            title: "chat.upload",
-          },
-        ].concat(toolbarButtons)
-      );
-    } else {
-      this.set("toolbarButtons", toolbarButtons);
+      toolbarBtns.push({
+        action: this.uploadClicked,
+        class: "upload-btn",
+        id: this.mobileFileUploaderId,
+        icon: "far-image",
+        title: "chat.upload",
+      });
     }
+
+    if (this.siteSettings.discourse_local_dates_enabled) {
+      toolbarBtns.push({
+        title: "discourse_local_dates.title",
+        id: "local-dates",
+        class: "chat-local-dates-btn",
+        icon: "calendar-alt",
+        action: this.insertDiscourseLocalDate,
+      });
+    }
+    this.set("toolbarButtons", toolbarBtns.concat(toolbarExtraButtons));
 
     if (this.siteSettings.composer_media_optimization_image_enabled) {
       // TODO:
@@ -360,6 +366,15 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
     this.element.querySelector(`#${this.fileUploadElementId}`).click();
   },
 
+  @action
+  insertDiscourseLocalDate() {
+    showModal("discourse-local-dates-create-modal").setProperties({
+      insertDate: (markup) => {
+        this.addText(this.getSelected(), markup);
+      },
+    });
+  },
+
   _applyUserAutocomplete() {
     if (this.siteSettings.enable_mentions) {
       $(this._textarea).autocomplete({
@@ -419,10 +434,9 @@ export default Component.extend(TextareaTextManipulation, ComposerUploadUppy, {
       treatAsTextarea: true,
 
       onKeyUp: (text, cp) => {
-        const matches =
-          /(?:^|[\s.\?,@\/#!%&*;:\[\]{}=\-_()])(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi.exec(
-            text.substring(0, cp)
-          );
+        const matches = /(?:^|[\s.\?,@\/#!%&*;:\[\]{}=\-_()])(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi.exec(
+          text.substring(0, cp)
+        );
 
         if (matches && matches[1]) {
           return [matches[1]];

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -25,6 +25,7 @@ import getURL, { samePrefix } from "discourse-common/lib/get-url";
 import { spinnerHTML } from "discourse/helpers/loading-spinner";
 import { decorateGithubOneboxBody } from "discourse/initializers/onebox-decorators";
 import highlightSyntax from "discourse/lib/highlight-syntax";
+import { applyLocalDates } from "discourse/lib/local-dates";
 
 const MAX_RECENT_MSGS = 100;
 const STICKY_SCROLL_LENIENCE = 4;
@@ -408,9 +409,9 @@ export default Component.extend({
         }
       });
     }
-    const lastReadId =
-      this.currentUser.chat_channel_tracking_state[this.chatChannel.id]
-        ?.chat_message_id;
+    const lastReadId = this.currentUser.chat_channel_tracking_state[
+      this.chatChannel.id
+    ]?.chat_message_id;
     if (!lastReadId) {
       return;
     }
@@ -1278,16 +1279,10 @@ export default Component.extend({
   },
 
   _pluginsDecorators() {
-    if (this.siteSettings.discourse_local_dates_enabled) {
-      const applyLocalDates = requirejs(
-        "discourse/plugins/discourse-local-dates/initializers/discourse-local-dates"
-      ).applyLocalDates;
-
-      applyLocalDates(
-        this.element.querySelectorAll(".discourse-local-date"),
-        this.siteSettings
-      );
-    }
+    applyLocalDates(
+      this.element.querySelectorAll(".discourse-local-date"),
+      this.siteSettings
+    );
 
     if (this.siteSettings.spoiler_enabled) {
       const applySpoiler = requirejs(

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -409,9 +409,9 @@ export default Component.extend({
         }
       });
     }
-    const lastReadId = this.currentUser.chat_channel_tracking_state[
-      this.chatChannel.id
-    ]?.chat_message_id;
+    const lastReadId =
+      this.currentUser.chat_channel_tracking_state[this.chatChannel.id]
+        ?.chat_message_id;
     if (!lastReadId) {
       return;
     }

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -1499,7 +1499,8 @@ acceptance("Discourse Chat - image uploads", function (needs) {
           short_url: "upload://yoj8pf9DdIeHRRULyw7i57GAYdz.jpeg",
           thumbnail_height: 320,
           thumbnail_width: 690,
-          url: "//testbucket.s3.dualstack.us-east-2.amazonaws.com/original/1X/f1095d89269ff22e1818cf54b73e857261851019.jpeg",
+          url:
+            "//testbucket.s3.dualstack.us-east-2.amazonaws.com/original/1X/f1095d89269ff22e1818cf54b73e857261851019.jpeg",
           width: 1920,
         });
       },
@@ -1548,6 +1549,36 @@ acceptance("Discourse Chat - image uploads", function (needs) {
 
     const image = createFile("avatar.png");
     appEvents.trigger("chat-composer:add-files", image);
+  });
+});
+
+acceptance("Discourse Chat - Insert Date", function (needs) {
+  needs.user({
+    username: "eviltrout",
+    id: 1,
+    can_chat: true,
+    has_chat_enabled: true,
+  });
+  needs.settings({
+    chat_enabled: true,
+    discourse_local_dates_enabled: true,
+  });
+  needs.pretender((server, helper) => {
+    baseChatPretenders(server, helper);
+    chatChannelPretender(server, helper);
+  });
+
+  test("can use local date modal", async function (assert) {
+    await visit("/chat/channel/7/Uncategorized");
+    await click(".open-toolbar-btn");
+    await click(".chat-local-dates-btn");
+
+    assert.ok(exists(".discourse-local-dates-create-modal"));
+    await click(".modal-footer .btn-primary");
+    assert.ok(
+      query(".chat-composer-input").value.startsWith("[date"),
+      "inserts date in composer input"
+    );
   });
 });
 

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -1499,8 +1499,7 @@ acceptance("Discourse Chat - image uploads", function (needs) {
           short_url: "upload://yoj8pf9DdIeHRRULyw7i57GAYdz.jpeg",
           thumbnail_height: 320,
           thumbnail_width: 690,
-          url:
-            "//testbucket.s3.dualstack.us-east-2.amazonaws.com/original/1X/f1095d89269ff22e1818cf54b73e857261851019.jpeg",
+          url: "//testbucket.s3.dualstack.us-east-2.amazonaws.com/original/1X/f1095d89269ff22e1818cf54b73e857261851019.jpeg",
           width: 1920,
         });
       },


### PR DESCRIPTION
Previously the date button was added in `discourse-local-dates`, see https://github.com/discourse/discourse/pull/16342 which removes it from core. 

This PR also 
 - fixes the date modal in chat, it previously was inserting `undefinedundefinedundefined` in the chat composer
 - adds an acceptance test
 - uses the new `applyLocalDates` wrapper from core
