### PR TITLE
FIX: decorates lazyYT only once

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1301,9 +1301,11 @@ export default Component.extend({
       });
     }
 
-    this.element.querySelectorAll(".lazyYT").forEach((iframe) => {
-      $(iframe).lazyYT();
-    });
+    this.element
+      .querySelectorAll(".lazyYT:not(.lazyYT-video-loaded)")
+      .forEach((iframe) => {
+        $(iframe).lazyYT();
+      });
 
     decorateGithubOneboxBody(this.element);
   },


### PR DESCRIPTION
This was causing Youtube embeds to be broken after a message has been sent on an already loaded feed.