### PR TITLE
DEV: Allow category group mods to moderate chat channels

### DIFF
--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -344,10 +344,10 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
     params.require(:message_ids)
     params.require(:destination_channel_id)
 
-    raise Discourse::InvalidAccess if !guardian.can_move_chat_messages?
-
     chat_channel = DiscourseChat::ChatChannelFetcher.find_with_access_check(params[:chat_channel_id], guardian)
     destination_channel = DiscourseChat::ChatChannelFetcher.find_with_access_check(params[:destination_channel_id], guardian)
+
+    raise Discourse::InvalidAccess if !guardian.can_move_chat_messages?(chat_channel)
 
     message_ids = params[:message_ids].map(&:to_i)
 

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -345,13 +345,11 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
     params.require(:destination_channel_id)
 
     chat_channel = DiscourseChat::ChatChannelFetcher.find_with_access_check(params[:chat_channel_id], guardian)
+    raise Discourse::InvalidAccess if !guardian.can_move_chat_messages?(chat_channel)
     destination_channel = DiscourseChat::ChatChannelFetcher.find_with_access_check(params[:destination_channel_id], guardian)
 
-    raise Discourse::InvalidAccess if !guardian.can_move_chat_messages?(chat_channel)
-
-    message_ids = params[:message_ids].map(&:to_i)
-
     begin
+      message_ids = params[:message_ids].map(&:to_i)
       moved_messages = DiscourseChat::MessageMover.new(
         acting_user: current_user, source_channel: chat_channel, message_ids: message_ids
       ).move_to_channel(destination_channel)

--- a/app/serializers/chat_view_serializer.rb
+++ b/app/serializers/chat_view_serializer.rb
@@ -18,7 +18,9 @@ class ChatViewSerializer < ApplicationSerializer
       can_flag: scope.can_flag_in_chat_channel?(object.chat_channel),
       channel_status: object.chat_channel.status,
       user_silenced: !scope.can_create_chat_message?,
-      can_moderate: scope.can_moderate_chat?(object.chat_channel.chatable)
+      can_moderate: scope.can_moderate_chat?(object.chat_channel.chatable),
+      can_delete_self: scope.can_delete_own_chats?(object.chat_channel.chatable),
+      can_delete_others: scope.can_delete_other_chats?(object.chat_channel.chatable),
     }
     meta_hash[:can_load_more_past] = object.can_load_more_past unless object.can_load_more_past.nil?
     meta_hash[:can_load_more_future] = object.can_load_more_future unless object.can_load_more_future.nil?

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -295,8 +295,8 @@ export default Component.extend({
       details: {
         chat_channel_id: this.chatChannel.id,
         chatable_type: this.chatChannel.chatable_type,
-        can_delete_self: true,
-        can_delete_others: this.currentUser.staff,
+        can_delete_self: messages.resultSetMeta.can_delete_self,
+        can_delete_others: messages.resultSetMeta.can_delete_others,
         can_flag: messages.resultSetMeta.can_flag,
         user_silenced: messages.resultSetMeta.user_silenced,
         can_moderate: messages.resultSetMeta.can_moderate,

--- a/assets/javascripts/discourse/components/chat-selection-manager.js
+++ b/assets/javascripts/discourse/components/chat-selection-manager.js
@@ -16,6 +16,7 @@ export default class AdminCustomizeColorsShowController extends Component {
   selectedMessageIds = null;
   showChatQuoteSuccess = false;
   cancelSelecting = null;
+  canModerate = false;
 
   @service router;
 
@@ -24,9 +25,9 @@ export default class AdminCustomizeColorsShowController extends Component {
     return this.selectedMessageIds.length > 0;
   }
 
-  @computed("chatChannel.isDirectMessageChannel")
+  @computed("chatChannel.isDirectMessageChannel", "canModerate")
   get showMoveMessageButton() {
-    return this.currentUser.staff && !this.chatChannel.isDirectMessageChannel;
+    return !this.chatChannel.isDirectMessageChannel && this.canModerate;
   }
 
   @action

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -85,6 +85,7 @@
     {{chat-selection-manager
       selectedMessageIds=selectedMessageIds
       chatChannel=chatChannel
+      canModerate=details.can_moderate
       cancelSelecting=(action "cancelSelecting")}}
   {{else}}
     {{chat-composer

--- a/lib/guardian_extensions.rb
+++ b/lib/guardian_extensions.rb
@@ -2,9 +2,14 @@
 
 module DiscourseChat::GuardianExtensions
   def can_moderate_chat?(chatable)
-    chatable.class.name == "Topic" ?
-      can_perform_action_available_to_group_moderators?(chatable) :
+    case chatable.class.name
+    when "Topic"
+      can_perform_action_available_to_group_moderators?(chatable)
+    when "Category"
+      is_staff? || is_category_group_moderator?(chatable)
+    else
       is_staff?
+    end
   end
 
   def can_chat?(user)
@@ -38,8 +43,8 @@ module DiscourseChat::GuardianExtensions
     is_staff?
   end
 
-  def can_move_chat_messages?
-    is_staff?
+  def can_move_chat_messages?(channel)
+    can_moderate_chat?(channel.chatable)
   end
 
   def can_create_channel_message?(chat_channel)

--- a/spec/lib/guardian_extensions_spec.rb
+++ b/spec/lib/guardian_extensions_spec.rb
@@ -153,7 +153,7 @@ describe DiscourseChat::GuardianExtensions do
 
           it "returns true if the regular user is part of the reviewable_by_group for the category" do
             mods = Fabricate(:group)
-            GroupUser.create(user: user, group: mods)
+            mods.add(user)
             category.update!(reviewable_by_group: mods)
             expect(staff_guardian.can_moderate_chat?(channel.chatable)).to eq(true)
             expect(guardian.can_moderate_chat?(channel.chatable)).to eq(true)

--- a/spec/lib/guardian_extensions_spec.rb
+++ b/spec/lib/guardian_extensions_spec.rb
@@ -147,6 +147,18 @@ describe DiscourseChat::GuardianExtensions do
           expect(staff_guardian.can_moderate_chat?(channel.chatable)).to eq(true)
           expect(guardian.can_moderate_chat?(channel.chatable)).to eq(false)
         end
+
+        context "when enable_category_group_moderation is true" do
+          before { SiteSetting.enable_category_group_moderation = true }
+
+          it "returns true if the regular user is part of the reviewable_by_group for the category" do
+            mods = Fabricate(:group)
+            GroupUser.create(user: user, group: mods)
+            category.update!(reviewable_by_group: mods)
+            expect(staff_guardian.can_moderate_chat?(channel.chatable)).to eq(true)
+            expect(guardian.can_moderate_chat?(channel.chatable)).to eq(true)
+          end
+        end
       end
 
       context "for DM channel" do

--- a/test/javascripts/acceptance/archive-channel-test.js
+++ b/test/javascripts/acceptance/archive-channel-test.js
@@ -3,11 +3,12 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import {
   allChannels,
   chatChannels,
-  chatView,
+  generateChatView,
 } from "discourse/plugins/discourse-chat/chat-fixtures";
 import {
   acceptance,
   exists,
+  loggedInUser,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
@@ -15,12 +16,14 @@ import { test } from "qunit";
 
 const baseChatPretenders = (server, helper) => {
   server.get("/chat/:chatChannelId/messages.json", () =>
-    helper.response(chatView)
+    helper.response(generateChatView(loggedInUser()))
   );
   server.post("/chat/:chatChannelId.json", () => {
     return helper.response({ success: "OK" });
   });
-  server.get("/chat/lookup/:messageId.json", () => helper.response(chatView));
+  server.get("/chat/lookup/:messageId.json", () =>
+    helper.response(generateChatView(loggedInUser()))
+  );
   server.post("/uploads/lookup-urls", () => {
     return helper.response([]);
   });

--- a/test/javascripts/acceptance/chat-flagging-test.js
+++ b/test/javascripts/acceptance/chat-flagging-test.js
@@ -43,7 +43,6 @@ acceptance("Discourse Chat - Flagging test", function (needs) {
     server.get("/chat/9/messages.json", () => {
       return helper.response(
         generateChatView(loggedInUser(), {
-          user_silenced: false,
           can_flag: false,
         })
       );

--- a/test/javascripts/acceptance/chat-flagging-test.js
+++ b/test/javascripts/acceptance/chat-flagging-test.js
@@ -12,7 +12,6 @@ import {
 } from "discourse/plugins/discourse-chat/chat-fixtures";
 import { test } from "qunit";
 import { click, settled, visit } from "@ember/test-helpers";
-import { cloneJSON } from "discourse-common/lib/object";
 import { isLegacyEmber } from "discourse-common/config/environment";
 import { next } from "@ember/runloop";
 import { Promise } from "rsvp";

--- a/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
+++ b/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
@@ -2,6 +2,7 @@ import showModal from "discourse/lib/show-modal";
 import {
   acceptance,
   exists,
+  loggedInUser,
   query,
   queryAll,
   updateCurrentUser,
@@ -18,7 +19,7 @@ import {
 } from "@ember/test-helpers";
 import {
   chatChannels,
-  chatView,
+  generateChatView,
 } from "discourse/plugins/discourse-chat/chat-fixtures";
 import ChatChannel from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 import { test } from "qunit";
@@ -39,7 +40,7 @@ if (!isLegacyEmber()) {
         helper.response(chatChannels)
       );
       server.get("/chat/:chatChannelId/messages.json", () =>
-        helper.response(chatView)
+        helper.response(generateChatView(loggedInUser()))
       );
       server.post("/uploads/lookup-urls", () => {
         return helper.response([]);

--- a/test/javascripts/acceptance/chat-move-message-to-channel-test.js
+++ b/test/javascripts/acceptance/chat-move-message-to-channel-test.js
@@ -1,5 +1,4 @@
 import { test } from "qunit";
-import { cloneJSON } from "discourse-common/lib/object";
 import { click, currentURL, visit } from "@ember/test-helpers";
 import {
   acceptance,

--- a/test/javascripts/acceptance/chat-quoting-test.js
+++ b/test/javascripts/acceptance/chat-quoting-test.js
@@ -4,12 +4,13 @@ import { click, currentURL, tap, visit } from "@ember/test-helpers";
 import {
   acceptance,
   exists,
+  loggedInUser,
   query,
   visible,
 } from "discourse/tests/helpers/qunit-helpers";
 import {
   chatChannels,
-  chatView,
+  generateChatView,
 } from "discourse/plugins/discourse-chat/chat-fixtures";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
@@ -24,7 +25,7 @@ function setupPretenders(server, helper) {
   server.post(`/chat/4/quote.json`, () => helper.response(quoteResponse));
   server.post(`/chat/7/quote.json`, () => helper.response(quoteResponse));
   server.get("/chat/:chat_channel_id/messages.json", () =>
-    helper.response(chatView)
+    helper.response(generateChatView(loggedInUser()))
   );
   server.post("/uploads/lookup-urls", () => {
     return helper.response([]);

--- a/test/javascripts/acceptance/chat-status-test.js
+++ b/test/javascripts/acceptance/chat-status-test.js
@@ -4,11 +4,12 @@ import { cloneJSON } from "discourse-common/lib/object";
 import {
   allChannels,
   chatChannels,
-  chatView,
+  generateChatView,
 } from "discourse/plugins/discourse-chat/chat-fixtures";
 import {
   acceptance,
   exists,
+  loggedInUser,
   publishToMessageBus,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
@@ -17,12 +18,14 @@ import { test } from "qunit";
 
 const baseChatPretenders = (server, helper) => {
   server.get("/chat/:chatChannelId/messages.json", () =>
-    helper.response(chatView)
+    helper.response(generateChatView(loggedInUser()))
   );
   server.post("/chat/:chatChannelId.json", () => {
     return helper.response({ success: "OK" });
   });
-  server.get("/chat/lookup/:messageId.json", () => helper.response(chatView));
+  server.get("/chat/lookup/:messageId.json", () =>
+    helper.response(generateChatView(loggedInUser()))
+  );
   server.post("/uploads/lookup-urls", () => {
     return helper.response([]);
   });

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -21,8 +21,8 @@ import { test } from "qunit";
 import {
   allChannels,
   chatChannels,
-  generateChatView,
   directMessageChannels,
+  generateChatView,
   messageContents,
   siteChannel,
 } from "discourse/plugins/discourse-chat/chat-fixtures";

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -21,7 +21,7 @@ import { test } from "qunit";
 import {
   allChannels,
   chatChannels,
-  chatView,
+  generateChatView,
   directMessageChannels,
   messageContents,
   siteChannel,
@@ -57,7 +57,7 @@ const chatSettled = async () => {
 
 const baseChatPretenders = (server, helper) => {
   server.get("/chat/:chatChannelId/messages.json", () =>
-    helper.response(chatView)
+    helper.response(generateChatView(loggedInUser()))
   );
   server.post("/chat/:chatChannelId.json", () => {
     return helper.response({ success: "OK" });
@@ -126,7 +126,9 @@ const baseChatPretenders = (server, helper) => {
       seen_notification_id: null,
     });
   });
-  server.get("/chat/lookup/:messageId.json", () => helper.response(chatView));
+  server.get("/chat/lookup/:messageId.json", () =>
+    helper.response(generateChatView(loggedInUser()))
+  );
   server.post("/uploads/lookup-urls", () => {
     return helper.response([]);
   });
@@ -1675,11 +1677,6 @@ acceptance(
     needs.pretender((server, helper) => {
       baseChatPretenders(server, helper);
       chatChannelPretender(server, helper);
-      server.get("/chat/7/messages.json", () => {
-        const cloned = cloneJSON(chatView);
-        cloned.meta.status = CHANNEL_STATUSES.readOnly;
-        return helper.response(cloned);
-      });
       server.get("/chat/chat_channels.json", () => {
         const cloned = cloneJSON(chatChannels);
         cloned.public_channels.find((chan) => chan.id === 7).status =
@@ -1731,11 +1728,6 @@ acceptance(
     needs.pretender((server, helper) => {
       baseChatPretenders(server, helper);
       chatChannelPretender(server, helper);
-      server.get("/chat/7/messages.json", () => {
-        const cloned = cloneJSON(chatView);
-        cloned.meta.status = CHANNEL_STATUSES.closed;
-        return helper.response(cloned);
-      });
       server.get("/chat/chat_channels.json", () => {
         const cloned = cloneJSON(chatChannels);
         cloned.public_channels.find((chan) => chan.id === 7).status =
@@ -1787,11 +1779,6 @@ acceptance(
     needs.pretender((server, helper) => {
       baseChatPretenders(server, helper);
       chatChannelPretender(server, helper);
-      server.get("/chat/7/messages.json", () => {
-        const cloned = cloneJSON(chatView);
-        cloned.meta.status = CHANNEL_STATUSES.closed;
-        return helper.response(cloned);
-      });
       server.get("/chat/chat_channels.json", () => {
         const cloned = cloneJSON(chatChannels);
         cloned.public_channels.find((chan) => chan.id === 7).status =
@@ -1809,11 +1796,20 @@ acceptance(
       await visit("/chat/channel/7/Uncategorized");
       const dropdown = selectKit(".chat-message-container .more-buttons");
       await dropdown.expand();
-      assert.ok(exists(".select-kit-row[data-value='edit']"));
-      assert.ok(exists(".select-kit-row[data-value='deleteMessage']"));
-      assert.ok(exists(".select-kit-row[data-value='rebakeMessage']"));
-      assert.ok(exists(".reply-btn"));
-      assert.ok(exists(".react-btn"));
+      assert.ok(
+        exists(".select-kit-row[data-value='edit']"),
+        "the edit message button is shown"
+      );
+      assert.ok(
+        exists(".select-kit-row[data-value='deleteMessage']"),
+        "the delete message button is shown"
+      );
+      assert.ok(
+        exists(".select-kit-row[data-value='rebakeMessage']"),
+        "the rebake message button is shown"
+      );
+      assert.ok(exists(".reply-btn", "the reply button is shown"));
+      assert.ok(exists(".react-btn"), "the react button is shown");
     });
   }
 );
@@ -1833,11 +1829,6 @@ acceptance("Discourse Chat - Channel Replying Indicator", function (needs) {
   needs.pretender((server, helper) => {
     baseChatPretenders(server, helper);
     chatChannelPretender(server, helper);
-    server.get("/chat/7/messages.json", () => {
-      const cloned = cloneJSON(chatView);
-      cloned.meta.status = CHANNEL_STATUSES.closed;
-      return helper.response(cloned);
-    });
     server.get("/chat/chat_channels.json", () => {
       const cloned = cloneJSON(chatChannels);
       cloned.public_channels.find((chan) => chan.id === 7).status =

--- a/test/javascripts/acceptance/close-open-channel-test.js
+++ b/test/javascripts/acceptance/close-open-channel-test.js
@@ -2,11 +2,12 @@ import { click, visit } from "@ember/test-helpers";
 import {
   allChannels,
   chatChannels,
-  chatView,
+  generateChatView,
 } from "discourse/plugins/discourse-chat/chat-fixtures";
 import {
   acceptance,
   exists,
+  loggedInUser,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
@@ -14,12 +15,14 @@ import { test } from "qunit";
 
 const baseChatPretenders = (server, helper) => {
   server.get("/chat/:chatChannelId/messages.json", () =>
-    helper.response(chatView)
+    helper.response(generateChatView(loggedInUser()))
   );
   server.post("/chat/:chatChannelId.json", () => {
     return helper.response({ success: "OK" });
   });
-  server.get("/chat/lookup/:messageId.json", () => helper.response(chatView));
+  server.get("/chat/lookup/:messageId.json", () =>
+    helper.response(generateChatView(loggedInUser()))
+  );
   server.post("/uploads/lookup-urls", () => {
     return helper.response([]);
   });

--- a/test/javascripts/acceptance/delete-channel-test.js
+++ b/test/javascripts/acceptance/delete-channel-test.js
@@ -2,23 +2,26 @@ import { click, fillIn, visit } from "@ember/test-helpers";
 import {
   allChannels,
   chatChannels,
-  chatView,
+  generateChatView,
 } from "discourse/plugins/discourse-chat/chat-fixtures";
 import {
   acceptance,
   exists,
+  loggedInUser,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 
 const baseChatPretenders = (server, helper) => {
   server.get("/chat/:chatChannelId/messages.json", () =>
-    helper.response(chatView)
+    helper.response(generateChatView(loggedInUser()))
   );
   server.post("/chat/:chatChannelId.json", () => {
     return helper.response({ success: "OK" });
   });
-  server.get("/chat/lookup/:messageId.json", () => helper.response(chatView));
+  server.get("/chat/lookup/:messageId.json", () =>
+    helper.response(generateChatView(loggedInUser()))
+  );
   server.post("/uploads/lookup-urls", () => {
     return helper.response([]);
   });

--- a/test/javascripts/acceptance/user-card-chat-test.js
+++ b/test/javascripts/acceptance/user-card-chat-test.js
@@ -10,8 +10,8 @@ import {
 import { click, settled, visit } from "@ember/test-helpers";
 import {
   chatChannels,
-  generateChatView,
   directMessageChannels,
+  generateChatView,
 } from "discourse/plugins/discourse-chat/chat-fixtures";
 import { test } from "qunit";
 import { isLegacyEmber } from "discourse-common/config/environment";

--- a/test/javascripts/acceptance/user-card-chat-test.js
+++ b/test/javascripts/acceptance/user-card-chat-test.js
@@ -3,13 +3,14 @@ import { cloneJSON } from "discourse-common/lib/object";
 import {
   acceptance,
   exists,
+  loggedInUser,
   query,
   visible,
 } from "discourse/tests/helpers/qunit-helpers";
 import { click, settled, visit } from "@ember/test-helpers";
 import {
   chatChannels,
-  chatView,
+  generateChatView,
   directMessageChannels,
 } from "discourse/plugins/discourse-chat/chat-fixtures";
 import { test } from "qunit";
@@ -36,7 +37,7 @@ if (!isLegacyEmber()) {
         helper.response(helper.response(directMessageChannels[0]))
       );
       server.get("/chat/:chatChannelId/messages.json", () =>
-        helper.response(chatView)
+        helper.response(generateChatView(loggedInUser()))
       );
       server.post("/chat/direct_messages/create.json", () => {
         return helper.response({

--- a/test/javascripts/chat-fixtures.js
+++ b/test/javascripts/chat-fixtures.js
@@ -244,6 +244,7 @@ export const chatView = {
     can_flag: true,
     channel_status: "open",
     user_silenced: false,
+    can_moderate: false,
   },
   chat_messages: [message0, message1, message2, message3],
 };

--- a/test/javascripts/chat-fixtures.js
+++ b/test/javascripts/chat-fixtures.js
@@ -1,4 +1,5 @@
-import { cloneJSON } from "discourse-common/lib/object";
+import { cloneJSON, deepMerge } from "discourse-common/lib/object";
+import { CHANNEL_STATUSES } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 export const messageContents = ["Hello world", "What up", "heyo!"];
 export const siteChannel = {
   chat_channel: {
@@ -239,12 +240,23 @@ const message3 = {
   },
 };
 
-export const chatView = {
-  meta: {
+export function generateChatView(
+  loggedInUser,
+  metaOverrides = {},
+  channelOverrides = {}
+) {
+  const metaDefaults = {
     can_flag: true,
-    channel_status: "open",
     user_silenced: false,
-    can_moderate: false,
-  },
-  chat_messages: [message0, message1, message2, message3],
-};
+    can_moderate: loggedInUser.staff,
+    can_delete_self: true,
+    can_delete_others: loggedInUser.staff,
+  };
+  const channelData = deepMerge(
+    { status: CHANNEL_STATUSES.open },
+    channelOverrides
+  );
+  channelData.meta = deepMerge(metaDefaults, metaOverrides);
+  channelData.chat_messages = [message0, message1, message2, message3];
+  return channelData;
+}

--- a/test/javascripts/chat-fixtures.js
+++ b/test/javascripts/chat-fixtures.js
@@ -1,5 +1,4 @@
 import { cloneJSON, deepMerge } from "discourse-common/lib/object";
-import { CHANNEL_STATUSES } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 export const messageContents = ["Hello world", "What up", "heyo!"];
 export const siteChannel = {
   chat_channel: {
@@ -240,11 +239,7 @@ const message3 = {
   },
 };
 
-export function generateChatView(
-  loggedInUser,
-  metaOverrides = {},
-  channelOverrides = {}
-) {
+export function generateChatView(loggedInUser, metaOverrides = {}) {
   const metaDefaults = {
     can_flag: true,
     user_silenced: false,
@@ -252,11 +247,8 @@ export function generateChatView(
     can_delete_self: true,
     can_delete_others: loggedInUser.staff,
   };
-  const channelData = deepMerge(
-    { status: CHANNEL_STATUSES.open },
-    channelOverrides
-  );
-  channelData.meta = deepMerge(metaDefaults, metaOverrides);
-  channelData.chat_messages = [message0, message1, message2, message3];
-  return channelData;
+  return {
+    meta: deepMerge(metaDefaults, metaOverrides),
+    chat_messages: [message0, message1, message2, message3],
+  };
 }

--- a/test/javascripts/components/chat-message-test.js
+++ b/test/javascripts/components/chat-message-test.js
@@ -56,8 +56,6 @@ discourseModule("Discourse Chat | Component | chat-message", function (hooks) {
         }),
         canInteractWithChat: true,
         details: {
-          chat_channel_id: chatChannel.id,
-          chatable_type: chatChannel.chatable_type,
           can_delete_self: true,
           can_delete_others: true,
           can_flag: true,


### PR DESCRIPTION
This allows category group moderators to moderate chat
channels via the `guardian.can_moderate_chat?` extension.
Practically this now allows category moderators to do
the following on category channels:

* Move messages to another channel
* Delete/restore/and see deleted chat messages

It also fixes some inconsistency with `can_delete_self` and
`can_delete_others`, which we had guardian methods for
and meta/details hash to attach the result to, but we were
setting a hardcoded result in the JS code.

Doing this necessitated introducing a dynamic `generateChatView`
function for the chat fixtures, because what is in these meta properties
is dependent on the current user. Tests were updated to use this
new function instead of the static `chatView`.