### PR TITLE
REFACTOR: fully refactor chat channel draft

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer-uploads.js
+++ b/assets/javascripts/discourse/components/chat-composer-uploads.js
@@ -9,6 +9,7 @@ import UppyUploadMixin from "discourse/mixins/uppy-upload";
 export default Component.extend(UppyUploadMixin, {
   classNames: ["chat-composer-uploads"],
   mediaOptimizationWorker: service(),
+  chatChannelDraftManager: service(),
   id: "chat-composer-uploader",
   type: "chat-composer",
   uploads: null,

--- a/assets/javascripts/discourse/lib/chat-api.js
+++ b/assets/javascripts/discourse/lib/chat-api.js
@@ -1,0 +1,16 @@
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+
+export default class ChatApi {
+  static saveDraft(channel, draft) {
+    const data = { channel_id: channel.id };
+
+    if (draft?.isValid) {
+      data.data = JSON.stringify(draft);
+    }
+
+    return ajax("/chat/drafts.json", { type: "POST", data }).catch(
+      popupAjaxError
+    );
+  }
+}

--- a/assets/javascripts/discourse/models/chat-channel-draft.js
+++ b/assets/javascripts/discourse/models/chat-channel-draft.js
@@ -1,0 +1,16 @@
+import EmberObject from "@ember/object";
+import { isPresent } from "@ember/utils";
+
+export default class ChatChannelDraft extends EmberObject {
+  value = "";
+  uploads = [];
+  replyToMsg = null;
+
+  get isValid() {
+    return (
+      isPresent(this.value) ||
+      isPresent(this.uploads) ||
+      isPresent(this.replyToMsg)
+    );
+  }
+}

--- a/assets/javascripts/discourse/services/chat-channel-draft-manager.js
+++ b/assets/javascripts/discourse/services/chat-channel-draft-manager.js
@@ -1,0 +1,41 @@
+import Service from "@ember/service";
+import ChatChannelDraft from "discourse/plugins/discourse-chat/discourse/models/chat-channel-draft";
+import ChatApi from "discourse/plugins/discourse-chat/discourse/lib/chat-api";
+
+export default class ChatChannelDraftManager extends Service {
+  init() {
+    super.init(...arguments);
+
+    this._store = new Map();
+    this._loadExistingDrafts();
+  }
+
+  draftForChannel(channel) {
+    return this.drafts.get(channel.id) || ChatChannelDraft.create();
+  }
+
+  get drafts() {
+    return this._store;
+  }
+
+  async sync(channel, draft) {
+    if (draft?.isValid) {
+      this._store.set(channel.id, draft);
+    } else {
+      this._store.delete(channel.id);
+    }
+
+    return ChatApi.saveDraft(channel, draft);
+  }
+
+  _loadExistingDrafts() {
+    if (this.currentUser?.chat_drafts) {
+      this.currentUser.chat_drafts.forEach((draft) => {
+        this._store.set(
+          draft.channel_id,
+          ChatChannelDraft.create(JSON.parse(draft.data))
+        );
+      });
+    }
+  }
+}

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -14,7 +14,6 @@ import ChatChannel, {
   CHATABLE_TYPES,
 } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 import simpleCategoryHashMentionTransform from "discourse/plugins/discourse-chat/discourse/lib/simple-category-hash-mention-transform";
-import discourseDebounce from "discourse-common/lib/debounce";
 import discourseComputed from "discourse-common/utils/decorators";
 
 export const LIST_VIEW = "list_view";
@@ -63,13 +62,6 @@ export default Service.extend({
       this._subscribeToChannelEdits();
       this._subscribeToChannelStatusChange();
       this.presenceChannel = this.presence.getChannel("/chat/online");
-      this.draftStore = {};
-
-      if (this.currentUser.chat_drafts) {
-        this.currentUser.chat_drafts.forEach((draft) => {
-          this.draftStore[draft.channel_id] = JSON.parse(draft.data);
-        });
-      }
     }
   },
 
@@ -833,38 +825,6 @@ export default Service.extend({
     return ajax("/chat/direct_messages.json", { data: { usernames } });
   },
 
-  _saveDraft(channelId, draft) {
-    const data = { channel_id: channelId };
-    if (draft) {
-      data.data = JSON.stringify(draft);
-    }
-
-    ajax("/chat/drafts", { type: "POST", data });
-  },
-
-  setDraftForChannel(channel, draft) {
-    if (
-      draft &&
-      (draft.value || draft.uploads.length > 0 || draft.replyToMsg)
-    ) {
-      this.draftStore[channel.id] = draft;
-    } else {
-      delete this.draftStore[channel.id];
-      draft = null; // _saveDraft will destroy draft
-    }
-
-    discourseDebounce(this, this._saveDraft, channel.id, draft, 2000);
-  },
-
-  getDraftForChannel(channelId) {
-    return (
-      this.draftStore[channelId] || {
-        value: "",
-        uploads: [],
-        replyToMsg: null,
-      }
-    );
-  },
 
   addToolbarButton(toolbarButton) {
     addChatToolbarButton(toolbarButton);

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -88,7 +88,6 @@
       cancelSelecting=(action "cancelSelecting")}}
   {{else}}
     {{chat-composer
-      draft=draft
       details=this.details
       canInteractWithChat=canInteractWithChat
       sendMessage=(action "sendMessage")

--- a/test/javascripts/unit/models/chat-channel-draft-test.js
+++ b/test/javascripts/unit/models/chat-channel-draft-test.js
@@ -1,0 +1,24 @@
+import ChatChannelDraft from "discourse/plugins/discourse-chat/discourse/models/chat-channel-draft";
+import { module, test } from "qunit";
+
+module("Discourse Chat | Unit | Model | chat-channel-draft", function () {
+  test(".isValid - has value", function (assert) {
+    const draft = ChatChannelDraft.create({ value: "test" });
+    assert.ok(draft.isValid);
+  });
+
+  test(".isValid - has uploads", function (assert) {
+    const draft = ChatChannelDraft.create({ uploads: [{ fileId: 1 }] });
+    assert.ok(draft.isValid);
+  });
+
+  test(".isValid - has replyToMsg", function (assert) {
+    const draft = ChatChannelDraft.create({ replyToMsg: { id: 1 } });
+    assert.ok(draft.isValid);
+  });
+
+  test(".isValid - has no params", function (assert) {
+    const draft = ChatChannelDraft.create({});
+    assert.notOk(draft.isValid);
+  });
+});

--- a/test/javascripts/unit/services/chat-channel-draft-manager-test.js
+++ b/test/javascripts/unit/services/chat-channel-draft-manager-test.js
@@ -1,0 +1,91 @@
+import {
+  acceptance,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import ChatChannelDraft from "discourse/plugins/discourse-chat/discourse/models/chat-channel-draft";
+
+acceptance(
+  "DiscourseChat | Service | chat-channel-draft-manager",
+  function (needs) {
+    needs.user();
+
+    needs.pretender((server, helper) => {
+      server.post("/chat/drafts.json", (request) => {
+        const data = helper.parsePostData(request.requestBody);
+        return helper.response(200, data);
+      });
+    });
+
+    test(".drafts - currentUser has existing drafts", async function (assert) {
+      const channelId = 1;
+
+      updateCurrentUser({
+        chat_drafts: [
+          { channel_id: channelId, data: JSON.stringify({ value: "foo" }) },
+        ],
+      });
+
+      const manager = this.container.lookup(
+        "service:chat-channel-draft-manager"
+      );
+      assert.equal(manager.drafts.size, 1);
+      assert.equal(manager.drafts.get(channelId).value, "foo");
+    });
+
+    test(".drafts - currentUser has no existing drafts", async function (assert) {
+      const manager = this.container.lookup(
+        "service:chat-channel-draft-manager"
+      );
+      assert.equal(manager.drafts.size, 0);
+    });
+
+    test(".sync - valid draft", async function (assert) {
+      const channel = { id: 1 };
+      const manager = this.container.lookup(
+        "service:chat-channel-draft-manager"
+      );
+      const draft = ChatChannelDraft.create({ value: "foo" });
+      await manager.sync(channel, draft);
+
+      assert.equal(manager.drafts.size, 1);
+      assert.equal(manager.drafts.get(channel.id).value, "foo");
+    });
+
+    test(".sync - invalid draft", async function (assert) {
+      const channel = { id: 1 };
+      const manager = this.container.lookup(
+        "service:chat-channel-draft-manager"
+      );
+      const draft = ChatChannelDraft.create({ bar: "foo" });
+      await manager.sync(channel, draft);
+
+      assert.equal(manager.drafts.size, 0);
+    });
+
+    test(".sync - null draft", async function (assert) {
+      const channel = { id: 1 };
+      const manager = this.container.lookup(
+        "service:chat-channel-draft-manager"
+      );
+      await manager.sync(channel, null);
+
+      assert.equal(manager.drafts.size, 0);
+    });
+
+    test(".sync - nullify existing draft", async function (assert) {
+      const channel = { id: 1 };
+      const manager = this.container.lookup(
+        "service:chat-channel-draft-manager"
+      );
+      const draft = ChatChannelDraft.create({ value: "foo" });
+      await manager.sync(channel, draft);
+
+      assert.equal(manager.drafts.size, 1);
+
+      await manager.sync(channel, null);
+
+      assert.equal(manager.drafts.size, 0);
+    });
+  }
+);


### PR DESCRIPTION
- defines clear objects
- creates chatChannelDraftManager service to hold drafts state
- removes the need to pass the draft object around
- tests