### PR TITLE
DEV: Use Ember getter and explicitly check for undefined

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -388,10 +388,9 @@ export default Component.extend(TextareaTextManipulation, {
       treatAsTextarea: true,
 
       onKeyUp: (text, cp) => {
-        const matches =
-          /(?:^|[\s.\?,@\/#!%&*;:\[\]{}=\-_()])(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi.exec(
-            text.substring(0, cp)
-          );
+        const matches = /(?:^|[\s.\?,@\/#!%&*;:\[\]{}=\-_()])(:(?!:).?[\w-]*:?(?!:)(?:t\d?)?:?) ?$/gi.exec(
+          text.substring(0, cp)
+        );
 
         if (matches && matches[1]) {
           return [matches[1]];
@@ -450,10 +449,14 @@ export default Component.extend(TextareaTextManipulation, {
 
           // note this will only work for emojis starting with :
           // eg: :-)
+          let emojiTranslation = this.get("site.custom_emoji_translation");
+          if (emojiTranslation === undefined) {
+            emojiTranslation = {};
+          }
           const allTranslations = Object.assign(
             {},
             translations,
-            this.getWithDefault("site.custom_emoji_translation", {})
+            emojiTranslation
           );
           if (allTranslations[full]) {
             return resolve([allTranslations[full]]);


### PR DESCRIPTION
Context -> https://deprecations.emberjs.com/v3.x/#toc_ember-metal-get-with-default

_if you try to open link above in new tab it will not take you to the correct context_ 🤷‍♂️ 

And a little `prettier` action on `matches`