### PR TITLE
FIX: Use @service router to fix chat quoting on mobile

### DIFF
--- a/assets/javascripts/discourse/components/chat-message.js
+++ b/assets/javascripts/discourse/components/chat-message.js
@@ -1,4 +1,5 @@
 import bootbox from "bootbox";
+import { isTesting } from "discourse-common/config/environment";
 import Component from "@ember/component";
 import I18n from "I18n";
 import getURL from "discourse-common/lib/get-url";
@@ -256,6 +257,14 @@ export default Component.extend({
   @action
   handleTouchStart() {
     if (!this.isHovered) {
+      // when testing this must be triggered immediately because there
+      // is no concept of "long press" there, the Ember `tap` test helper
+      // does send the touchstart/touchend events but immediately, see
+      // https://github.com/emberjs/ember-test-helpers/blob/master/API.md#tap
+      if (isTesting()) {
+        this._handleLongPress();
+      }
+
       this._isPressingHandler = later(this._handleLongPress, 500);
     }
   },

--- a/assets/javascripts/discourse/components/chat-selection-manager.js
+++ b/assets/javascripts/discourse/components/chat-selection-manager.js
@@ -11,7 +11,7 @@ import getURL from "discourse-common/lib/get-url";
 
 export default class AdminCustomizeColorsShowController extends Component {
   tagName = "";
-  router = service();
+  @service router;
   chatChannel = null;
   selectedMessageIds = null;
   showChatQuoteSuccess = false;

--- a/test/javascripts/acceptance/chat-quoting-test.js
+++ b/test/javascripts/acceptance/chat-quoting-test.js
@@ -1,5 +1,5 @@
 import { skip, test } from "qunit";
-import { click, currentURL, visit } from "@ember/test-helpers";
+import { click, currentURL, tap, visit } from "@ember/test-helpers";
 import {
   acceptance,
   exists,
@@ -187,11 +187,11 @@ acceptance("Discourse Chat | quoting on mobile", async function (needs) {
   });
   needs.mobileView();
 
-  skip("it opens the chatable, opens the composer, and pastes the markdown in", async function (assert) {
+  test("it opens the chatable, opens the composer, and pastes the markdown in", async function (assert) {
     await visit("/chat/channel/7/Uncategorized");
     assert.ok(exists(".chat-message-container"));
     const firstMessage = query(".chat-message-container");
-    await click(firstMessage);
+    await tap(firstMessage);
     await click(".chat-message-action-item[data-id='selectMessage'] button");
 
     assert.ok(firstMessage.classList.contains("selecting-messages"));

--- a/test/javascripts/acceptance/chat-quoting-test.js
+++ b/test/javascripts/acceptance/chat-quoting-test.js
@@ -1,4 +1,5 @@
-import { skip, test } from "qunit";
+import { test } from "qunit";
+import { isLegacyEmber } from "discourse-common/config/environment";
 import { click, currentURL, tap, visit } from "@ember/test-helpers";
 import {
   acceptance,
@@ -167,53 +168,55 @@ acceptance(
   }
 );
 
-// TODO: implement touch support for this test
-acceptance("Discourse Chat | quoting on mobile", async function (needs) {
-  needs.user({
-    admin: false,
-    moderator: false,
-    username: "eviltrout",
-    id: 1,
-    can_chat: true,
-    has_chat_enabled: true,
-  });
+// TODO: Uncomment when we get rid of legacy ember, it does not have the tap helper.
+if (!isLegacyEmber()) {
+  acceptance("Discourse Chat | quoting on mobile", async function (needs) {
+    needs.user({
+      admin: false,
+      moderator: false,
+      username: "eviltrout",
+      id: 1,
+      can_chat: true,
+      has_chat_enabled: true,
+    });
 
-  needs.settings({
-    chat_enabled: true,
-  });
+    needs.settings({
+      chat_enabled: true,
+    });
 
-  needs.pretender((server, helper) => {
-    setupPretenders(server, helper);
-  });
-  needs.mobileView();
+    needs.pretender((server, helper) => {
+      setupPretenders(server, helper);
+    });
+    needs.mobileView();
 
-  test("it opens the chatable, opens the composer, and pastes the markdown in", async function (assert) {
-    await visit("/chat/channel/7/Uncategorized");
-    assert.ok(exists(".chat-message-container"));
-    const firstMessage = query(".chat-message-container");
-    await tap(firstMessage);
-    await click(".chat-message-action-item[data-id='selectMessage'] button");
+    test("it opens the chatable, opens the composer, and pastes the markdown in", async function (assert) {
+      await visit("/chat/channel/7/Uncategorized");
+      assert.ok(exists(".chat-message-container"));
+      const firstMessage = query(".chat-message-container");
+      await tap(firstMessage);
+      await click(".chat-message-action-item[data-id='selectMessage'] button");
 
-    assert.ok(firstMessage.classList.contains("selecting-messages"));
-    await click("#chat-quote-btn");
-    assert.equal(
-      currentURL(),
-      "/c/uncategorized/1",
-      "navigates to the chatable url"
-    );
-    assert.ok(
-      exists("#reply-control.composer-action-createTopic"),
-      "the composer opens"
-    );
-    assert.strictEqual(
-      query("textarea.d-editor-input").value,
-      quoteResponse.markdown,
-      "the composer has the markdown"
-    );
-    assert.strictEqual(
-      selectKit(".category-chooser").header().value(),
-      "1",
-      "it fills category selector with the right category"
-    );
+      assert.ok(firstMessage.classList.contains("selecting-messages"));
+      await click("#chat-quote-btn");
+      assert.equal(
+        currentURL(),
+        "/c/uncategorized/1",
+        "navigates to the chatable url"
+      );
+      assert.ok(
+        exists("#reply-control.composer-action-createTopic"),
+        "the composer opens"
+      );
+      assert.strictEqual(
+        query("textarea.d-editor-input").value,
+        quoteResponse.markdown,
+        "the composer has the markdown"
+      );
+      assert.strictEqual(
+        selectKit(".category-chooser").header().value(),
+        "1",
+        "it fills category selector with the right category"
+      );
+    });
   });
-});
+}


### PR DESCRIPTION
In 6445af48bb74b6312f863b1001bdc46546b1e34b I moved some things
from chat-live-pane into a new chat-selection-manager component.
However I did not realise I made a breaking change when I used
the class syntax for the Component; in this syntax instead of
doing `router: service()` we need to do `@service router`. This
was not picked up by the mobile quoting test because it was commented/
skipped back in 8794f358389b366fbe25b5ff5eb90ad31528251f because
the mobile menu was added but we did not have a way to test the
touch support.

This commit fixes the router issue and also adds a way to test the
long press on mobile by triggering the long press on a message
immediately instead of 500ms later in testing mode. This must be triggered
immediately because there is no concept of "long press" there, the Ember
`tap` test helper does send the touchstart/touchend events correctly but immediately
see https://github.com/emberjs/ember-test-helpers/blob/master/API.md#tap