### PR TITLE
FIX: Don't hide the new messages indicator beside the channel header

### DIFF
--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -186,6 +186,7 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
     else
       # When direction is blank, we'll return the latest messages.
       can_load_more_future = false
+      can_load_more_past = messages.size == page_size
     end
 
     chat_view = ChatView.new(

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -3,6 +3,10 @@
 class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
   PAST_MESSAGE_LIMIT = 20
   FUTURE_MESSAGE_LIMIT = 40
+  PAST = 'past'
+  FUTURE = 'future'
+  BOTH = 'both'
+  CHAT_DIRECTIONS = [PAST, FUTURE, BOTH]
 
   before_action :find_chatable, only: [:enable_chat, :disable_chat]
   before_action :find_chat_message, only: [
@@ -151,37 +155,42 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
   def messages
     set_channel_and_chatable
     page_size = params[:page_size]&.to_i || 1000
-    if page_size > 50 || (params[:before_message_id] && params[:after_message_id])
+    direction = params[:direction].to_s
+    message_id = params[:message_id]
+    if page_size > 50 || (message_id.blank? ^ direction.blank? && (direction.present? && !CHAT_DIRECTIONS.include?(direction)))
       raise Discourse::InvalidParameters
     end
 
     messages = preloaded_chat_message_query.where(chat_channel: @chat_channel)
-
-    order_direction = :desc
-    if params[:before_message_id]
-      messages = messages.where("id < ?", params[:before_message_id])
-    end
-
-    if params[:after_message_id]
-      messages = messages.where("id > ?", params[:after_message_id])
-      order_direction = :asc
-    end
-
     messages = messages.with_deleted if guardian.can_moderate_chat?(@chatable)
-    messages = messages.order(id: order_direction).limit(page_size)
 
-    can_load_more_past = params[:after_message_id] ? nil : messages.count == page_size
-    can_load_more_future = if !params[:before_message_id] && !params[:after_message_id]
-      false
-    elsif params[:before_message_id]
-      nil
-    elsif params[:after_message_id]
-      messages.count == page_size
+    if message_id.present?
+      condition = [PAST, BOTH].include?(direction) ? '<' : '>'
+      messages = messages.where("id #{condition} ?", message_id.to_i)
+    end
+
+    order = :desc
+    order = :asc if direction == FUTURE
+    messages = messages.order(id: order).limit(page_size).to_a
+
+    can_load_more_past = nil
+    can_load_more_future = nil
+
+    if direction == FUTURE
+      can_load_more_future = messages.size == page_size
+    elsif direction == PAST
+      can_load_more_past = messages.size == page_size
+    elsif direction == BOTH
+      can_load_more_past = messages.size == page_size
+      can_load_more_future = true
+    else
+      # When direction is blank, we'll return the latest messages.
+      can_load_more_future = false
     end
 
     chat_view = ChatView.new(
       chat_channel: @chat_channel,
-      chat_messages: params[:after_message_id] ? messages : messages.to_a.reverse,
+      chat_messages: direction == FUTURE ? messages : messages.reverse,
       user: current_user,
       can_load_more_past: can_load_more_past,
       can_load_more_future: can_load_more_future

--- a/assets/javascripts/discourse/adapters/chat-message.js
+++ b/assets/javascripts/discourse/adapters/chat-message.js
@@ -7,11 +7,11 @@ export default RESTAdapter.extend({
     }
 
     let path = `/chat/${findArgs.channelId}/messages.json?page_size=${findArgs.pageSize}`;
-    if (findArgs.beforeMessageId) {
-      path += `&before_message_id=${findArgs.beforeMessageId}`;
+    if (findArgs.messageId) {
+      path += `&message_id=${findArgs.messageId}`;
     }
-    if (findArgs.afterMessageId) {
-      path += `&after_message_id=${findArgs.afterMessageId}`;
+    if (findArgs.direction) {
+      path += `&direction=${findArgs.direction}`;
     }
     return path;
   },

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -30,9 +30,11 @@ const MAX_RECENT_MSGS = 100;
 const STICKY_SCROLL_LENIENCE = 4;
 const READ_INTERVAL = 1000;
 const PAGE_SIZE = 50;
+const MESSAGES_ABOVE_NEW_MESSAGE_INDICATOR = 2;
 
-const PAST = "Past";
-const FUTURE = "Future";
+const PAST = "past";
+const FUTURE = "future";
+const BOTH = "both";
 
 let _chatMessageDecorators = [];
 
@@ -175,11 +177,17 @@ export default Component.extend({
 
     return this.chat.loadCookFunction(this.site.categories).then((cook) => {
       this.set("cook", cook);
+
       const findArgs = {
         channelId,
         targetMessageId: this.targetMessageId,
         pageSize: PAGE_SIZE,
       };
+
+      if (!this.targetMessageId) {
+        this._includeImmediateHistory(findArgs);
+      }
+
       return this.store
         .findAll("chat-message", findArgs)
         .then((messages) => {
@@ -233,8 +241,9 @@ export default Component.extend({
     const findArgs = {
       channelId: this.chatChannel.id,
       pageSize: PAGE_SIZE,
+      direction,
+      messageId,
     };
-    findArgs[`${loadingPast ? "before" : "after"}MessageId`] = messageId;
     const channelId = this.chatChannel.id;
 
     return this.store
@@ -410,6 +419,23 @@ export default Component.extend({
     return message.id || `staged-${message.stagedId}`;
   },
 
+  _getLastReadId() {
+    return this.currentUser.chat_channel_tracking_state[this.chatChannel.id]
+      ?.chat_message_id;
+  },
+
+  _includeImmediateHistory(findArgs) {
+    const lastReadId = this._getLastReadId();
+
+    if (lastReadId) {
+      // We are fetching the last read message, the two previous ones,
+      // and the next 47 to complete a page.
+      const offset = PAGE_SIZE - MESSAGES_ABOVE_NEW_MESSAGE_INDICATOR;
+      findArgs["messageId"] = lastReadId + offset;
+      findArgs["direction"] = BOTH;
+    }
+  },
+
   _markLastReadMessage(opts = { reRender: false }) {
     if (opts.reRender) {
       this.messages.forEach((m) => {
@@ -418,9 +444,7 @@ export default Component.extend({
         }
       });
     }
-    const lastReadId =
-      this.currentUser.chat_channel_tracking_state[this.chatChannel.id]
-        ?.chat_message_id;
+    const lastReadId = this._getLastReadId();
     if (!lastReadId) {
       return;
     }
@@ -428,12 +452,20 @@ export default Component.extend({
     this.set("lastSendReadMessageId", lastReadId);
     const indexOfLastReadyMessage =
       this.messages.findIndex((m) => m.id === lastReadId) || 0;
-    const newestUnreadMessage = this.messages[indexOfLastReadyMessage + 1];
+    let newestUnreadScrollTarget = indexOfLastReadyMessage + 1;
+    let newestUnreadMessage = this.messages[newestUnreadScrollTarget];
 
     if (newestUnreadMessage) {
       newestUnreadMessage.set("newestMessage", true);
-      // We have the last read message from lookup, but now we need the index of the message,
-      // so that we can scroll to the message directly after it.
+      newestUnreadScrollTarget =
+        newestUnreadScrollTarget - MESSAGES_ABOVE_NEW_MESSAGE_INDICATOR;
+
+      if (newestUnreadScrollTarget < 0) {
+        newestUnreadScrollTarget += Math.abs(newestUnreadScrollTarget);
+      }
+
+      newestUnreadMessage = this.messages[newestUnreadScrollTarget];
+
       return this.scrollToMessage(newestUnreadMessage.id);
     }
     this._stickScrollToBottom();

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -123,9 +123,9 @@ RSpec.describe DiscourseChat::ChatController do
       expect(reactions[smile_emoji]["reacted"]).to be false
     end
 
-    describe "with 'before_message_id' param" do
+    describe "scrolling to the past" do
       it "returns the correct messages" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { before_message_id: message_40.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_40.id, direction: described_class::PAST, page_size: page_size }
         messages = response.parsed_body["chat_messages"]
         expect(messages.count).to eq(page_size)
         expect(messages.first["id"]).to eq(message_10.id)
@@ -133,21 +133,21 @@ RSpec.describe DiscourseChat::ChatController do
       end
 
       it "returns 'can_load...' properly when there are more past messages" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { before_message_id: message_40.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_40.id, direction: described_class::PAST, page_size: page_size }
         expect(response.parsed_body["meta"]["can_load_more_past"]).to be true
         expect(response.parsed_body["meta"]["can_load_more_future"]).to be_nil
       end
 
       it "returns 'can_load...' properly when there are no past messages" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { before_message_id: message_3.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_3.id, direction: described_class::PAST, page_size: page_size }
         expect(response.parsed_body["meta"]["can_load_more_past"]).to be false
         expect(response.parsed_body["meta"]["can_load_more_future"]).to be_nil
       end
     end
 
-    describe "with 'after_message_id' param" do
+    describe "scrolling to the future" do
       it "returns the correct messages when there are many after" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { after_message_id: message_10.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_10.id, direction: described_class::FUTURE, page_size: page_size }
         messages = response.parsed_body["chat_messages"]
         expect(messages.count).to eq(page_size)
         expect(messages.first["id"]).to eq(message_11.id)
@@ -155,27 +155,39 @@ RSpec.describe DiscourseChat::ChatController do
       end
 
       it "return 'can_load..' properly when there are future messages" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { after_message_id: message_10.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_10.id, direction: described_class::FUTURE, page_size: page_size }
         expect(response.parsed_body["meta"]["can_load_more_past"]).to be_nil
         expect(response.parsed_body["meta"]["can_load_more_future"]).to be true
       end
 
       it "returns 'can_load..' properly when there are no future messages" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { after_message_id: message_60.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_60.id, direction: described_class::FUTURE, page_size: page_size }
         expect(response.parsed_body["meta"]["can_load_more_past"]).to be_nil
         expect(response.parsed_body["meta"]["can_load_more_future"]).to be false
       end
     end
 
-    it "errors when both 'after_message_id' and 'before_message_id' are present" do
-      get "/chat/#{chat_channel.id}/messages.json", params: {
-        before_message_id: message_40.id,
-        after_message_id: message_20.id,
-        page_size: page_size
-      }
-      expect(response.status).to eq(400)
-    end
+    describe 'when direction is both ways' do
+      it 'returns messages before the ID' do
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_30.id, direction: described_class::BOTH, page_size: page_size }
+        messages = response.parsed_body["chat_messages"]
+        expect(messages.count).to eq(page_size)
+        expect(messages.first["id"]).to eq(message_0.id)
+        expect(messages.last["id"]).to eq(message_29.id)
+      end
 
+      it "signals there are messages available both ways when the results size matches the page size" do
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_30.id, direction: described_class::BOTH, page_size: page_size }
+        expect(response.parsed_body["meta"]["can_load_more_past"]).to eq(true)
+        expect(response.parsed_body["meta"]["can_load_more_future"]).to eq(true)
+      end
+
+      it "only signals there are messages available in the past when the results size doesn't matches" do
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_10.id, direction: described_class::BOTH, page_size: page_size }
+        expect(response.parsed_body["meta"]["can_load_more_past"]).to eq(false)
+        expect(response.parsed_body["meta"]["can_load_more_future"]).to eq(true)
+      end
+    end
   end
 
   describe "#enable_chat" do

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -188,6 +188,30 @@ RSpec.describe DiscourseChat::ChatController do
         expect(response.parsed_body["meta"]["can_load_more_future"]).to eq(true)
       end
     end
+
+    describe 'without direction (latest messages)' do
+      it 'signals there are no future messages' do
+        get "/chat/#{chat_channel.id}/messages.json", params: { page_size: page_size }
+
+        expect(response.parsed_body["meta"]["can_load_more_future"]).to eq(false)
+      end
+
+      it 'signals there are more messages in the past' do
+        get "/chat/#{chat_channel.id}/messages.json", params: { page_size: page_size }
+
+        expect(response.parsed_body["meta"]["can_load_more_past"]).to eq(true)
+      end
+
+      it 'signals there are no more messages' do
+        new_channel = Fabricate(:chat_channel)
+        Fabricate(:chat_message, chat_channel: new_channel, user: other_user, message: "message")
+        chat_messages_qty = 1
+
+        get "/chat/#{new_channel.id}/messages.json", params: { page_size: chat_messages_qty + 1 }
+
+        expect(response.parsed_body["meta"]["can_load_more_past"]).to eq(false)
+      end
+    end
   end
 
   describe "#enable_chat" do


### PR DESCRIPTION
Reintroduces discourse/discourse-chat#818, which was reverted on discourse/discourse-chat#826.