### PR TITLE
FIX: ensures collapsing is working on legacy

### DIFF
--- a/assets/javascripts/discourse/components/chat-message-text.js
+++ b/assets/javascripts/discourse/components/chat-message-text.js
@@ -2,15 +2,14 @@ import Component from "@ember/component";
 import { computed } from "@ember/object";
 import { isCollapsible } from "discourse/plugins/discourse-chat/discourse/components/chat-message-collapser";
 
-export default Component.extend({
-  classNames: "chat-message-text",
+export default class ChatMessageText extends Component {
+  tagName = "";
+  cooked = null;
+  uploads = null;
+  edited = false;
 
-  cooked: null,
-  uploads: null,
-  edited: false,
-
-  @computed("cooked", "uploads")
+  @computed("cooked", "uploads.[]")
   get isCollapsible() {
     return isCollapsible(this.cooked, this.uploads);
-  },
-});
+  }
+}

--- a/assets/javascripts/discourse/templates/components/chat-message-text.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message-text.hbs
@@ -1,10 +1,12 @@
-{{#if isCollapsible}}
-  {{chat-message-collapser cooked=cooked uploads=uploads}}
-{{else}}
-  {{html-safe cooked}}
-  {{#if edited}}
-    <span class="chat-message-edited">({{i18n "chat.edited"}})</span>
+<div class="chat-message-text">
+  {{#if isCollapsible}}
+    {{chat-message-collapser cooked=cooked uploads=uploads}}
+  {{else}}
+    {{html-safe cooked}}
+    {{#if edited}}
+      <span class="chat-message-edited">({{i18n "chat.edited"}})</span>
+    {{/if}}
   {{/if}}
-{{/if}}
 
-{{yield}}
+  {{yield}}
+</div>


### PR DESCRIPTION
As part of this fix was related to the use of get/`@computed` in a non native class, I have refactored the whole component:

- native class
- tagless