### PR TITLE
FIX: Scope updating ChatMessageEmailStatus records to current_user

### DIFF
--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -151,6 +151,7 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
       .joins(:chat_message)
       .where(chat_message: { chat_channel_id: @chat_channel.id })
       .where("chat_message.id <= ?", params[:message_id])
+      .where(user: current_user)
       .update_all(status: ChatMessageEmailStatus::STATUSES[:processed])
 
     chat_mentions = ChatMention

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DiscourseChat::ChatController do
   fab!(:category) { Fabricate(:category) }
   fab!(:topic) { Fabricate(:topic, category: category) }
   fab!(:chat_channel) { Fabricate(:chat_channel) }
-  fab!(:dm_chat_channel) { Fabricate(:chat_channel, chatable: Fabricate(:direct_message_channel, users: [user, admin])) }
+  fab!(:dm_chat_channel) { Fabricate(:chat_channel, chatable: Fabricate(:direct_message_channel, users: [user, other_user, admin])) }
   fab!(:tag) { Fabricate(:tag) }
 
   MESSAGE_COUNT = 70
@@ -787,7 +787,7 @@ RSpec.describe DiscourseChat::ChatController do
       expect(notification2.reload.read).to be true
     end
 
-    it "marks all chat_message_email_status records to `processed`" do
+    it "marks all chat_message_email_status records to `processed` for current_user" do
       message1 = DiscourseChat::ChatMessageCreator.create(
         chat_channel: dm_chat_channel,
         user: admin,
@@ -817,6 +817,13 @@ RSpec.describe DiscourseChat::ChatController do
         user
           .chat_message_email_statuses
           .where(chat_message_id: message_ids, status: ChatMessageEmailStatus::STATUSES[:processed])
+          .count
+      ).to eq(2)
+
+      expect(
+        other_user
+          .chat_message_email_statuses
+          .where(chat_message_id: message_ids, status: ChatMessageEmailStatus::STATUSES[:unprocessed])
           .count
       ).to eq(2)
     end


### PR DESCRIPTION
Woops, this was not good. `ChatMessageEmailsStatuses` for all users a part of a channel were being updated when 1 user read X message. Scope the current_user.