### PR TITLE
FIX: Change copy for the quote button

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -234,7 +234,7 @@ en:
 
       selection:
         cancel: "Cancel"
-        quote_selection: "Quote"
+        quote_selection: "Quote in Topic"
         error: "There was an error moving the chat messages"
         title: "Move Chat to Topic"
         new_topic:


### PR DESCRIPTION
Change to "Quote in Topic" for more clarity about
what this button does in chat.

![image](https://user-images.githubusercontent.com/920448/161653377-4821f0c8-3a36-4172-b5de-90816f46b892.png)
