### PR TITLE
FIX: Do not show Move Messages button in DM channels

### DIFF
--- a/assets/javascripts/discourse/components/chat-selection-manager.js
+++ b/assets/javascripts/discourse/components/chat-selection-manager.js
@@ -24,6 +24,11 @@ export default class AdminCustomizeColorsShowController extends Component {
     return this.selectedMessageIds.length > 0;
   }
 
+  @computed("chatChannel.isDirectMessageChannel")
+  get showMoveMessageButton() {
+    return this.currentUser.staff && !this.chatChannel.isDirectMessageChannel;
+  }
+
   @action
   openMoveMessageModal() {
     showModal("chat-message-move-to-channel-modal").setProperties({

--- a/assets/javascripts/discourse/templates/components/chat-selection-manager.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-selection-manager.hbs
@@ -10,7 +10,7 @@
       action=(action "quoteMessages")
     }}
 
-    {{#if currentUser.staff}}
+    {{#if showMoveMessageButton}}
       {{d-button
         id="chat-move-to-channel-btn"
         class="btn-secondary"

--- a/test/javascripts/acceptance/chat-move-message-to-channel-test.js
+++ b/test/javascripts/acceptance/chat-move-message-to-channel-test.js
@@ -98,6 +98,20 @@ acceptance(
         "it goes to the destination channel after the move"
       );
     });
+
+    test("does not allow moving messages from a direct message channel", async function (assert) {
+      await visit("/chat/channel/75/@hawk");
+      assert.ok(exists(".chat-message-container"));
+      const firstMessage = query(".chat-message-container");
+      const dropdown = selectKit(".chat-message-container .more-buttons");
+      await dropdown.expand();
+      await dropdown.selectRowByValue("selectMessage");
+      assert.ok(firstMessage.classList.contains("selecting-messages"));
+      assert.notOk(
+        exists(".chat-live-pane #chat-move-to-channel-btn"),
+        "the move to channel button is not shown in direct message channels"
+      );
+    });
   }
 );
 


### PR DESCRIPTION
In f898aa7ff51d457e231c9a4c7098626ee6fcdfe3 we introduced
move messages to another channel, where we had a server side
check to prevent moving messages from a DM channel, but we
did not hide the button in the UI for DM channels.