### PR TITLE
DEV: Fix composer upload event and drop target issues

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer-uploads.js
+++ b/assets/javascripts/discourse/components/chat-composer-uploads.js
@@ -13,6 +13,7 @@ export default Component.extend(UppyUploadMixin, {
   type: "chat-composer",
   uploads: null,
   useMultipartUploadsIfAvailable: true,
+  fullPage: false,
 
   init() {
     this._super(...arguments);
@@ -64,15 +65,14 @@ export default Component.extend(UppyUploadMixin, {
   },
 
   _uploadDropTargetOptions() {
-    const chatWidget = document.querySelector(
-      ".topic-chat-container.expanded.visible"
-    );
-    const fullPageChat = document.querySelector(".full-page-chat");
-
-    const targetEl =
-      chatWidget || fullPageChat
-        ? document.querySelector(".chat-enabled")
-        : null;
+    let targetEl;
+    if (this.fullPage) {
+      targetEl = document.querySelector(".full-page-chat");
+    } else {
+      targetEl = document.querySelector(
+        ".topic-chat-container.expanded.visible"
+      );
+    }
 
     if (!targetEl) {
       return this._super();

--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -112,11 +112,6 @@ export default Component.extend(TextareaTextManipulation, {
     this._applyEmojiAutocomplete(this._$textarea);
     this.appEvents.on("chat:focus-composer", this, "_focusTextArea");
     this.appEvents.on("chat:insert-text", this, "insertText");
-    this.appEvents.on(
-      `${this.composerEventPrefix}:insert-text`,
-      this,
-      "insertText"
-    );
 
     if (!this.site.mobileView) {
       this._focusTextArea();
@@ -175,11 +170,6 @@ export default Component.extend(TextareaTextManipulation, {
 
     this.appEvents.off("chat:focus-composer", this, "_focusTextArea");
     this.appEvents.off("chat:insert-text", this, "insertText");
-    this.appEvents.off(
-      `${this.composerEventPrefix}:insert-text`,
-      this,
-      "insertText"
-    );
     this.appEvents.off("chat:modify-selection", this, "_modifySelection");
     this.appEvents.off(
       "chat:open-insert-link-modal",

--- a/assets/javascripts/discourse/templates/components/chat-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer.hbs
@@ -72,6 +72,7 @@
 
 {{#if canAttachUploads}}
   {{chat-composer-uploads
+    fullPage=fullPage
     fileUploadElementId=fileUploadElementId
     onUploadChanged=(action "uploadsChanged")
   }}


### PR DESCRIPTION
This commit fixes an issue where the "Uploading..." placeholder
markdown from the composer was inserted into the chat composer.
This was due to the insert-text app event using composerEventPrefix,
which was not removed when it should have been in the
f0e777d07800dda1a0265bd57768edc4c6d8291a commit.

Also fixes an issue where the drop target was the entire page
for uploads in the floated chat, rather than just the floated
chat drawer.