### PR TITLE
FIX: Scope chat image/onebox styling to `.chat-message`

### DIFF
--- a/assets/stylesheets/common/chat-message-images.scss
+++ b/assets/stylesheets/common/chat-message-images.scss
@@ -1,30 +1,32 @@
 $max_image_height: 150px;
 
-aside.onebox {
-  width: max-content;
-  max-width: -moz-fit-content;
-  max-width: fit-content;
-}
+.chat-message {
+  aside.onebox {
+    width: max-content;
+    max-width: -moz-fit-content;
+    max-width: fit-content;
+  }
 
-// append selectors to set images to a
-// max height of $max_image_height
-.chat-message-collapser .onebox img:not(.ytp-thumbnail-image),
-.chat-message-collapser img.onebox,
-.chat-message-collapser .chat-uploads img,
-.chat-message-collapser p img,
-aside.onebox .onebox-body .aspect-image-full-size,
-aside.onebox .onebox-body .aspect-image-full-size img {
-  object-fit: contain;
-  max-height: $max_image_height;
-  max-width: 100%;
-  width: unset;
-}
+  // append selectors to set images to a
+  // max height of $max_image_height
+  .chat-message-collapser .onebox img:not(.ytp-thumbnail-image),
+  .chat-message-collapser img.onebox,
+  .chat-message-collapser .chat-uploads img,
+  .chat-message-collapser p img,
+  aside.onebox .onebox-body .aspect-image-full-size,
+  aside.onebox .onebox-body .aspect-image-full-size img {
+    object-fit: contain;
+    max-height: $max_image_height;
+    max-width: 100%;
+    width: unset;
+  }
 
-.chat-message-collapser
-  .chat-message-collapser-header
-  + div
-  .chat-message-collapser-youtube {
-  object-fit: contain;
-  height: $max_image_height;
-  width: calc(#{$max_image_height} / 9 * 16);
+  .chat-message-collapser
+    .chat-message-collapser-header
+    + div
+    .chat-message-collapser-youtube {
+    object-fit: contain;
+    height: $max_image_height;
+    width: calc(#{$max_image_height} / 9 * 16);
+  }
 }


### PR DESCRIPTION
This styling was leaking into regular discourse posts and breaking onebox widths. Followup to 811595b8