### PR TITLE
FIX: Default channel setting not working

### DIFF
--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -391,7 +391,8 @@ export default Service.extend({
             publicChannelWithUnread = channel;
           } else if (
             !defaultChannel &&
-            this.siteSettings.chat_default_channel_id === parseInt(channel, 10)
+            parseInt(this.siteSettings.chat_default_channel_id || 0, 10) ===
+              parseInt(channel, 10)
           ) {
             defaultChannel = channel;
           } else if (!publicChannel) {


### PR DESCRIPTION
This commit https://github.com/discourse/discourse-chat/commit/b8c5f7397c15126baed4363d7e19264c25ae56e9 introduced the site setting for a default channel. The issue is that the setting is a string in the JS, rather than an int (so that it can be left blank), and we were not casting the value to an integer when comparing.