### PR TITLE
FIX: ensures channels are refreshed when creating channel

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -992,11 +992,12 @@ export default Component.extend({
             message,
             upload_ids: (uploads || []).mapBy("id"),
           },
-        }).then(() =>
+        }).then(() => {
+          this.chat.forceRefreshChannels();
           this.onSwitchChannel(ChatChannel.create(c), {
             replace: true,
-          })
-        )
+          });
+        })
       )
       .finally(() => {
         if (this.isDestroyed || this.isDestroying) {

--- a/assets/javascripts/discourse/components/sidebar-channels.js
+++ b/assets/javascripts/discourse/components/sidebar-channels.js
@@ -2,11 +2,12 @@ import Component from "@ember/component";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import { reads } from "@ember/object/computed";
 
 export default Component.extend({
   tagName: "",
-  publicChannels: null,
-  directMessageChannels: null,
+  publicChannels: reads("chat.publicChannels.[]"),
+  directMessageChannels: reads("chat.directMessageChannels.[]"),
   toggleSection: null,
   chat: service(),
   router: service(),
@@ -48,12 +49,8 @@ export default Component.extend({
 
   @action
   fetchChannels() {
-    this.chat.getChannels().then((channels) => {
-      this.setProperties({
-        publicChannels: channels.publicChannels,
-        directMessageChannels: channels.directMessageChannels,
-        fetchedChannels: true,
-      });
+    this.chat.getChannels().then(() => {
+      this.set("fetchedChannels", true);
     });
   },
 


### PR DESCRIPTION
Previously the sequence of event would go like this:
- create channel
- refresh channels
- create message
-- > channels contain a channel which don't have properties to end up sorted at the top as the message was not created yet

This commit also relies directly on chat service channels instead of creating its own local properties.