### PR TITLE
FIX: shows edited text if editing a collapsible into a collapsible

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-message-text.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message-text.hbs
@@ -3,9 +3,10 @@
     {{chat-message-collapser cooked=cooked uploads=uploads}}
   {{else}}
     {{html-safe cooked}}
-    {{#if edited}}
-      <span class="chat-message-edited">({{i18n "chat.edited"}})</span>
-    {{/if}}
+  {{/if}}
+
+  {{#if edited}}
+    <span class="chat-message-edited">({{i18n "chat.edited"}})</span>
   {{/if}}
 
   {{yield}}

--- a/test/javascripts/components/chat-message-text-test.js
+++ b/test/javascripts/components/chat-message-text-test.js
@@ -5,7 +5,7 @@ import hbs from "htmlbars-inline-precompile";
 import { discourseModule, exists } from "discourse/tests/helpers/qunit-helpers";
 
 discourseModule(
-  "Discourse Chat | Component | chat message text",
+  "Discourse Chat | Component | chat-message-text",
   function (hooks) {
     setupRenderingTest(hooks);
 
@@ -51,11 +51,23 @@ discourseModule(
       },
     });
 
-    componentTest("shows edits", {
+    componentTest("shows edits - regular message", {
       template: hbs`{{chat-message-text cooked=cooked edited=true}}`,
 
       beforeEach() {
         this.set("cooked", "<p></p>");
+      },
+
+      async test(assert) {
+        assert.ok(exists(".chat-message-edited"));
+      },
+    });
+
+    componentTest("shows edits - collapsible message", {
+      template: hbs`{{chat-message-text cooked=cooked edited=true}}`,
+
+      beforeEach() {
+        this.set("cooked", '<div class="onebox lazyYT-container"></div>');
       },
 
       async test(assert) {


### PR DESCRIPTION
Prior to this change, editing a youtube link and replacing it with another link wouldn't display the `edited` text.