### PR TITLE
FIX: ensures separator is correctly translated

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -361,8 +361,8 @@ export default Component.extend({
         messageData.firstMessageOfTheDayAt = moment(
           messageData.created_at
         ).calendar(moment(), {
-          sameDay: "[Today]",
-          lastDay: "[Yesterday]",
+          sameDay: `[${I18n.t("chat.chat_message_separator.today")}]`,
+          lastDay: `[${I18n.t("chat.chat_message_separator.yesterday")}]`,
           lastWeek: "LL",
           sameElse: "LL",
         });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -149,6 +149,10 @@ en:
         open_header: "Channel is open."
         open: "Open"
 
+      chat_message_separator:
+        today: Today
+        yesterday: Yesterday
+
       direct_message_creator:
         title: New Message
         prefix: "To:"


### PR DESCRIPTION
As we are overriding defaults of `moment.js` calendar function, we have to provide our own translation.

A test would be very heavy to test this due to the lack of isolation currently in chat-live-pane. I'm reluctant to have a full acceptance test only for this. chat-message-separator is already well tested by itself.