### PR TITLE
FIX: Resize images within oneboxes

### DIFF
--- a/assets/stylesheets/common/chat-message-collapser.scss
+++ b/assets/stylesheets/common/chat-message-collapser.scss
@@ -1,5 +1,3 @@
-$max_image_height: 150px;
-
 .chat-message-collapser {
   .chat-message-collapser-header {
     display: flex;
@@ -36,22 +34,5 @@ $max_image_height: 150px;
         color: var(--primary);
       }
     }
-  }
-
-  .onebox img:not(.ytp-thumbnail-image),
-  img.onebox,
-  .chat-uploads img,
-  p img {
-    object-fit: contain;
-    max-height: $max_image_height;
-    max-width: 100%;
-
-    width: unset;
-  }
-
-  .chat-message-collapser-header + div .chat-message-collapser-youtube {
-    object-fit: contain;
-    height: $max_image_height;
-    width: calc(#{$max_image_height} / 9 * 16);
   }
 }

--- a/assets/stylesheets/common/chat-message-images.scss
+++ b/assets/stylesheets/common/chat-message-images.scss
@@ -1,0 +1,30 @@
+$max_image_height: 150px;
+
+aside.onebox {
+  width: max-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
+}
+
+// append selectors to set images to a
+// max height of $max_image_height
+.chat-message-collapser .onebox img:not(.ytp-thumbnail-image),
+.chat-message-collapser img.onebox,
+.chat-message-collapser .chat-uploads img,
+.chat-message-collapser p img,
+aside.onebox .onebox-body .aspect-image-full-size,
+aside.onebox .onebox-body .aspect-image-full-size img {
+  object-fit: contain;
+  max-height: $max_image_height;
+  max-width: 100%;
+  width: unset;
+}
+
+.chat-message-collapser
+  .chat-message-collapser-header
+  + div
+  .chat-message-collapser-youtube {
+  object-fit: contain;
+  height: $max_image_height;
+  width: calc(#{$max_image_height} / 9 * 16);
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -16,6 +16,7 @@ register_asset 'stylesheets/mobile/chat-message.scss', :mobile
 register_asset 'stylesheets/common/chat-message.scss'
 register_asset 'stylesheets/common/direct-message-creator.scss'
 register_asset 'stylesheets/common/chat-message-collapser.scss'
+register_asset 'stylesheets/common/chat-message-images.scss'
 register_asset 'stylesheets/common/chat-transcript.scss'
 register_asset 'stylesheets/common/chat-retention-reminder.scss'
 register_asset 'stylesheets/common/chat-composer-uploads.scss'


### PR DESCRIPTION
We never really resized images within oneboxes, so here's an attempt:

Reddit:
<img width="596" alt="Screenshot 2022-04-26 at 1 53 54 PM" src="https://user-images.githubusercontent.com/1555215/165231279-acebd411-bda8-460f-a275-d582b550aeee.png">

Existing collapser + Twitter:
<img width="812" alt="Screenshot 2022-04-26 at 1 47 20 PM" src="https://user-images.githubusercontent.com/1555215/165236501-fb5280ea-ea11-4789-90f5-e4e5ef65cc5d.png">

Keeps max width without overflowing:
<img width="787" alt="Screenshot 2022-04-26 at 2 29 29 PM" src="https://user-images.githubusercontent.com/1555215/165236099-d3a56c28-d4b5-412c-befa-e73121fb0e6e.png">

Tested in chrome and ff