### PR TITLE
REFACTOR: sidebar-channels

### DIFF
--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -7,6 +7,7 @@ import { ajax } from "discourse/lib/ajax";
 import { A } from "@ember/array";
 import { generateCookFunction } from "discourse/lib/text";
 import { next } from "@ember/runloop";
+import { computed } from "@ember/object";
 import { Promise } from "rsvp";
 import ChatChannel, {
   CHANNEL_STATUSES,
@@ -53,10 +54,6 @@ export default Service.extend({
 
   init() {
     this._super(...arguments);
-    this.set(
-      "userCanChat",
-      this.currentUser?.has_chat_enabled && this.siteSettings.chat_enabled
-    );
 
     if (this.userCanChat) {
       this.set("allChannels", []);
@@ -75,6 +72,11 @@ export default Service.extend({
     }
   },
 
+  @computed("currentUser.has_chat_enabled", "siteSettings.chat_enabled")
+  get userCanChat() {
+    return this.currentUser?.has_chat_enabled && this.siteSettings.chat_enabled;
+  },
+
   willDestroy() {
     this._super(...arguments);
 
@@ -88,6 +90,7 @@ export default Service.extend({
     }
   },
 
+  @computed("router.currentRouteName")
   get isChatPage() {
     return (
       this.router.currentRouteName === "chat" ||
@@ -95,6 +98,7 @@ export default Service.extend({
     );
   },
 
+  @computed("router.currentRouteName")
   get isBrowsePage() {
     return this.router.currentRouteName === "chat.browse";
   },

--- a/assets/javascripts/discourse/templates/components/sidebar-channels.hbs
+++ b/assets/javascripts/discourse/templates/components/sidebar-channels.hbs
@@ -1,4 +1,4 @@
-{{#if show}}
+{{#if isDisplayed}}
   {{channel-list
     onSelect=(action "switchChannel")
     toggleSection=toggleSection

--- a/test/javascripts/components/sidebar-channels-test.js
+++ b/test/javascripts/components/sidebar-channels-test.js
@@ -1,0 +1,106 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import hbs from "htmlbars-inline-precompile";
+import { discourseModule, exists } from "discourse/tests/helpers/qunit-helpers";
+import {
+  setup as setupChatStub,
+  teardown as teardownChatStub,
+} from "../helpers/chat-stub";
+
+discourseModule(
+  "Discourse chat | Component | sidebar-channels",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    componentTest("chat is not isolated", {
+      template: hbs`{{sidebar-channels}}`,
+
+      beforeEach() {
+        this.set("currentUser.chat_isolated", false);
+
+        setupChatStub(this);
+      },
+
+      afterEach() {
+        teardownChatStub();
+      },
+
+      async test(assert) {
+        assert.ok(exists("[data-chat-channel-id]"));
+      },
+    });
+
+    componentTest("chat is on browse page", {
+      template: hbs`{{sidebar-channels}}`,
+
+      beforeEach() {
+        this.set("currentUser.chat_isolated", true);
+
+        setupChatStub(this, { isBrowsePage: true });
+      },
+
+      afterEach() {
+        teardownChatStub();
+      },
+
+      async test(assert) {
+        assert.ok(exists("[data-chat-channel-id]"));
+      },
+    });
+
+    componentTest("chat is on chat page", {
+      template: hbs`{{sidebar-channels}}`,
+
+      beforeEach() {
+        this.set("currentUser.chat_isolated", true);
+
+        setupChatStub(this, { isChatPage: true });
+      },
+
+      afterEach() {
+        teardownChatStub();
+      },
+
+      async test(assert) {
+        assert.ok(exists("[data-chat-channel-id]"));
+      },
+    });
+
+    componentTest("none of the conditions are fullfilled", {
+      template: hbs`{{sidebar-channels}}`,
+
+      beforeEach() {
+        this.set("currentUser.chat_isolated", true);
+
+        setupChatStub(this);
+      },
+
+      afterEach() {
+        teardownChatStub();
+      },
+
+      async test(assert) {
+        assert.notOk(exists("[data-chat-channel-id]"));
+      },
+    });
+
+    componentTest("user cant chat", {
+      template: hbs`{{sidebar-channels}}`,
+
+      beforeEach() {
+        this.set("currentUser.chat_isolated", false);
+
+        setupChatStub(this, { userCanChat: false });
+      },
+
+      afterEach() {
+        teardownChatStub();
+      },
+
+      async test(assert) {
+        assert.notOk(exists("[data-chat-channel-id]"));
+      },
+    });
+  }
+);

--- a/test/javascripts/helpers/chat-stub.js
+++ b/test/javascripts/helpers/chat-stub.js
@@ -1,0 +1,34 @@
+import fabricate from "../helpers/fabricators";
+import { isPresent } from "@ember/utils";
+import Service from "@ember/service";
+
+let publicChannels;
+let userCanChat;
+let isBrowsePage;
+let isChatPage;
+
+class ChatStub extends Service {
+  userCanChat = userCanChat;
+  publicChannels = publicChannels;
+  isBrowsePage = isBrowsePage;
+  isChatPage = isChatPage;
+}
+
+export function setup(context, options = {}) {
+  context.registry.register("service:chat-stub", ChatStub);
+  context.registry.injection("component", "chat", "service:chat-stub");
+
+  publicChannels = isPresent(options.publicChannels)
+    ? options.publicChannels
+    : [fabricate("chat-channel")];
+  userCanChat = isPresent(options.userCanChat) ? options.userCanChat : true;
+  isBrowsePage = isPresent(options.isBrowsePage) ? options.isBrowsePage : false;
+  isChatPage = isPresent(options.isChatPage) ? options.isChatPage : false;
+}
+
+export function teardown() {
+  publicChannels = [];
+  userCanChat = true;
+  isBrowsePage = false;
+  isChatPage = false;
+}


### PR DESCRIPTION
- native class
- tests
- relies on chat service being the source of truth for channels
- relies on currentRouterName instead of pageChange API
- implements a chat-stub helper as recommended by ember documentation: https://guides.emberjs.com/v2.0.0/testing/testing-components/#toc_stubbing-services