### PR TITLE
FIX: correctly acknowledge for deletion in unread_counts

### DIFF
--- a/lib/chat_channel_fetcher.rb
+++ b/lib/chat_channel_fetcher.rb
@@ -131,7 +131,11 @@ module DiscourseChat::ChatChannelFetcher
       FROM chat_messages cm
       JOIN chat_channels cc ON cc.id = cm.chat_channel_id
       JOIN user_chat_channel_memberships uccm ON uccm.chat_channel_id = cc.id
-      WHERE cc.id IN (:channel_ids) AND cm.user_id != :user_id AND uccm.user_id = :user_id AND cm.id > COALESCE(uccm.last_read_message_id, 0)
+      WHERE cc.id IN (:channel_ids)
+        AND cm.user_id != :user_id
+        AND uccm.user_id = :user_id
+        AND cm.id > COALESCE(uccm.last_read_message_id, 0)
+        AND cm.deleted_at IS NULL
       GROUP BY cc.id
     SQL
 

--- a/spec/lib/chat_channel_fetcher_spec.rb
+++ b/spec/lib/chat_channel_fetcher_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 describe DiscourseChat::ChatChannelFetcher do
   describe ".unread_counts" do
     fab!(:user_1) { Fabricate(:user) }
@@ -27,7 +26,7 @@ describe DiscourseChat::ChatChannelFetcher do
       context "has no unread messages" do
         it "returns the correct count" do
           unread_counts = subject.unread_counts([chat_channel], user_1)
-          expect(unread_counts[chat_channel.id]).to be_nil
+          expect(unread_counts[chat_channel.id]).to eq(0)
         end
       end
 
@@ -40,7 +39,7 @@ describe DiscourseChat::ChatChannelFetcher do
 
         it "returns the correct count" do
           unread_counts = subject.unread_counts([chat_channel], user_1)
-          expect(unread_counts[chat_channel.id]).to be_nil
+          expect(unread_counts[chat_channel.id]).to eq(0)
         end
       end
     end
@@ -53,7 +52,7 @@ describe DiscourseChat::ChatChannelFetcher do
 
         it "returns the correct count" do
           unread_counts = subject.unread_counts([chat_channel], user_1)
-          expect(unread_counts[chat_channel.id]).to be_nil
+          expect(unread_counts[chat_channel.id]).to eq(0)
         end
       end
     end

--- a/spec/lib/chat_channel_fetcher_spec.rb
+++ b/spec/lib/chat_channel_fetcher_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "rails_helper"
 
 describe DiscourseChat::ChatChannelFetcher do
   describe ".unread_counts" do

--- a/spec/lib/chat_channel_fetcher_spec.rb
+++ b/spec/lib/chat_channel_fetcher_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe DiscourseChat::ChatChannelFetcher do
+  describe ".unread_counts" do
+    fab!(:user_1) { Fabricate(:user) }
+    fab!(:user_2) { Fabricate(:user) }
+    fab!(:chat_channel) { Fabricate(:chat_channel) }
+
+    context "user is member of the channel" do
+      before do
+        Fabricate(:user_chat_channel_membership, chat_channel: chat_channel, user: user_1)
+      end
+
+      context "has unread messages" do
+        before do
+          Fabricate(:chat_message, chat_channel: chat_channel, message: "hi", user: user_2)
+          Fabricate(:chat_message, chat_channel: chat_channel, message: "bonjour", user: user_2)
+        end
+
+        it "returns the correct count" do
+          unread_counts = subject.unread_counts([chat_channel], user_1)
+          expect(unread_counts[chat_channel.id]).to eq(2)
+        end
+      end
+
+      context "has no unread messages" do
+        it "returns the correct count" do
+          unread_counts = subject.unread_counts([chat_channel], user_1)
+          expect(unread_counts[chat_channel.id]).to be_nil
+        end
+      end
+
+      context "last unread message has been deleted" do
+        fab!(:last_unread) { Fabricate(:chat_message, chat_channel: chat_channel, message: "hi", user: user_2) }
+
+        before do
+          last_unread.update!(deleted_at: Time.zone.now)
+        end
+
+        it "returns the correct count" do
+          unread_counts = subject.unread_counts([chat_channel], user_1)
+          expect(unread_counts[chat_channel.id]).to be_nil
+        end
+      end
+    end
+
+    context "user is not member of the channel" do
+      context "the channel has new messages" do
+        before do
+          Fabricate(:chat_message, chat_channel: chat_channel, message: "hi", user: user_2)
+        end
+
+        it "returns the correct count" do
+          unread_counts = subject.unread_counts([chat_channel], user_1)
+          expect(unread_counts[chat_channel.id]).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prior to this fix, if deleted message was the last message of a channel it would forever stay in unread state.

Note that this commit won't fix client side not updating unread state after without a refresh after last message has been deleted. But refresh or navigating to channel will now work where it wouldn't have before.

This commit also adds extensive specs for unread_counts.