### PR TITLE
FIX: Ensure long messages don't hide the new messages indicator.

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -457,16 +457,26 @@ export default Component.extend({
 
     if (newestUnreadMessage) {
       newestUnreadMessage.set("newestMessage", true);
-      newestUnreadScrollTarget =
-        newestUnreadScrollTarget - MESSAGES_ABOVE_NEW_MESSAGE_INDICATOR;
 
-      if (newestUnreadScrollTarget < 0) {
-        newestUnreadScrollTarget += Math.abs(newestUnreadScrollTarget);
+      // We add some additional offset here to ensure we'll display previous messages
+      // but won't push the new messages indicator too far down.
+      let showPreviousMessageOffset = 100;
+
+      if (this.fullPage) {
+        showPreviousMessageOffset = 200;
       }
 
-      newestUnreadMessage = this.messages[newestUnreadScrollTarget];
+      if (this.site.mobileView) {
+        showPreviousMessageOffset = 80;
+      }
 
-      return this.scrollToMessage(newestUnreadMessage.id);
+      const scrollOpts = {
+        highlight: false,
+        position: "top",
+        additionalTopOffset: showPreviousMessageOffset,
+      };
+
+      return this.scrollToMessage(newestUnreadMessage.id, scrollOpts);
     }
     this._stickScrollToBottom();
   },
@@ -491,7 +501,12 @@ export default Component.extend({
 
   scrollToMessage(
     messageId,
-    opts = { highlight: false, position: "top", autoExpand: false }
+    opts = {
+      highlight: false,
+      position: "top",
+      autoExpand: false,
+      additionalTopOffset: -20,
+    }
   ) {
     if (this._selfDeleted) {
       return;
@@ -513,7 +528,7 @@ export default Component.extend({
         this._scrollerEl.scrollTop =
           messageEl.offsetTop -
           (opts.position === "top"
-            ? this._scrollerEl.offsetTop - 20
+            ? this._scrollerEl.offsetTop + opts.additionalTopOffset
             : this._scrollerEl.offsetHeight);
       });
 


### PR DESCRIPTION
Scrolling to the first unread message and using an offset depending on the viewport works better than scrolling to a previous message because these could be long enough to push the indicator too far down.

<!-- Checklist for UI / stylesheet changes, delete if not applicable -->

- [x] chat-scoped -- core unaffected

### View mode

- [x] docked (windowed/drawer)
- [x] isolated (full-screen)

### Browsers

- [x] safari
- [x] chrome
- [x] firefox

### Device

- [x] desktop – wide screen
- [x] mobile – `?mobile_view=1`

#### Screenshots:

#### Full page
<img width="931" alt="Screen Shot 2022-05-04 at 13 03 09" src="https://user-images.githubusercontent.com/5025816/166733530-064a0430-ab2b-4fd1-b8ec-c64522a05f63.png">

#### Windowed
<img width="472" alt="Screen Shot 2022-05-04 at 13 24 41" src="https://user-images.githubusercontent.com/5025816/166733598-4bc00e46-0b7e-413e-9f2f-a42beed0b267.png">

#### Mobile
<img width="392" alt="Screen Shot 2022-05-04 at 13 28 24" src="https://user-images.githubusercontent.com/5025816/166733629-afc2f16a-6c7b-43b7-a50b-6f3a587613c5.png">

