### PR TITLE
FIX: following public channel doesn’t return channel

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -881,11 +881,11 @@ export default Component.extend({
 
     // TODO: all send message logic is due for massive refactoring
     // This is all the possible case Im currently aware of
-    // - answering to a public channel where you are not a member yet (preview = true)
-    // - answering to an existing direct channel you were not tracking yet through dm creator (channel draft)
-    // - answering to a new direct channel through DM creator (channel draft)
-    // - answer to a direct channel you were tracking (preview = false, not draft)
-    // - answer to a public channel you were tracking (preview = false, not draft)
+    // - messaging to a public channel where you are not a member yet (preview = true)
+    // - messaging to an existing direct channel you were not tracking yet through dm creator (channel draft)
+    // - messaging to a new direct channel through DM creator (channel draft)
+    // - message to a direct channel you were tracking (preview = false, not draft)
+    // - message to a public channel you were tracking (preview = false, not draft)
     if (this.previewing || this.chatChannel.isDraft) {
       this.set("loading", true);
 


### PR DESCRIPTION
Prior to this change answering to an unfollowed public channel would create an error. This commit makes the result of the first step similar to allow for proper code sharing.

This commit also explains more precisely the different possible cases of sendMessage to prepare for future refactoring.