### PR TITLE
DEV: Move chat selection buttons out of chat-live-pane

### DIFF
--- a/assets/javascripts/discourse/components/chat-selection-manager.js
+++ b/assets/javascripts/discourse/components/chat-selection-manager.js
@@ -1,0 +1,117 @@
+import Component from "@ember/component";
+import discourseComputed from "discourse-common/utils/decorators";
+import { clipboardCopyAsync } from "discourse/lib/utilities";
+import { getOwner } from "discourse-common/lib/get-owner";
+import { action } from "@ember/object";
+import { ajax } from "discourse/lib/ajax";
+import { isTesting } from "discourse-common/config/environment";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import { schedule } from "@ember/runloop";
+import { inject as service } from "@ember/service";
+import getURL from "discourse-common/lib/get-url";
+
+export default Component.extend({
+  tagName: "",
+  router: service(),
+  chatChannel: null,
+  selectedMessageIds: null,
+  showChatQuoteSuccess: false,
+  cancelSelecting: null,
+
+  @discourseComputed("selectedMessageIds")
+  anyMessagesSelected(selectedMessageIds) {
+    return selectedMessageIds.length > 0;
+  },
+
+  @action
+  async quoteMessages() {
+    const quoteGenerationPromise = async () => {
+      const response = await ajax(
+        getURL(`/chat/${this.chatChannel.id}/quote.json`),
+        {
+          data: { message_ids: this.selectedMessageIds },
+          type: "POST",
+        }
+      );
+      return new Blob([response.markdown], {
+        type: "text/plain",
+      });
+    };
+
+    // copy the generated quote to the clipboard
+    if (!this.site.isMobileDevice && this.currentUser.chat_isolated) {
+      if (!isTesting()) {
+        return clipboardCopyAsync(quoteGenerationPromise)
+          .then(() => {
+            this._showCopyQuoteSuccess();
+          })
+          .catch(popupAjaxError);
+      } else {
+        // clipboard API throws errors in tests
+        return;
+      }
+    }
+
+    let quoteMarkdownBlob, quoteMarkdown;
+    try {
+      quoteMarkdownBlob = await quoteGenerationPromise();
+      quoteMarkdown = await quoteMarkdownBlob.text();
+    } catch (error) {
+      popupAjaxError(error);
+    }
+    const container = getOwner(this);
+    const composer = container.lookup("controller:composer");
+    const openOpts = {};
+
+    if (this.chatChannel.isCategoryChannel) {
+      openOpts.categoryId = this.chatChannel.chatable_id;
+    }
+
+    if (this.site.isMobileDevice) {
+      // go to the relevant chatable (e.g. category) and open the
+      // composer to insert text
+      this._goToChatableUrl().then(() => {
+        composer.focusComposer({
+          fallbackToNewTopic: true,
+          insertText: quoteMarkdown,
+          openOpts,
+        });
+      });
+    } else {
+      // open the composer and insert text, reply to the current
+      // topic if there is one, use the active draft if there is one
+      const topic = container.lookup("controller:topic");
+      composer.focusComposer({
+        fallbackToNewTopic: true,
+        topic: topic?.model,
+        insertText: quoteMarkdown,
+        openOpts,
+      });
+    }
+  },
+
+  _showCopyQuoteSuccess() {
+    this.set("showChatQuoteSuccess", true);
+
+    schedule("afterRender", () => {
+      if (this._selfDeleted) {
+        return;
+      }
+
+      const element = document.querySelector(".chat-selection-message");
+      element.addEventListener(
+        "animationend",
+        () => {
+          this.set("showChatQuoteSuccess", false);
+        },
+        { once: true }
+      );
+    });
+  },
+
+  _goToChatableUrl() {
+    if (this.chatChannel.chatable_url) {
+      return this.router.transitionTo(this.chatChannel.chatable_url);
+    }
+  },
+});

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -82,31 +82,10 @@
 
 {{#if expanded}}
   {{#if selectingMessages}}
-    <div class="chat-selection-management">
-      <div class="chat-selection-management-buttons">
-        {{d-button
-          id="chat-quote-btn"
-          class="btn-secondary"
-          icon="quote-left"
-          label="chat.selection.quote_selection"
-          title="chat.selection.quote_selection"
-          disabled=(not anyMessagesSelected)
-          action=(action "quoteMessages")
-        }}
-        {{d-button
-          icon="times"
-          class="btn-secondary cancel-btn"
-          label="chat.selection.cancel"
-          title="chat.selection.cancel"
-          action=(action "cancelSelecting")
-        }}
-      </div>
-      {{#if showChatQuoteSuccess}}
-        <div class="chat-selection-message alert alert-success">
-          {{i18n "chat.quote.copy_success"}}
-        </div>
-      {{/if}}
-    </div>
+    {{chat-selection-manager
+      selectedMessageIds=selectedMessageIds
+      chatChannel=chatChannel
+      cancelSelecting=(action "cancelSelecting")}}
   {{else}}
     {{chat-composer
       draft=draft

--- a/assets/javascripts/discourse/templates/components/chat-selection-manager.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-selection-manager.hbs
@@ -1,0 +1,25 @@
+<div class="chat-selection-management">
+  <div class="chat-selection-management-buttons">
+    {{d-button
+      id="chat-quote-btn"
+      class="btn-secondary"
+      icon="quote-left"
+      label="chat.selection.quote_selection"
+      title="chat.selection.quote_selection"
+      disabled=(not anyMessagesSelected)
+      action=(action "quoteMessages")
+    }}
+    {{d-button
+      icon="times"
+      class="btn-secondary cancel-btn"
+      label="chat.selection.cancel"
+      title="chat.selection.cancel"
+      action=cancelSelecting
+    }}
+  </div>
+  {{#if showChatQuoteSuccess}}
+    <div class="chat-selection-message alert alert-success">
+      {{i18n "chat.quote.copy_success"}}
+    </div>
+  {{/if}}
+</div>

--- a/assets/stylesheets/common/chat-selection-manager.scss
+++ b/assets/stylesheets/common/chat-selection-manager.scss
@@ -1,0 +1,31 @@
+.chat-selection-management {
+  @keyframes chat-quote-message-background-fade-highlight {
+    0% {
+      background-color: var(--success-low);
+      color: black;
+    }
+    100% {
+      background-color: transparent;
+      color: transparent;
+    }
+  }
+
+  padding: 0.5em;
+  border-top: 1px solid var(--primary-low);
+  display: flex;
+
+  .chat-selection-message {
+    padding: 0.5em 0.65em;
+    margin: 0 1em;
+    flex: 1;
+    line-height: normal;
+
+    animation: chat-quote-message-background-fade-highlight 2.5s ease-out 3s;
+  }
+
+  .chat-selection-management-buttons {
+    .cancel-btn {
+      margin-left: 1em;
+    }
+  }
+}

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -804,38 +804,6 @@ body.composer-open .topic-chat-float-container {
       }
     }
   }
-
-  .chat-selection-management {
-    @keyframes chat-quote-message-background-fade-highlight {
-      0% {
-        background-color: var(--success-low);
-        color: black;
-      }
-      100% {
-        background-color: transparent;
-        color: transparent;
-      }
-    }
-
-    padding: 0.5em;
-    border-top: 1px solid var(--primary-low);
-    display: flex;
-
-    .chat-selection-message {
-      padding: 0.5em 0.65em;
-      margin: 0 1em;
-      flex: 1;
-      line-height: normal;
-
-      animation: chat-quote-message-background-fade-highlight 2.5s ease-out 3s;
-    }
-
-    .chat-selection-management-buttons {
-      .cancel-btn {
-        margin-left: 1em;
-      }
-    }
-  }
 }
 
 .topic-title-chat-icon {

--- a/plugin.rb
+++ b/plugin.rb
@@ -20,6 +20,7 @@ register_asset 'stylesheets/common/chat-transcript.scss'
 register_asset 'stylesheets/common/chat-retention-reminder.scss'
 register_asset 'stylesheets/common/chat-composer-uploads.scss'
 register_asset 'stylesheets/common/chat-composer-upload.scss'
+register_asset 'stylesheets/common/chat-selection-manager.scss'
 register_asset 'stylesheets/common/chat-channel-selector-modal.scss'
 register_asset 'stylesheets/mobile/mobile.scss', :mobile
 register_asset 'stylesheets/desktop/desktop.scss', :desktop


### PR DESCRIPTION
At the moment there is just a Quote button when selecting messages,
but we are adding another button here and potentially more
in future, it makes more sense to have the chat selection
management buttons to be in their own component, not clogging
up chat-live-pane.