### PR TITLE
DEV: Drop old post_id and action_code columns from ChatMessage

### DIFF
--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -260,5 +260,4 @@ end
 # Indexes
 #
 #  index_chat_messages_on_chat_channel_id_and_created_at  (chat_channel_id,created_at)
-#  index_chat_messages_on_post_id                         (post_id)
 #

--- a/db/post_migrate/20220504080457_drop_old_chat_message_post_id_action_code_columns.rb
+++ b/db/post_migrate/20220504080457_drop_old_chat_message_post_id_action_code_columns.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class DropOldChatMessagePostIdActionCodeColumns < ActiveRecord::Migration[7.0]
+  DROPPED_COLUMNS ||= {
+    chat_messages: %i{
+      post_id
+      action_code
+    }
+  }
+
+  def up
+    DROPPED_COLUMNS.each do |table, columns|
+      Migration::ColumnDropper.execute_drop(table, columns)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Follow up to 5baf232a597d27da490c021d7fcf2c570bb5f0a8, drops `post_id` and `action_code` from `chat_messages`.