### PR TITLE
FIX: makes direct_messages an index route

### DIFF
--- a/app/controllers/direct_messages_controller.rb
+++ b/app/controllers/direct_messages_controller.rb
@@ -10,9 +10,10 @@ class DiscourseChat::DirectMessagesController < DiscourseChat::ChatBaseControlle
     render_serialized(chat_channel, ChatChannelSerializer, root: "chat_channel")
   end
 
-  def show
+  def index
     guardian.ensure_can_chat!(current_user)
     users = users_from_usernames(current_user, params)
+
     direct_message_channel = DirectMessageChannel.for_user_ids(users.map(&:id).uniq)
     if direct_message_channel
       chat_channel = ChatChannel.find_by(

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -827,12 +827,6 @@ export default Service.extend({
     return ajax("/chat/direct_messages.json", { data: { usernames } });
   },
 
-  poss(usernames) {
-    return ajax(`/chat/direct_messages/${usernames}.json`).catch(
-      popupAjaxError
-    );
-  },
-
   _saveDraft(channelId, draft) {
     const data = { channel_id: channelId };
     if (draft) {

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -824,7 +824,7 @@ export default Service.extend({
   },
 
   getDmChannelForUsernames(usernames) {
-    return ajax(`/chat/direct_messages/${usernames}.json`);
+    return ajax("/chat/direct_messages.json", { data: { usernames } });
   },
 
   poss(usernames) {

--- a/plugin.rb
+++ b/plugin.rb
@@ -363,7 +363,7 @@ after_initialize do
 
   DiscourseChat::Engine.routes.draw do
     # direct_messages_controller routes
-    get '/direct_messages/:usernames' => 'direct_messages#show'
+    get '/direct_messages' => 'direct_messages#index'
     post '/direct_messages/create' => 'direct_messages#create'
 
     # incoming_webhooks_controller routes

--- a/spec/requests/direct_messages_controller_spec.rb
+++ b/spec/requests/direct_messages_controller_spec.rb
@@ -22,21 +22,21 @@ RSpec.describe DiscourseChat::DirectMessagesController do
     ChatChannel.create!(chatable: direct_messages_channel)
   end
 
-  describe "#show" do
+  describe "#index" do
     context "user is not allowed to chat" do
       before do
         SiteSetting.chat_allowed_groups = nil
       end
 
       it "returns a forbidden error" do
-        get "/chat/direct_messages/#{user1.username}.json"
+        get "/chat/direct_messages.json", params: { usernames: user1.username }
         expect(response.status).to eq(403)
       end
     end
 
     context "channel doesn’t exists" do
       it "returns a not found error" do
-        get "/chat/direct_messages/#{user1.username}.json"
+        get "/chat/direct_messages.json", params: { usernames: user1.username }
         expect(response.status).to eq(404)
       end
     end
@@ -50,7 +50,7 @@ RSpec.describe DiscourseChat::DirectMessagesController do
       }
 
       it "returns the channel" do
-        get "/chat/direct_messages/#{user1.username}.json"
+        get "/chat/direct_messages.json", params: { usernames: user1.username }
         expect(response.status).to eq(200)
         expect(response.parsed_body["chat_channel"]["id"]).to eq(channel.id)
       end

--- a/test/javascripts/acceptance/chat-browse-test.js
+++ b/test/javascripts/acceptance/chat-browse-test.js
@@ -183,7 +183,7 @@ acceptance("Discourse Chat - chat browsing no channels", function (needs) {
         chat_messages: [],
       });
     });
-    server.get("/chat/direct_messages/hawk.json", () => {
+    server.get("/chat/direct_messages.json", () => {
       return helper.response({
         chat_channel: {
           id: 75,

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -235,7 +235,7 @@ acceptance("Discourse Chat - without unread", function (needs) {
     server.post("/chat/chat_channels/:chatChannelId/unfollow", () => {
       return helper.response({ success: "OK" });
     });
-    server.get("/chat/direct_messages/hawk.json", () => {
+    server.get("/chat/direct_messages.json", () => {
       return helper.response({
         chat_channel: {
           id: 75,


### PR DESCRIPTION
It makes more sense to have usernames as a query string than a URL param and it avoids issues with format and dots.