### PR TITLE
FIX: ensures widget is re-rendering when router changes

### DIFF
--- a/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/assets/javascripts/discourse/initializers/chat-setup.js
@@ -78,6 +78,14 @@ export default {
       );
 
       api.addToHeaderIcons("header-chat-link");
+
+      // TODO: drop this once sidebar
+      // is not using widgets anymore
+      api.onPageChange(() => {
+        api.container
+          .lookup("service:appEvents")
+          .trigger("chat:rerender-header");
+      });
     });
   },
 


### PR DESCRIPTION
Prior to chis change widgets are not correctly rendered using the last value of `this.chat.isChatPage` for example.