### PR TITLE
FIX: Fix overflowing github oneboxes

### DIFF
--- a/assets/stylesheets/common/chat-message-images.scss
+++ b/assets/stylesheets/common/chat-message-images.scss
@@ -2,7 +2,6 @@ $max_image_height: 150px;
 
 .chat-message {
   aside.onebox {
-    width: max-content;
     max-width: -moz-fit-content;
     max-width: fit-content;
   }


### PR DESCRIPTION
https://github.com/discourse/discourse-chat/pull/797 had caused github oneboxes to overflow when screens are not wide. 

Problem:

<img width="647" alt="Screenshot 2022-04-27 at 10 52 20 PM" src="https://user-images.githubusercontent.com/1555215/165547079-1e02af2e-be7d-4349-9b66-80267a5a9a27.png">


Onebox after the removal of `width: max-content`:

<img width="685" alt="Screenshot 2022-04-27 at 10 51 06 PM" src="https://user-images.githubusercontent.com/1555215/165546791-82214097-7c2d-474e-bf8d-3cb4a02ed36f.png">

^ not overflowing
