### PR TITLE
FIX: Don't hide the new messages indicator beside the channel header.

### DIFF
--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -3,6 +3,10 @@
 class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
   PAST_MESSAGE_LIMIT = 20
   FUTURE_MESSAGE_LIMIT = 40
+  PAST = 'past'
+  FUTURE = 'future'
+  BOTH = 'both'
+  CHAT_DIRECTIONS = [PAST, FUTURE, BOTH]
 
   before_action :find_chatable, only: [:enable_chat, :disable_chat]
   before_action :find_chat_message, only: [
@@ -177,37 +181,42 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
   def messages
     set_channel_and_chatable
     page_size = params[:page_size]&.to_i || 1000
-    if page_size > 50 || (params[:before_message_id] && params[:after_message_id])
+    direction = params[:direction].to_s
+    message_id = params[:message_id]
+    if page_size > 50 || (message_id.blank? ^ direction.blank? && (direction.present? && !CHAT_DIRECTIONS.include?(direction)))
       raise Discourse::InvalidParameters
     end
 
     messages = preloaded_chat_message_query.where(chat_channel: @chat_channel)
-
-    order_direction = :desc
-    if params[:before_message_id]
-      messages = messages.where("id < ?", params[:before_message_id])
-    end
-
-    if params[:after_message_id]
-      messages = messages.where("id > ?", params[:after_message_id])
-      order_direction = :asc
-    end
-
     messages = messages.with_deleted if guardian.can_moderate_chat?(@chatable)
-    messages = messages.order(id: order_direction).limit(page_size)
 
-    can_load_more_past = params[:after_message_id] ? nil : messages.count == page_size
-    can_load_more_future = if !params[:before_message_id] && !params[:after_message_id]
-      false
-    elsif params[:before_message_id]
-      nil
-    elsif params[:after_message_id]
-      messages.count == page_size
+    if message_id.present?
+      condition = [PAST, BOTH].include?(direction) ? '<' : '>'
+      messages = messages.where("id #{condition} ?", message_id.to_i)
+    end
+
+    order = :desc
+    order = :asc if direction == FUTURE
+    messages = messages.order(id: order).limit(page_size).to_a
+
+    can_load_more_past = nil
+    can_load_more_future = nil
+
+    if direction == FUTURE
+      can_load_more_future = messages.size == page_size
+    elsif direction == PAST
+      can_load_more_past = messages.size == page_size
+    elsif direction == BOTH
+      can_load_more_past = messages.size == page_size
+      can_load_more_future = true
+    else
+      # When direction is blank, we'll return the latest messages.
+      can_load_more_future = false
     end
 
     chat_view = ChatView.new(
       chat_channel: @chat_channel,
-      chat_messages: params[:after_message_id] ? messages : messages.to_a.reverse,
+      chat_messages: direction == FUTURE ? messages : messages.reverse,
       user: current_user,
       can_load_more_past: can_load_more_past,
       can_load_more_future: can_load_more_future

--- a/assets/javascripts/discourse/adapters/chat-message.js
+++ b/assets/javascripts/discourse/adapters/chat-message.js
@@ -7,11 +7,11 @@ export default RESTAdapter.extend({
     }
 
     let path = `/chat/${findArgs.channelId}/messages.json?page_size=${findArgs.pageSize}`;
-    if (findArgs.beforeMessageId) {
-      path += `&before_message_id=${findArgs.beforeMessageId}`;
+    if (findArgs.messageId) {
+      path += `&message_id=${findArgs.messageId}`;
     }
-    if (findArgs.afterMessageId) {
-      path += `&after_message_id=${findArgs.afterMessageId}`;
+    if (findArgs.direction) {
+      path += `&direction=${findArgs.direction}`;
     }
     return path;
   },

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -30,6 +30,7 @@ const MAX_RECENT_MSGS = 100;
 const STICKY_SCROLL_LENIENCE = 4;
 const READ_INTERVAL = 1000;
 const PAGE_SIZE = 50;
+const MESSAGES_ABOVE_NEW_MESSAGE_INDICATOR = 2;
 
 const PAST = "past";
 const FUTURE = "future";
@@ -184,7 +185,7 @@ export default Component.extend({
       };
 
       if (!this.targetMessageId) {
-        this._includeInmediateHistory(findArgs);
+        this._includeImmediateHistory(findArgs);
       }
 
       return this.store
@@ -423,13 +424,13 @@ export default Component.extend({
       ?.chat_message_id;
   },
 
-  _includeInmediateHistory(findArgs) {
-    let lastReadId = this._getLastReadId();
+  _includeImmediateHistory(findArgs) {
+    const lastReadId = this._getLastReadId();
 
     if (lastReadId) {
       // We are fetching the last read message, the two previous ones,
       // and the next 47 to complete a page.
-      const offset = 47;
+      const offset = PAGE_SIZE - MESSAGES_ABOVE_NEW_MESSAGE_INDICATOR;
       findArgs["messageId"] = lastReadId + offset;
       findArgs["direction"] = BOTH;
     }
@@ -456,9 +457,8 @@ export default Component.extend({
 
     if (newestUnreadMessage) {
       newestUnreadMessage.set("newestMessage", true);
-      const previousMessagesToDisplay = 3;
       newestUnreadScrollTarget =
-        newestUnreadScrollTarget - previousMessagesToDisplay;
+        newestUnreadScrollTarget - MESSAGES_ABOVE_NEW_MESSAGE_INDICATOR;
 
       if (newestUnreadScrollTarget < 0) {
         newestUnreadScrollTarget += Math.abs(newestUnreadScrollTarget);

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -123,9 +123,9 @@ RSpec.describe DiscourseChat::ChatController do
       expect(reactions[smile_emoji]["reacted"]).to be false
     end
 
-    describe "with 'before_message_id' param" do
+    describe "scrolling to the past" do
       it "returns the correct messages" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { before_message_id: message_40.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_40.id, direction: described_class::PAST, page_size: page_size }
         messages = response.parsed_body["chat_messages"]
         expect(messages.count).to eq(page_size)
         expect(messages.first["id"]).to eq(message_10.id)
@@ -133,21 +133,21 @@ RSpec.describe DiscourseChat::ChatController do
       end
 
       it "returns 'can_load...' properly when there are more past messages" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { before_message_id: message_40.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_40.id, direction: described_class::PAST, page_size: page_size }
         expect(response.parsed_body["meta"]["can_load_more_past"]).to be true
         expect(response.parsed_body["meta"]["can_load_more_future"]).to be_nil
       end
 
       it "returns 'can_load...' properly when there are no past messages" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { before_message_id: message_3.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_3.id, direction: described_class::PAST, page_size: page_size }
         expect(response.parsed_body["meta"]["can_load_more_past"]).to be false
         expect(response.parsed_body["meta"]["can_load_more_future"]).to be_nil
       end
     end
 
-    describe "with 'after_message_id' param" do
+    describe "scrolling to the future" do
       it "returns the correct messages when there are many after" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { after_message_id: message_10.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_10.id, direction: described_class::FUTURE, page_size: page_size }
         messages = response.parsed_body["chat_messages"]
         expect(messages.count).to eq(page_size)
         expect(messages.first["id"]).to eq(message_11.id)
@@ -155,27 +155,39 @@ RSpec.describe DiscourseChat::ChatController do
       end
 
       it "return 'can_load..' properly when there are future messages" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { after_message_id: message_10.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_10.id, direction: described_class::FUTURE, page_size: page_size }
         expect(response.parsed_body["meta"]["can_load_more_past"]).to be_nil
         expect(response.parsed_body["meta"]["can_load_more_future"]).to be true
       end
 
       it "returns 'can_load..' properly when there are no future messages" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { after_message_id: message_60.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_60.id, direction: described_class::FUTURE, page_size: page_size }
         expect(response.parsed_body["meta"]["can_load_more_past"]).to be_nil
         expect(response.parsed_body["meta"]["can_load_more_future"]).to be false
       end
     end
 
-    it "errors when both 'after_message_id' and 'before_message_id' are present" do
-      get "/chat/#{chat_channel.id}/messages.json", params: {
-        before_message_id: message_40.id,
-        after_message_id: message_20.id,
-        page_size: page_size
-      }
-      expect(response.status).to eq(400)
-    end
+    describe 'when direction is both ways' do
+      it 'returns messages before the ID' do
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_30.id, direction: described_class::BOTH, page_size: page_size }
+        messages = response.parsed_body["chat_messages"]
+        expect(messages.count).to eq(page_size)
+        expect(messages.first["id"]).to eq(message_0.id)
+        expect(messages.last["id"]).to eq(message_29.id)
+      end
 
+      it "signals there are messages available both ways when the results size matches the page size" do
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_30.id, direction: described_class::BOTH, page_size: page_size }
+        expect(response.parsed_body["meta"]["can_load_more_past"]).to eq(true)
+        expect(response.parsed_body["meta"]["can_load_more_future"]).to eq(true)
+      end
+
+      it "only signals there are messages available in the past when the results size doesn't matches" do
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_10.id, direction: described_class::BOTH, page_size: page_size }
+        expect(response.parsed_body["meta"]["can_load_more_past"]).to eq(false)
+        expect(response.parsed_body["meta"]["can_load_more_future"]).to eq(true)
+      end
+    end
   end
 
   describe "#enable_chat" do


### PR DESCRIPTION
Previously, seeing new messages in a channel was unnatural when there was a large number on unread messages because we displayed the newest ones first, meaning you'll have to scroll back to see the conversation from the last you
read.

This change improves our scrolling logic by loading new messages from where you left the last time you visited the channel. Also, it'll load a couple of older messages to avoid leaving the "New Messages" indicator hidden beside the
channel header. We had to refactor the messages endpoint to make the direction you're scrolling explicit, which let us create the concept of landing in the middle of the conversation, where you can generally scroll both ways.

**Before:**
<img width="700" alt="Screen Shot 2022-04-28 at 18 16 28" src="https://user-images.githubusercontent.com/5025816/165847335-465b5c69-e058-49ca-9beb-f1cd8294ba2b.png">
**After:**
<img width="700" alt="Screen Shot 2022-04-28 at 18 14 43" src="https://user-images.githubusercontent.com/5025816/165847320-bd80a2f6-f084-49b6-9111-03c03c96f2ff.png">

