### PR TITLE
FEATURE: Chat notification emails

### DIFF
--- a/app/jobs/scheduled/email_chat_notifications.rb
+++ b/app/jobs/scheduled/email_chat_notifications.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Jobs
+  class EmailChatNotifications < ::Jobs::Scheduled
+    every 15.minutes
+
+    def execute(args = {})
+      return unless SiteSetting.chat_enabled
+
+      DiscourseChat::ChatMailer.send_unread_mentions_summary
+    end
+  end
+end

--- a/app/jobs/scheduled/email_chat_notifications.rb
+++ b/app/jobs/scheduled/email_chat_notifications.rb
@@ -2,7 +2,7 @@
 
 module Jobs
   class EmailChatNotifications < ::Jobs::Scheduled
-    every 15.minutes
+    every 5.minutes
 
     def execute(args = {})
       return unless SiteSetting.chat_enabled

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -122,6 +122,21 @@ class ChatChannel < ActiveRecord::Base
     end
   end
 
+  def email_title(user)
+    if direct_message_channel?
+      usernames = (chatable.users.map(&:username) - [user.username]).map { |username| "@#{username}" }
+      if usernames.count > 5
+        return I18n.t("chat.channel.title_for_large_group_dm", users: usernames.take(5).join(", "), count: usernames.count - 5)
+      end
+
+      if usernames.count > 1
+        return usernames.join(", ")
+      end
+    end
+
+    title(user)
+  end
+
   def change_status(acting_user, target_status)
     return if !ChatChannel.statuses.include?(target_status.to_s)
     return if !Guardian.new(acting_user).can_change_channel_status?(self, target_status)

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -122,21 +122,6 @@ class ChatChannel < ActiveRecord::Base
     end
   end
 
-  def email_title(user)
-    if direct_message_channel?
-      usernames = (chatable.users.map(&:username) - [user.username]).map { |username| "@#{username}" }
-      if usernames.count > 5
-        return I18n.t("chat.channel.title_for_large_group_dm", users: usernames.take(5).join(", "), count: usernames.count - 5)
-      end
-
-      if usernames.count > 1
-        return usernames.join(", ")
-      end
-    end
-
-    title(user)
-  end
-
   def change_status(acting_user, target_status)
     return if !ChatChannel.statuses.include?(target_status.to_s)
     return if !Guardian.new(acting_user).can_change_channel_status?(self, target_status)

--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -68,7 +68,11 @@ class ChatMessage < ActiveRecord::Base
     return uploads.first.original_filename if cooked.blank? && uploads.present?
 
     # this may return blank for some complex things like quotes, that is acceptable
-    PrettyText.excerpt(cooked, 50)
+    PrettyText.excerpt(cooked, 50, {})
+  end
+
+  def cooked_for_excerpt
+    (cooked.blank? && uploads.present?) ? "<p>#{uploads.first.original_filename}</p>" : cooked
   end
 
   def push_notification_excerpt

--- a/app/models/direct_message_channel.rb
+++ b/app/models/direct_message_channel.rb
@@ -17,7 +17,7 @@ class DirectMessageChannel < ActiveRecord::Base
     # all users deleted
     return chat_channel.id if !users.first
 
-    usernames_formatted = users.map { |u| "@#{u.username}" }
+    usernames_formatted = users.sort_by(&:username).map { |u| "@#{u.username}" }
     if usernames_formatted.size > 5
       return I18n.t(
         "chat.channel.dm_title.multi_user_truncated",

--- a/app/models/user_chat_channel_membership.rb
+++ b/app/models/user_chat_channel_membership.rb
@@ -38,16 +38,17 @@ end
 #
 # Table name: user_chat_channel_memberships
 #
-#  id                         :bigint           not null, primary key
-#  user_id                    :integer          not null
-#  chat_channel_id            :integer          not null
-#  last_read_message_id       :integer
-#  following                  :boolean          default(FALSE), not null
-#  muted                      :boolean          default(FALSE), not null
-#  desktop_notification_level :integer          default("mention"), not null
-#  mobile_notification_level  :integer          default("mention"), not null
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
+#  id                                :bigint           not null, primary key
+#  user_id                           :integer          not null
+#  chat_channel_id                   :integer          not null
+#  last_read_message_id              :integer
+#  following                         :boolean          default(FALSE), not null
+#  muted                             :boolean          default(FALSE), not null
+#  desktop_notification_level        :integer          default("mention"), not null
+#  mobile_notification_level         :integer          default("mention"), not null
+#  created_at                        :datetime         not null
+#  updated_at                        :datetime         not null
+#  last_read_message_when_emailed_id :integer
 #
 # Indexes
 #

--- a/app/views/user_notifications/chat_summary.html.erb
+++ b/app/views/user_notifications/chat_summary.html.erb
@@ -26,7 +26,7 @@
       <tbody>
         <tr>
           <td colspan="100%">
-            <h5 style="margin:0.5em 0 0.5em 0;font-size:0.9em;"><%= chat_channel.email_title(@user) %></h5>
+            <h5 style="margin:0.5em 0 0.5em 0;font-size:0.9em;"><%= chat_channel.title(@user) %></h5>
           </td>
         </tr>
         <%- messages.take(2).each do |chat_message| %>

--- a/app/views/user_notifications/chat_summary.html.erb
+++ b/app/views/user_notifications/chat_summary.html.erb
@@ -50,7 +50,7 @@
         <%- end %>
         <tr>
           <td colspan="100%" style="padding:<%= rtl? ? '2em 2em 0 0' : '2em 0 0 2em' %>">
-            <a class="more-messages-link" href="<%= chat_channel.url %>">
+            <a class="more-messages-link" href="<%= messages.first.url %>">
               <%- if other_messages_count <= 0 %>
                 <%= I18n.t("user_notifications.chat_summary.view_messages", count: messages.size)%>
               <%- else %>
@@ -69,8 +69,7 @@
     <td align="center">
       <%= raw(t 'user_notifications.chat_summary.unsubscribe',
               site_link: html_site_link,
-              email_preferences_link: link_to(t('user_notifications.chat_summary.your_chat_settings'), Discourse.base_url + '/my/preferences/chat')
-          )  
+              email_preferences_link: link_to(t('user_notifications.chat_summary.your_chat_settings'), Discourse.base_url + '/my/preferences/chat'))  
       %>
     </td>
   </tr>

--- a/app/views/user_notifications/chat_summary.html.erb
+++ b/app/views/user_notifications/chat_summary.html.erb
@@ -69,8 +69,7 @@
     <td align="center">
       <%= raw(t 'user_notifications.chat_summary.unsubscribe',
               site_link: html_site_link,
-              email_preferences_link: link_to(t('user_notifications.chat_summary.your_chat_settings'), Discourse.base_url + '/my/preferences/chat'),
-              unsubscribe_link: link_to(t('user_notifications.digest.click_here'), "#{Discourse.base_url}/email/unsubscribe/#{@unsubscribe_key}")
+              email_preferences_link: link_to(t('user_notifications.chat_summary.your_chat_settings'), Discourse.base_url + '/my/preferences/chat')
           )  
       %>
     </td>

--- a/app/views/user_notifications/chat_summary.html.erb
+++ b/app/views/user_notifications/chat_summary.html.erb
@@ -1,0 +1,78 @@
+<div class="summary-email">
+  <table class="chat-summary-header text-header with-dir" style="background-color:#<%= @header_bgcolor -%>;width:100%;min-width:100%;">
+    <tr>
+      <td align="center" style="text-align: center;padding: 20px 0; font-family:Arial,sans-serif;">
+
+        <a href="<%= Discourse.base_url %>" style="color:#<%= @header_color -%>;font-size:22px;text-decoration:none;">
+          <%- if logo_url.blank? %>
+            <%= SiteSetting.title %>
+          <%- else %>
+            <img src="<%= logo_url %>" height="40" style="clear:both;display:block;height:40px;margin:auto;max-width:100%;outline:0;text-decoration:none;" alt="<%= SiteSetting.title %>">
+          <%- end %>
+        </a>
+
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="font-weight:bold;font-size:22px;color:#0a0a0a">
+        <%= I18n.t("user_notifications.chat_summary.description", count: @messages.size) %>
+      </td>
+    </tr>
+  </table>
+
+  <%- @grouped_mentions.each do |chat_channel, messages| %>
+    <%- other_messages_count = messages.size - 2 %>
+    <table class="chat-summary-content" style="padding:1em;margin-top:20px;width:100%;min-width:100%;background-color:#f7f7f7;">
+      <tbody>
+        <tr>
+          <td colspan="100%">
+            <h5 style="margin:0.5em 0 0.5em 0;font-size:0.9em;"><%= chat_channel.email_title(@user) %></h5>
+          </td>
+        </tr>
+        <%- messages.take(2).each do |chat_message| %>
+          <%- sender = chat_message.user %>
+          <%- sender_name = @display_usernames ? sender.username : sender.name %>
+
+          <tr class="message-row">
+            <td style="white-space:nowrap;vertical-align:top;padding:<%= rtl? ? '1em 2em 0 0' : '1em 0 0 2em' %>">
+              <img src="<%= sender.small_avatar_url -%>" style="height:20px;width:20px;margin:<%= rtl? ? '0 0 5px 0' : '0 5px 0 0' %>;border-radius:50%;clear:both;display:inline-block;outline:0;text-decoration:none;vertical-align:top;" alt="<%= sender_name -%>">
+              <span style="display:inline-block;color:#0a0a0a;vertical-align:top;font-weight:bold;">
+                <%= sender_name -%>
+              </span>
+              <span style="display:inline-block;color:#0a0a0a;font-size:0.8em;">
+                <%= I18n.l(@user_tz.to_local(chat_message.created_at), format: :long) -%>
+              </span>
+            </td>
+            <td style="width:99%;margin:0;padding:<%= rtl? ? '0 2em 0 0' : '0 0 0 2em' %>;vertical-align:top;">
+              <%= email_excerpt(chat_message.cooked_for_excerpt) %>
+            </td>
+          </tr>
+        <%- end %>
+        <tr>
+          <td colspan="100%" style="padding:<%= rtl? ? '2em 2em 0 0' : '2em 0 0 2em' %>">
+            <a class="more-messages-link" href="<%= chat_channel.url %>">
+              <%- if other_messages_count <= 0 %>
+                <%= I18n.t("user_notifications.chat_summary.view_messages", count: messages.size)%>
+              <%- else %>
+                <%= I18n.t("user_notifications.chat_summary.view_more", count: other_messages_count)%>
+              <%- end %>
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  <%- end %>
+</div>
+
+<table class='summary-footer with-dir' style="margin-top:2em;width:100%">
+  <tr>
+    <td align="center">
+      <%= raw(t 'user_notifications.chat_summary.unsubscribe',
+              site_link: html_site_link,
+              email_preferences_link: link_to(t('user_notifications.chat_summary.your_chat_settings'), Discourse.base_url + '/my/preferences/chat'),
+              unsubscribe_link: link_to(t('user_notifications.digest.click_here'), "#{Discourse.base_url}/email/unsubscribe/#{@unsubscribe_key}")
+          )  
+      %>
+    </td>
+  </tr>
+</table>

--- a/app/views/user_notifications/chat_summary.text.erb
+++ b/app/views/user_notifications/chat_summary.text.erb
@@ -1,0 +1,8 @@
+<%- site_link = raw(@markdown_linker.create(@site_name, '/')) %>
+<%= t('user_notifications.chat_summary.description', count: @messages.size,) %>
+<%= raw(@markdown_linker.create(t("user_notifications.chat_summary.view_messages", count: @messages.size), "/chat")) %>
+<%=raw(t :'user_notifications.chat_summary.unsubscribe',
+       site_link: site_link,
+       email_preferences_link: @markdown_linker.create(t('user_notifications.chat_summary.your_chat_settings'), Discourse.base_url + '/my/preferences/chat'),
+       unsubscribe_link: @markdown_linker.create(t('user_notifications.digest.click_here'), "#{Discourse.base_url}/email/unsubscribe/#{@unsubscribe_key}"))  %>
+<%= raw(@markdown_linker.references) %>

--- a/app/views/user_notifications/chat_summary.text.erb
+++ b/app/views/user_notifications/chat_summary.text.erb
@@ -1,8 +1,8 @@
 <%- site_link = raw(@markdown_linker.create(@site_name, '/')) %>
 <%= t('user_notifications.chat_summary.description', count: @messages.size,) %>
 <%= raw(@markdown_linker.create(t("user_notifications.chat_summary.view_messages", count: @messages.size), "/chat")) %>
-<%=raw(t :'user_notifications.chat_summary.unsubscribe',
+<%= raw(t :'user_notifications.chat_summary.unsubscribe',
        site_link: site_link,
-       email_preferences_link: @markdown_linker.create(t('user_notifications.chat_summary.your_chat_settings'), Discourse.base_url + '/my/preferences/chat'),
-       unsubscribe_link: @markdown_linker.create(t('user_notifications.digest.click_here'), "#{Discourse.base_url}/email/unsubscribe/#{@unsubscribe_key}"))  %>
+       email_preferences_link: @markdown_linker.create(t('user_notifications.chat_summary.your_chat_settings'), Discourse.base_url + '/my/preferences/chat'))
+%>
 <%= raw(@markdown_linker.references) %>

--- a/assets/javascripts/discourse/controllers/preferences-chat.js
+++ b/assets/javascripts/discourse/controllers/preferences-chat.js
@@ -12,9 +12,20 @@ const chatAttrs = [
   "only_chat_push_notifications",
   "ignore_channel_wide_mention",
   "chat_sound",
+  "chat_email_frequency",
+];
+
+const emailFrequencyOptions = [
+  { name: I18n.t(`chat.email_frequency.never`), value: "never" },
+  { name: I18n.t(`chat.email_frequency.when_away`), value: "when_away" },
 ];
 
 export default Controller.extend({
+  init() {
+    this._super(...arguments);
+    this.set("emailFrequencyOptions", emailFrequencyOptions);
+  },
+
   @discourseComputed
   chatSounds() {
     return Object.keys(CHAT_SOUNDS).map((value) => {

--- a/assets/javascripts/discourse/controllers/preferences-chat.js
+++ b/assets/javascripts/discourse/controllers/preferences-chat.js
@@ -6,7 +6,7 @@ import { action } from "@ember/object";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { CHAT_SOUNDS } from "discourse/plugins/discourse-chat/discourse/initializers/chat-notification-sounds";
 
-const chatAttrs = [
+const CHAT_ATTRS = [
   "chat_enabled",
   "chat_isolated",
   "only_chat_push_notifications",
@@ -15,7 +15,7 @@ const chatAttrs = [
   "chat_email_frequency",
 ];
 
-const emailFrequencyOptions = [
+const EMAIL_FREQUENCY_OPTIONS = [
   { name: I18n.t(`chat.email_frequency.never`), value: "never" },
   { name: I18n.t(`chat.email_frequency.when_away`), value: "when_away" },
 ];
@@ -23,7 +23,7 @@ const emailFrequencyOptions = [
 export default Controller.extend({
   init() {
     this._super(...arguments);
-    this.set("emailFrequencyOptions", emailFrequencyOptions);
+    this.set("emailFrequencyOptions", EMAIL_FREQUENCY_OPTIONS);
   },
 
   @discourseComputed
@@ -46,7 +46,7 @@ export default Controller.extend({
   save() {
     this.set("saved", false);
     return this.model
-      .save(chatAttrs)
+      .save(CHAT_ATTRS)
       .then(() => {
         this.set("saved", true);
         if (!isTesting()) {

--- a/assets/javascripts/discourse/initializers/chat-user-options.js
+++ b/assets/javascripts/discourse/initializers/chat-user-options.js
@@ -5,6 +5,7 @@ const CHAT_ISOLATED_FIELD = "chat_isolated";
 const ONLY_CHAT_PUSH_NOTI_FIELD = "only_chat_push_notifications";
 const IGNORE_CHANNEL_WIDE_MENTION = "ignore_channel_wide_mention";
 const CHAT_SOUND = "chat_sound";
+const CHAT_EMAIL_FREQUENCY = "chat_email_frequency";
 
 export default {
   name: "chat-user-options",
@@ -18,6 +19,7 @@ export default {
         api.addSaveableUserOptionField(ONLY_CHAT_PUSH_NOTI_FIELD);
         api.addSaveableUserOptionField(IGNORE_CHANNEL_WIDE_MENTION);
         api.addSaveableUserOptionField(CHAT_SOUND);
+        api.addSaveableUserOptionField(CHAT_EMAIL_FREQUENCY);
       }
     });
   },

--- a/assets/javascripts/discourse/templates/preferences/chat.hbs
+++ b/assets/javascripts/discourse/templates/preferences/chat.hbs
@@ -59,4 +59,18 @@
   }}
 </div>
 
+<div class="control-group chat-setting controls-dropdown">
+  <label for="user_chat_email_frequency">{{i18n "chat.email_frequency.title"}}</label>
+  {{combo-box
+    valueProperty="value"
+    content=emailFrequencyOptions
+    value=model.user_option.chat_email_frequency
+    id="user_chat_email_frequency"
+    onChange=(action (mut model.user_option.chat_email_frequency))
+  }}
+  {{#if (eq model.user_option.chat_email_frequency "when_away")}}
+    <div class="control-instructions">{{i18n "chat.email_frequency.description"}}</div>
+  {{/if}}
+</div>
+
 {{save-controls id="user_chat_preference_save" model=model action=(action "save") saved=saved}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -71,7 +71,7 @@ en:
         start_direct_message: "You can also start a personal chat with one or more users."
         title: "Get started by joining a channel"
       email_frequency:
-        description: "We'll only email you if we haven't seen you in the last 10 minutes."
+        description: "We'll only email you if we haven't seen you in the last 15 minutes."
         never: "Never"
         title: "Email Notifications"
         when_away: "Only when away"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -70,6 +70,11 @@ en:
         public_available: "There are public channels available for you to follow."
         start_direct_message: "You can also start a personal chat with one or more users."
         title: "Get started by joining a channel"
+      email_frequency:
+        description: "We'll only email you if we haven't seen you in the last 10 minutes."
+        never: "Never"
+        title: "Email Notifications"
+        when_away: "Only when away"
       enable: "Enable chat"
       flag: "Flag"
       flagged: "This message has been flagged for review"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -127,7 +127,7 @@ en:
       subject:
         one: "[%{email_prefix}] New chat message"
         other: "[%{email_prefix}] New chat messages"
-      unsubscribe: "This chat summary is sent from %{site_link} when you are away. Change your %{email_preferences_link}, or %{unsubscribe_link} to unsubscribe."
+      unsubscribe: "This chat summary is sent from %{site_link} when you are away. Change your %{email_preferences_link}."
       view_messages:
         one: "View message"
         other: "View %{count} messages"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -116,3 +116,22 @@ en:
   reviewable_score_types:
     needs_review:
       title: "Needs Review"
+
+  user_notifications:
+    chat_summary:
+      deleted_user: "Deleted user"
+      description:
+        one: "You have a new chat message"
+        other: "You have new chat messages"
+      from: "%{site_name}"
+      subject:
+        one: "[%{email_prefix}] New chat message"
+        other: "[%{email_prefix}] New chat messages"
+      unsubscribe: "This chat summary is sent from %{site_link} when you are away. Change your %{email_preferences_link}, or %{unsubscribe_link} to unsubscribe."
+      view_messages:
+        one: "View message"
+        other: "View %{count} messages"
+      view_more:
+        one: "View %{count} more message"
+        other: "View %{count} more messages"
+      your_chat_settings: "chat email frequency preference"

--- a/db/migrate/20220518140004_track_last_unread_mention_when_emailed.rb
+++ b/db/migrate/20220518140004_track_last_unread_mention_when_emailed.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class TrackLastUnreadMentionWhenEmailed < ActiveRecord::Migration[7.0]
+  def change
+    add_column :user_chat_channel_memberships, :last_unread_mention_when_emailed_id, :integer
+  end
+end

--- a/db/post_migrate/20220516142658_remove_email_statuses_table.rb
+++ b/db/post_migrate/20220516142658_remove_email_statuses_table.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RemoveEmailStatusesTable < ActiveRecord::Migration[7.0]
+  def up
+    remove_index :chat_message_email_statuses, :status
+    remove_index :chat_message_email_statuses, [:user_id, :chat_message_id]
+
+    Migration::TableDropper.execute_drop("chat_message_email_statuses")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/post_migrate/20220518180642_remove_user_option_last_emailed_at.rb
+++ b/db/post_migrate/20220518180642_remove_user_option_last_emailed_at.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveUserOptionLastEmailedAt < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :user_options, :last_emailed_for_chat, :datetime
+  end
+end

--- a/lib/chat_mailer.rb
+++ b/lib/chat_mailer.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class DiscourseChat::ChatMailer
+  def send_unread_mentions_summary
+    return unless SiteSetting.chat_enabled
+
+    users.find_each do |user|
+      Jobs.enqueue(:user_email,
+        type: "chat_summary",
+        user_id: user.id,
+        force_respect_seen_recently: true
+      )
+
+      user.user_option.update(last_emailed_for_chat: Time.now)
+    end
+  end
+
+  def users
+    User
+      .distinct
+      .joins(:user_option)
+      .where(user_options: { chat_enabled: true, chat_email_frequency: UserOption.chat_email_frequencies[:when_away] })
+      .where('user_options.last_emailed_for_chat IS NULL OR user_options.last_emailed_for_chat < ?', 5.minutes.ago)
+      .not_suspended
+      .real
+      .joins(:groups)
+      .where(groups: { id: DiscourseChat.allowed_group_ids })
+      .joins('INNER JOIN user_chat_channel_memberships uccm ON uccm.user_id = users.id')
+      .joins('INNER JOIN chat_channels cc ON cc.id = uccm.chat_channel_id')
+      .joins('INNER JOIN chat_messages c_msg ON c_msg.chat_channel_id = uccm.chat_channel_id')
+      .joins('LEFT OUTER JOIN chat_mentions c_mentions ON c_mentions.chat_message_id = c_msg.id AND c_mentions.user_id = users.id')
+      .where(uccm: { following: true })
+      .where('c_msg.deleted_at IS NULL AND c_msg.user_id <> users.id')
+      .where(
+      <<~SQL
+        (c_mentions.id IS NOT NULL OR cc.chatable_type = 'DirectMessageChannel') AND
+        (uccm.last_read_message_id IS NULL OR c_msg.id > uccm.last_read_message_id)
+      SQL
+    )
+  end
+end

--- a/lib/chat_mailer.rb
+++ b/lib/chat_mailer.rb
@@ -28,9 +28,6 @@ class DiscourseChat::ChatMailer
     when_away_frequency = UserOption.chat_email_frequencies[:when_away]
     allowed_group_ids = DiscourseChat.allowed_group_ids
 
-    # If it's not the first time we send a summary, make sure the user read more messages
-    # since the last time we emailed them.
-
     User
       .select('users.id', 'ARRAY_AGG(ARRAY[uccm.id, c_msg.id]) AS memberships_with_unread_messages')
       .joins(:user_option)

--- a/lib/chat_mailer.rb
+++ b/lib/chat_mailer.rb
@@ -4,38 +4,53 @@ class DiscourseChat::ChatMailer
   def send_unread_mentions_summary
     return unless SiteSetting.chat_enabled
 
-    users.find_each do |user|
+    users_with_unprocessed_unread_mentions.find_each do |user|
+      # user#memberships_with_unread_messages is a nested array that looks like [[membership_id, unread_message_id]]
+      # Find the max unread id per membership.
+      membership_and_max_unread_mention_ids = user.memberships_with_unread_messages
+        .group_by { |memberships| memberships[0] }
+        .transform_values do |membership_and_msg_ids|
+          membership_and_msg_ids.max_by { |membership, msg| msg }
+        end.values
+
       Jobs.enqueue(:user_email,
         type: "chat_summary",
         user_id: user.id,
-        force_respect_seen_recently: true
+        force_respect_seen_recently: true,
+        memberships_to_update_data: membership_and_max_unread_mention_ids
       )
-
-      user.user_option.update(last_emailed_for_chat: Time.now)
     end
   end
 
-  def users
+  private
+
+  def users_with_unprocessed_unread_mentions
+    when_away_frequency = UserOption.chat_email_frequencies[:when_away]
+    allowed_group_ids = DiscourseChat.allowed_group_ids
+
+    # If it's not the first time we send a summary, make sure the user read more messages
+    # since the last time we emailed them.
+
     User
-      .distinct
+      .select('users.id', 'ARRAY_AGG(ARRAY[uccm.id, c_msg.id]) AS memberships_with_unread_messages')
       .joins(:user_option)
-      .where(user_options: { chat_enabled: true, chat_email_frequency: UserOption.chat_email_frequencies[:when_away] })
-      .where('user_options.last_emailed_for_chat IS NULL OR user_options.last_emailed_for_chat < ?', 5.minutes.ago)
-      .not_suspended
-      .real
+      .where(user_options: { chat_enabled: true, chat_email_frequency: when_away_frequency })
+      .where('users.last_seen_at < ?', 15.minutes.ago)
       .joins(:groups)
-      .where(groups: { id: DiscourseChat.allowed_group_ids })
+      .where(groups: { id: allowed_group_ids })
       .joins('INNER JOIN user_chat_channel_memberships uccm ON uccm.user_id = users.id')
       .joins('INNER JOIN chat_channels cc ON cc.id = uccm.chat_channel_id')
       .joins('INNER JOIN chat_messages c_msg ON c_msg.chat_channel_id = uccm.chat_channel_id')
-      .joins('LEFT OUTER JOIN chat_mentions c_mentions ON c_mentions.chat_message_id = c_msg.id AND c_mentions.user_id = users.id')
+      .joins('LEFT OUTER JOIN chat_mentions c_mentions ON c_mentions.chat_message_id = c_msg.id')
       .where(uccm: { following: true })
       .where('c_msg.deleted_at IS NULL AND c_msg.user_id <> users.id')
       .where(
-      <<~SQL
-        (c_mentions.id IS NOT NULL OR cc.chatable_type = 'DirectMessageChannel') AND
-        (uccm.last_read_message_id IS NULL OR c_msg.id > uccm.last_read_message_id)
-      SQL
-    )
+        <<~SQL
+          (c_mentions.user_id = uccm.user_id OR cc.chatable_type = 'DirectMessageChannel') AND
+          (uccm.last_read_message_id IS NULL OR c_msg.id > uccm.last_read_message_id) AND
+          (uccm.last_unread_mention_when_emailed_id IS NULL OR c_msg.id > uccm.last_unread_mention_when_emailed_id)
+        SQL
+      )
+      .group('users.id, uccm.user_id')
   end
 end

--- a/lib/chat_message_creator.rb
+++ b/lib/chat_message_creator.rb
@@ -39,7 +39,10 @@ class DiscourseChat::ChatMessageCreator
       ChatDraft.where(user_id: @user.id, chat_channel_id: @chat_channel.id).destroy_all
       ChatPublisher.publish_new!(@chat_channel, @chat_message, @staged_id)
       Jobs.enqueue(:process_chat_message, { chat_message_id: @chat_message.id })
-      DiscourseChat::ChatNotifier.notify_new(chat_message: @chat_message, timestamp: @chat_message.created_at)
+      DiscourseChat::ChatNotifier.notify_new(
+        chat_message: @chat_message,
+        timestamp: @chat_message.created_at
+      )
     rescue => error
       @error = error
     end
@@ -53,6 +56,7 @@ class DiscourseChat::ChatMessageCreator
 
   def validate_user_permissions!
     return if @guardian.can_create_chat_message!
+
     raise StandardError.new(
       I18n.t("chat.errors.user_cannot_send_message")
     )
@@ -60,6 +64,7 @@ class DiscourseChat::ChatMessageCreator
 
   def validate_channel_status!
     return if @guardian.can_create_channel_message?(@chat_channel)
+
     raise StandardError.new(
       I18n.t("chat.errors.channel_new_message_disallowed", status: @chat_channel.status_name)
     )

--- a/lib/chat_message_updater.rb
+++ b/lib/chat_message_updater.rb
@@ -31,7 +31,10 @@ class DiscourseChat::ChatMessageUpdater
       revision = save_revision!
       ChatPublisher.publish_edit!(@chat_channel, @chat_message)
       Jobs.enqueue(:process_chat_message, { chat_message_id: @chat_message.id })
-      DiscourseChat::ChatNotifier.notify_edit(chat_message: @chat_message, timestamp: revision.created_at)
+      DiscourseChat::ChatNotifier.notify_edit(
+        chat_message: @chat_message,
+        timestamp: revision.created_at
+      )
     rescue => error
       @error = error
     end

--- a/lib/extensions/user_email_extension.rb
+++ b/lib/extensions/user_email_extension.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DiscourseChat::UserEmailExtension
+  def execute(args)
+    super(args)
+
+    if args[:type] == 'chat_summary' && args[:memberships_to_update_data].present?
+      args[:memberships_to_update_data].to_a.each do |membership_id, max_unread_mention_id|
+        UserChatChannelMembership
+          .find_by(user: args[:user_id], id: membership_id.to_i)
+          &.update(last_unread_mention_when_emailed_id: max_unread_mention_id.to_i)
+      end
+    end
+  end
+end

--- a/lib/extensions/user_notifications_extension.rb
+++ b/lib/extensions/user_notifications_extension.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module DiscourseChat::UserNotificationsExtension
+  def chat_summary(user, opts)
+    @messages = ChatMessage
+      .joins(:user, :chat_channel)
+      .where.not(user: user)
+      .joins('LEFT OUTER JOIN chat_mentions cm ON cm.chat_message_id = chat_messages.id')
+      .joins('INNER JOIN user_chat_channel_memberships uccm ON uccm.chat_channel_id = chat_channels.id')
+      .where(uccm: { following: true, user_id: user.id })
+      .where(
+        <<~SQL
+          (cm.user_id = #{user.id} OR chat_channels.chatable_type = 'DirectMessageChannel') AND
+          (uccm.last_read_message_id IS NULL OR chat_messages.id > uccm.last_read_message_id)
+        SQL
+      ).to_a
+    return if @messages.empty?
+
+    @display_usernames = SiteSetting.prioritize_username_in_ux || !SiteSetting.enable_names
+
+    build_summary_for(user)
+    opts = {
+      from_alias: I18n.t('user_notifications.chat_summary.from', site_name: Email.site_title),
+      subject: I18n.t('user_notifications.chat_summary.subject', count: @messages.size, email_prefix: @email_prefix, date: short_date(Time.now)),
+      add_unsubscribe_link: true,
+      unsubscribe_url: "#{Discourse.base_url}/email/unsubscribe/#{@unsubscribe_key}",
+    }
+
+    @grouped_mentions = @messages.group_by { |message| message.chat_channel }
+    @grouped_mentions.each do |chat_channel, mentions|
+      @grouped_mentions[chat_channel] = mentions.sort_by(&:created_at)
+    end
+    @user = user
+    @user_tz = UserOption.user_tzinfo(user.id)
+
+    build_email(user.email, opts)
+  end
+end

--- a/lib/extensions/user_notifications_extension.rb
+++ b/lib/extensions/user_notifications_extension.rb
@@ -11,7 +11,8 @@ module DiscourseChat::UserNotificationsExtension
       .where(
         <<~SQL
           (cm.user_id = #{user.id} OR chat_channels.chatable_type = 'DirectMessageChannel') AND
-          (uccm.last_read_message_id IS NULL OR chat_messages.id > uccm.last_read_message_id)
+          (uccm.last_read_message_id IS NULL OR chat_messages.id > uccm.last_read_message_id) AND
+          (uccm.last_unread_mention_when_emailed_id IS NULL OR chat_messages.id > uccm.last_unread_mention_when_emailed_id)
         SQL
       ).to_a
     return if @messages.empty?
@@ -22,8 +23,7 @@ module DiscourseChat::UserNotificationsExtension
     opts = {
       from_alias: I18n.t('user_notifications.chat_summary.from', site_name: Email.site_title),
       subject: I18n.t('user_notifications.chat_summary.subject', count: @messages.size, email_prefix: @email_prefix, date: short_date(Time.now)),
-      add_unsubscribe_link: true,
-      unsubscribe_url: "#{Discourse.base_url}/email/unsubscribe/#{@unsubscribe_key}",
+      add_unsubscribe_link: false,
     }
 
     @grouped_mentions = @messages.group_by { |message| message.chat_channel }

--- a/lib/extensions/user_option_extension.rb
+++ b/lib/extensions/user_option_extension.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module DiscourseChat::UserOptionExtension
+  def self.prepended(base)
+    def base.chat_email_frequencies
+      @chat_email_frequencies ||= {
+        never: 0,
+        when_away: 1
+      }
+    end
+
+    base.enum chat_email_frequency: base.chat_email_frequencies
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -108,6 +108,7 @@ after_initialize do
   load File.expand_path('../app/serializers/user_chat_message_bookmark_serializer.rb', __FILE__)
   load File.expand_path('../app/serializers/reviewable_chat_message_serializer.rb', __FILE__)
   load File.expand_path('../lib/chat_channel_fetcher.rb', __FILE__)
+  load File.expand_path('../lib/chat_mailer.rb', __FILE__)
   load File.expand_path('../lib/chat_message_creator.rb', __FILE__)
   load File.expand_path('../lib/chat_message_processor.rb', __FILE__)
   load File.expand_path('../lib/chat_message_updater.rb', __FILE__)
@@ -123,6 +124,8 @@ after_initialize do
   load File.expand_path('../lib/guardian_extensions.rb', __FILE__)
   load File.expand_path('../lib/extensions/topic_view_serializer_extension.rb', __FILE__)
   load File.expand_path('../lib/extensions/detailed_tag_serializer_extension.rb', __FILE__)
+  load File.expand_path('../lib/extensions/user_option_extension.rb', __FILE__)
+  load File.expand_path('../lib/extensions/user_notifications_extension.rb', __FILE__)
   load File.expand_path('../lib/slack_compatibility.rb', __FILE__)
   load File.expand_path('../lib/post_notification_handler.rb', __FILE__)
   load File.expand_path('../app/jobs/regular/process_chat_message.rb', __FILE__)
@@ -132,6 +135,7 @@ after_initialize do
   load File.expand_path('../app/jobs/regular/chat_notify_watching.rb', __FILE__)
   load File.expand_path('../app/jobs/scheduled/delete_old_chat_messages.rb', __FILE__)
   load File.expand_path('../app/jobs/scheduled/update_user_counts_for_chat_channels.rb', __FILE__)
+  load File.expand_path('../app/jobs/scheduled/email_chat_notifications.rb', __FILE__)
   load File.expand_path('../app/services/chat_publisher.rb', __FILE__)
 
   if Discourse.allow_dev_populate?
@@ -139,6 +143,8 @@ after_initialize do
     load File.expand_path('../lib/discourse_dev/direct_channel.rb', __FILE__)
     load File.expand_path('../lib/discourse_dev/message.rb', __FILE__)
   end
+
+  UserNotifications.append_view_path(File.expand_path('../app/views', __FILE__))
 
   register_topic_custom_field_type(DiscourseChat::HAS_CHAT_ENABLED, :boolean)
   register_category_custom_field_type(DiscourseChat::HAS_CHAT_ENABLED, :boolean)
@@ -148,6 +154,7 @@ after_initialize do
   UserUpdater::OPTION_ATTR.push(:only_chat_push_notifications)
   UserUpdater::OPTION_ATTR.push(:chat_sound)
   UserUpdater::OPTION_ATTR.push(:ignore_channel_wide_mention)
+  UserUpdater::OPTION_ATTR.push(:chat_email_frequency)
 
   register_reviewable_type ReviewableChatMessage
 
@@ -166,6 +173,8 @@ after_initialize do
     Guardian.class_eval { include DiscourseChat::GuardianExtensions }
     TopicViewSerializer.class_eval { prepend DiscourseChat::TopicViewSerializerExtension }
     DetailedTagSerializer.class_eval { prepend DiscourseChat::DetailedTagSerializerExtension }
+    UserNotifications.class_eval { prepend DiscourseChat::UserNotificationsExtension }
+    UserOption.class_eval { prepend DiscourseChat::UserOptionExtension }
     Topic.class_eval {
       has_one :chat_channel, as: :chatable
     }
@@ -315,6 +324,10 @@ after_initialize do
 
   add_to_serializer(:user_option, :ignore_channel_wide_mention) do
     object.ignore_channel_wide_mention
+  end
+
+  add_to_serializer(:user_option, :chat_email_frequency) do
+    object.chat_email_frequency
   end
 
   RETENTION_SETTINGS_TO_USER_OPTION_FIELDS = {
@@ -483,4 +496,10 @@ after_initialize do
       params: %i[chat_channel_id]
     }
   })
+
+  # Dark mode email styles
+  Email::Styles.register_plugin_style do |fragment|
+    fragment.css('.chat-summary-header').each { |element| element[:dm] = 'header' }
+    fragment.css('.chat-summary-content').each { |element| element[:dm] = 'body' }
+  end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -126,6 +126,7 @@ after_initialize do
   load File.expand_path('../lib/extensions/detailed_tag_serializer_extension.rb', __FILE__)
   load File.expand_path('../lib/extensions/user_option_extension.rb', __FILE__)
   load File.expand_path('../lib/extensions/user_notifications_extension.rb', __FILE__)
+  load File.expand_path('../lib/extensions/user_email_extension.rb', __FILE__)
   load File.expand_path('../lib/slack_compatibility.rb', __FILE__)
   load File.expand_path('../lib/post_notification_handler.rb', __FILE__)
   load File.expand_path('../app/jobs/regular/process_chat_message.rb', __FILE__)
@@ -186,6 +187,7 @@ after_initialize do
       has_many :chat_message_reactions, dependent: :destroy
       has_many :chat_mentions
     }
+    Jobs::UserEmail.class_eval { prepend DiscourseChat::UserEmailExtension }
 
     Bookmark.register_bookmarkable(ChatMessageBookmarkable)
   end

--- a/spec/components/chat_mailer_spec.rb
+++ b/spec/components/chat_mailer_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DiscourseChat::ChatMailer do
+  before do
+    SiteSetting.chat_enabled = true
+
+    @chatters_group = Fabricate(:group)
+    SiteSetting.chat_allowed_groups = @chatters_group.id
+
+    @sender = Fabricate(:user, group_ids: [@chatters_group.id])
+    @user_1 = Fabricate(:user, group_ids: [@chatters_group.id])
+
+    @last_emailed = 15.minutes.ago
+    @user_1.user_option.update!(last_emailed_for_chat: @last_emailed)
+
+    @chat_channel = Fabricate(:chat_channel)
+    @chat_message = Fabricate(:chat_message, user: @sender, chat_channel: @chat_channel)
+
+    Fabricate(:user_chat_channel_membership, user: @sender, chat_channel: @chat_channel)
+
+    @user_membership = Fabricate(
+      :user_chat_channel_membership, user: @user_1,
+                                     chat_channel: @chat_channel, last_read_message_id: nil
+    )
+
+    @private_channel = DiscourseChat::DirectMessageChannelCreator.create!([@sender, @user_1])
+  end
+
+  def asert_summary_skipped(last_emailed_at: @last_emailed)
+    expect(job_enqueued?(job: :user_email, args: { type: "chat_summary", user_id: @user_1.id })).to eq(false)
+    expect(@user_1.user_option.reload.last_emailed_for_chat).to eq_time(last_emailed_at)
+  end
+
+  def assert_only_queued_once
+    expect_job_enqueued(job: :user_email, args: { type: "chat_summary", user_id: @user_1.id })
+    expect(Jobs::UserEmail.jobs.size).to eq(1)
+  end
+
+  describe 'for chat mentions' do
+    before do
+      Fabricate(:chat_mention, user: @user_1, chat_message: @chat_message)
+    end
+
+    it 'skips users without chat access' do
+      @chatters_group.remove(@user_1)
+
+      subject.send_unread_mentions_summary
+
+      asert_summary_skipped
+    end
+
+    it 'skips suspended users' do
+      @user_1.update!(suspended_till: 5.months.from_now)
+
+      subject.send_unread_mentions_summary
+
+      asert_summary_skipped
+    end
+
+    it 'skips users with summaries disabled' do
+      @user_1.user_option.update(chat_email_frequency: UserOption.chat_email_frequencies[:never])
+
+      subject.send_unread_mentions_summary
+
+      asert_summary_skipped
+    end
+
+    it 'skips users emailed recently' do
+      updated_last_emails = 1.minutes.ago
+      @user_1.user_option.update!(last_emailed_for_chat: updated_last_emails)
+
+      subject.send_unread_mentions_summary
+
+      asert_summary_skipped(last_emailed_at: updated_last_emails)
+    end
+
+    it 'queues a job for users we never emailed before' do
+      @user_1.user_option.update!(last_emailed_for_chat: nil)
+
+      subject.send_unread_mentions_summary
+
+      assert_only_queued_once
+    end
+
+    it 'skips without chat enabled' do
+      @user_1.user_option.update(chat_enabled: false, chat_email_frequency: UserOption.chat_email_frequencies[:when_away])
+
+      subject.send_unread_mentions_summary
+
+      asert_summary_skipped
+    end
+
+    it 'queues a job for users that was mentioned and never read the channel before' do
+      subject.send_unread_mentions_summary
+
+      assert_only_queued_once
+    end
+
+    it 'skips the job when the user was mentioned but already read the message' do
+      @user_membership.update!(last_read_message_id: @chat_message.id)
+
+      subject.send_unread_mentions_summary
+
+      asert_summary_skipped
+    end
+
+    it 'skips the job when the user is not following the channel anymore' do
+      @user_membership.update!(last_read_message_id: @chat_message.id - 1, following: false)
+
+      subject.send_unread_mentions_summary
+
+      asert_summary_skipped
+    end
+
+    it 'updates the last_emailed_for_chat timestamp' do
+      @user_membership.update!(last_read_message_id: @chat_message.id - 1)
+
+      subject.send_unread_mentions_summary
+
+      assert_only_queued_once
+      expect(@user_1.user_option.reload.last_emailed_for_chat).to be > @last_emailed
+    end
+
+    it 'skips users with unread messages from a different channel' do
+      @user_membership.update!(last_read_message_id: @chat_message.id)
+      second_channel = Fabricate(:chat_channel)
+      Fabricate(:user_chat_channel_membership, user: @user_1, chat_channel: second_channel, last_read_message_id: @chat_message.id - 1)
+
+      subject.send_unread_mentions_summary
+
+      asert_summary_skipped
+    end
+
+    it 'only queues the job once for users who are member of multiple groups with chat access' do
+      chatters_group_2 = Fabricate(:group, users: [@user_1])
+      SiteSetting.chat_allowed_groups = [@chatters_group, chatters_group_2].map(&:id).join('|')
+
+      subject.send_unread_mentions_summary
+
+      assert_only_queued_once
+    end
+
+    it 'skips users when the mention was deleted' do
+      @chat_message.trash!
+
+      subject.send_unread_mentions_summary
+
+      asert_summary_skipped
+    end
+  end
+
+  describe 'for direct messages' do
+    before do
+      Fabricate(:chat_message, user: @sender, chat_channel: @private_channel)
+    end
+
+    it 'queue a job when the user has unread private mentions' do
+      subject.send_unread_mentions_summary
+
+      assert_only_queued_once
+    end
+
+    it 'only queues the job once when the user has mentions and private messages' do
+      Fabricate(:chat_mention, user: @user_1, chat_message: @chat_message)
+
+      subject.send_unread_mentions_summary
+
+      assert_only_queued_once
+    end
+
+    it "Doesn't mix mentions from other users when joining tables" do
+      user_2 = Fabricate(:user, groups: [@chatters_group])
+      Fabricate(:user_chat_channel_membership, user: user_2, chat_channel: @chat_channel, last_read_message_id: @chat_message.id)
+      Fabricate(:chat_mention, user: user_2, chat_message: @chat_message)
+
+      subject.send_unread_mentions_summary
+
+      assert_only_queued_once
+    end
+  end
+end

--- a/spec/components/chat_message_creator_spec.rb
+++ b/spec/components/chat_message_creator_spec.rb
@@ -12,6 +12,7 @@ describe DiscourseChat::ChatMessageCreator do
   fab!(:user_group) { Fabricate(:public_group, users: [user1, user2, user3], mentionable_level: Group::ALIAS_LEVELS[:everyone]) }
   fab!(:user_without_memberships) { Fabricate(:user) }
   fab!(:public_chat_channel) { Fabricate(:chat_channel, chatable: Fabricate(:topic)) }
+  fab!(:dm_chat_channel) { Fabricate(:chat_channel, chatable: Fabricate(:direct_message_channel, users: [user1, user2, user3])) }
 
   before do
     SiteSetting.chat_enabled = true

--- a/spec/components/chat_message_updater_spec.rb
+++ b/spec/components/chat_message_updater_spec.rb
@@ -134,19 +134,20 @@ describe DiscourseChat::ChatMessageUpdater do
   end
 
   describe "group mentions" do
-    it "sends group mentions on update" do
+    it "creates group mentions on update" do
       chat_message = create_chat_message(user1, "ping nobody", public_chat_channel)
       expect {
         DiscourseChat::ChatMessageUpdater.update(
           chat_message: chat_message,
           new_content: "ping @#{admin_group.name}"
         )
-      }.to change { ChatMention.count }.by(2)
+      }.to change { ChatMention.where(chat_message: chat_message).count }.by(2)
+
       expect(admin1.chat_mentions.where(chat_message: chat_message)).to be_present
       expect(admin2.chat_mentions.where(chat_message: chat_message)).to be_present
     end
 
-    it "doesn't repeat mentions when the user is already direct mentioned and then group mentioned" do
+    it "doesn't duplicate mentions when the user is already direct mentioned and then group mentioned" do
       chat_message = create_chat_message(user1, "ping @#{admin2.username}", public_chat_channel)
       expect {
         DiscourseChat::ChatMessageUpdater.update(
@@ -167,6 +168,7 @@ describe DiscourseChat::ChatMessageUpdater do
           new_content: "ping nobody anymore!"
         )
       }.to change { ChatMention.where(chat_message: chat_message).count }.by(-2)
+
       expect(admin1.chat_mentions.where(chat_message: chat_message)).not_to be_present
       expect(admin2.chat_mentions.where(chat_message: chat_message)).not_to be_present
     end

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UserNotifications do
+  describe '.chat_summary' do
+    before do
+      @chatters_group = Fabricate(:group)
+      @sender = Fabricate(:user, name: 'A name', username: 'username', group_ids: [@chatters_group.id])
+      @user = Fabricate(:user, group_ids: [@chatters_group.id])
+
+      @chat_channel = Fabricate(:chat_channel)
+      @chat_message = Fabricate(:chat_message, user: @sender, chat_channel: @chat_channel)
+
+      Fabricate(:user_chat_channel_membership, chat_channel: @chat_channel, user: @sender)
+      @user_membership = Fabricate(:user_chat_channel_membership, chat_channel: @chat_channel, user: @user, last_read_message_id: @chat_message.id - 2)
+
+      SiteSetting.chat_enabled = true
+      SiteSetting.chat_allowed_groups = @chatters_group.id
+    end
+
+    it "doesn't return an email if there are no unread mentions" do
+      email = described_class.chat_summary(@user, {})
+
+      expect(email.to).to be_blank
+    end
+
+    describe 'When there are mentions' do
+      before { Fabricate(:chat_mention, user: @user, chat_message: @chat_message) }
+
+      describe 'selecting mentions' do
+        it "doesn't return an email if the user is not following the channel" do
+          @user_membership.update!(following: false)
+
+          email = described_class.chat_summary(@user, {})
+
+          expect(email.to).to be_blank
+        end
+
+        it "doesn't return an email if the membership object doesn't exist" do
+          @user_membership.destroy!
+
+          email = described_class.chat_summary(@user, {})
+
+          expect(email.to).to be_blank
+        end
+
+        it "doesn't return an email if the sender was deleted" do
+          @sender.destroy!
+
+          email = described_class.chat_summary(@user, {})
+
+          expect(email.to).to be_blank
+        end
+
+        it "doesn't return an email when the user already saw the mention" do
+          @user_membership.update!(last_read_message_id: @chat_message.id)
+
+          email = described_class.chat_summary(@user, {})
+
+          expect(email.to).to be_blank
+        end
+
+        it "returns an email when the user haven't read a message yet" do
+          @user_membership.update!(last_read_message_id: nil)
+
+          email = described_class.chat_summary(@user, {})
+
+          expect(email.to).to contain_exactly(@user.email)
+        end
+
+        it "doesn't return an email when the unread count belongs to a different channel" do
+          @user_membership.update!(last_read_message_id: @chat_message.id)
+          second_channel = Fabricate(:chat_channel)
+          Fabricate(:user_chat_channel_membership, chat_channel: second_channel, user: @user, last_read_message_id: @chat_message.id - 1)
+
+          email = described_class.chat_summary(@user, {})
+
+          expect(email.to).to be_blank
+        end
+
+        it "doesn't return an email if the message was deleted" do
+          @chat_message.trash!
+
+          email = described_class.chat_summary(@user, {})
+
+          expect(email.to).to be_blank
+        end
+
+        it 'returns an email when the user has unread private messages' do
+          @user_membership.update!(last_read_message_id: @chat_message.id)
+          private_channel = DiscourseChat::DirectMessageChannelCreator.create!([@sender, @user])
+          Fabricate(:chat_message, user: @sender, chat_channel: private_channel)
+
+          email = described_class.chat_summary(@user, {})
+
+          expect(email.to).to contain_exactly(@user.email)
+        end
+      end
+
+      describe 'mail contents' do
+        it 'returns an email when the user has unread mentions' do
+          email = described_class.chat_summary(@user, {})
+
+          expect(email.to).to contain_exactly(@user.email)
+          expect(email.html_part.body.to_s).to include(@chat_message.cooked_for_excerpt)
+
+          user_avatar = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row img")
+
+          expect(user_avatar.attribute('src').value).to eq(@sender.small_avatar_url)
+          expect(user_avatar.attribute('alt').value).to eq(@sender.username)
+
+          more_messages_channel_link = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".more-messages-link")
+
+          expect(more_messages_channel_link.attribute('href').value).to eq(@chat_channel.url)
+          expect(more_messages_channel_link.text).to include(I18n.t("user_notifications.chat_summary.view_messages", count: 1))
+        end
+
+        it "displays the sender's name when the site is configured to prioritize it" do
+          SiteSetting.enable_names = true
+          SiteSetting.prioritize_username_in_ux = false
+
+          email = described_class.chat_summary(@user, {})
+
+          user_name = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row span")
+          expect(user_name.text).to include(@sender.name)
+
+          user_avatar = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row img")
+
+          expect(user_avatar.attribute('alt').value).to eq(@sender.name)
+        end
+
+        it "displays the sender's username when the site is configured to prioritize it" do
+          SiteSetting.enable_names = true
+          SiteSetting.prioritize_username_in_ux = true
+
+          email = described_class.chat_summary(@user, {})
+
+          user_name = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row span")
+          expect(user_name.text).to include(@sender.username)
+
+          user_avatar = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row img")
+
+          expect(user_avatar.attribute('alt').value).to eq(@sender.username)
+        end
+
+        it "displays the sender's username when names are disabled" do
+          SiteSetting.enable_names = false
+          SiteSetting.prioritize_username_in_ux = false
+
+          email = described_class.chat_summary(@user, {})
+
+          user_name = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row span")
+          expect(user_name.text).to include(@sender.username)
+
+          user_avatar = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row img")
+
+          expect(user_avatar.attribute('alt').value).to eq(@sender.username)
+        end
+
+        it "displays the sender's username when the site is configured to prioritize it" do
+          SiteSetting.enable_names = false
+          SiteSetting.prioritize_username_in_ux = true
+
+          email = described_class.chat_summary(@user, {})
+
+          user_name = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row span")
+          expect(user_name.text).to include(@sender.username)
+
+          user_avatar = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row img")
+
+          expect(user_avatar.attribute('alt').value).to eq(@sender.username)
+        end
+
+        it 'includes a view more link when there are more than two mentions' do
+          2.times do
+            msg = Fabricate(:chat_message, user: @sender, chat_channel: @chat_channel)
+            Fabricate(:chat_mention, user: @user, chat_message: msg)
+          end
+
+          email = described_class.chat_summary(@user, {})
+          more_messages_channel_link = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".more-messages-link")
+
+          expect(more_messages_channel_link.attribute('href').value).to eq(@chat_channel.url)
+          expect(more_messages_channel_link.text).to include(I18n.t("user_notifications.chat_summary.view_more", count: 1))
+        end
+      end
+    end
+  end
+end

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -123,7 +123,7 @@ describe UserNotifications do
 
           more_messages_channel_link = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".more-messages-link")
 
-          expect(more_messages_channel_link.attribute('href').value).to eq(@chat_channel.url)
+          expect(more_messages_channel_link.attribute('href').value).to eq(@chat_message.url)
           expect(more_messages_channel_link.text).to include(I18n.t("user_notifications.chat_summary.view_messages", count: 1))
         end
 
@@ -192,7 +192,7 @@ describe UserNotifications do
           email = described_class.chat_summary(@user, {})
           more_messages_channel_link = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".more-messages-link")
 
-          expect(more_messages_channel_link.attribute('href').value).to eq(@chat_channel.url)
+          expect(more_messages_channel_link.attribute('href').value).to eq(@chat_message.url)
           expect(more_messages_channel_link.text).to include(I18n.t("user_notifications.chat_summary.view_more", count: 1))
         end
 

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -29,6 +29,22 @@ describe UserNotifications do
       before { Fabricate(:chat_mention, user: @user, chat_message: @chat_message) }
 
       describe 'selecting mentions' do
+        it "doesn't return an email if the user can't see chat" do
+          SiteSetting.chat_allowed_groups = ''
+
+          email = described_class.chat_summary(@user, {})
+
+          expect(email.to).to be_blank
+        end
+
+        it "doesn't return an email if the user can't see any of the included channels" do
+          @chat_channel.chatable.trash!
+
+          email = described_class.chat_summary(@user, {})
+
+          expect(email.to).to be_blank
+        end
+
         it "doesn't return an email if the user is not following the channel" do
           @user_membership.update!(following: false)
 

--- a/spec/models/chat_channel_spec.rb
+++ b/spec/models/chat_channel_spec.rb
@@ -212,33 +212,4 @@ describe ChatChannel do
       ).to eq(true)
     end
   end
-
-  describe "#email_title" do
-    fab!(:small_dm_channel) {
-      Fabricate(:chat_channel, chatable: Fabricate(:direct_message_channel, users: [user1, user2, user3]))
-    }
-    fab!(:large_dm_channel) {
-      Fabricate(:chat_channel, chatable: Fabricate(:direct_message_channel, users: [user1, user2, user3, user4, user5, user6, user7]))
-    }
-
-    it "returns the correct usernames and remaing count for DM channel with many users" do
-      expect(large_dm_channel.email_title(user1)).to eq(
-        I18n.t(
-          "chat.channel.title_for_large_group_dm",
-          users: [user2, user3, user4, user5, user6].map { |u| "@#{u.username}" }.join(", "),
-          count: 1
-        )
-      )
-    end
-
-    it "returns the correct usernames DM channel with few users" do
-      expect(small_dm_channel.email_title(user1)).to eq("@#{user2.username}, @#{user3.username}")
-    end
-
-    it "returns the channel name for public channels" do
-      name = "This is the name!!"
-      public_topic_channel.update!(name: name)
-      expect(public_topic_channel.email_title(user1)).to eq(name)
-    end
-  end
 end

--- a/spec/models/chat_channel_spec.rb
+++ b/spec/models/chat_channel_spec.rb
@@ -5,6 +5,11 @@ require 'rails_helper'
 describe ChatChannel do
   fab!(:user1) { Fabricate(:user) }
   fab!(:user2) { Fabricate(:user) }
+  fab!(:user3) { Fabricate(:user) }
+  fab!(:user4) { Fabricate(:user) }
+  fab!(:user5) { Fabricate(:user) }
+  fab!(:user6) { Fabricate(:user) }
+  fab!(:user7) { Fabricate(:user) }
   fab!(:staff) { Fabricate(:user, admin: true) }
   fab!(:group) { Fabricate(:group) }
   fab!(:public_topic_channel) { Fabricate(:chat_channel, chatable: Fabricate(:topic)) }
@@ -205,6 +210,35 @@ describe ChatChannel do
           previous_value: :read_only
         )
       ).to eq(true)
+    end
+  end
+
+  describe "#email_title" do
+    fab!(:small_dm_channel) {
+      Fabricate(:chat_channel, chatable: Fabricate(:direct_message_channel, users: [user1, user2, user3]))
+    }
+    fab!(:large_dm_channel) {
+      Fabricate(:chat_channel, chatable: Fabricate(:direct_message_channel, users: [user1, user2, user3, user4, user5, user6, user7]))
+    }
+
+    it "returns the correct usernames and remaing count for DM channel with many users" do
+      expect(large_dm_channel.email_title(user1)).to eq(
+        I18n.t(
+          "chat.channel.title_for_large_group_dm",
+          users: [user2, user3, user4, user5, user6].map { |u| "@#{u.username}" }.join(", "),
+          count: 1
+        )
+      )
+    end
+
+    it "returns the correct usernames DM channel with few users" do
+      expect(small_dm_channel.email_title(user1)).to eq("@#{user2.username}, @#{user3.username}")
+    end
+
+    it "returns the channel name for public channels" do
+      name = "This is the name!!"
+      public_topic_channel.update!(name: name)
+      expect(public_topic_channel.email_title(user1)).to eq(name)
     end
   end
 end

--- a/spec/models/chat_channel_spec.rb
+++ b/spec/models/chat_channel_spec.rb
@@ -5,11 +5,6 @@ require 'rails_helper'
 describe ChatChannel do
   fab!(:user1) { Fabricate(:user) }
   fab!(:user2) { Fabricate(:user) }
-  fab!(:user3) { Fabricate(:user) }
-  fab!(:user4) { Fabricate(:user) }
-  fab!(:user5) { Fabricate(:user) }
-  fab!(:user6) { Fabricate(:user) }
-  fab!(:user7) { Fabricate(:user) }
   fab!(:staff) { Fabricate(:user, admin: true) }
   fab!(:group) { Fabricate(:group) }
   fab!(:public_topic_channel) { Fabricate(:chat_channel, chatable: Fabricate(:topic)) }

--- a/spec/models/direct_message_channel_spec.rb
+++ b/spec/models/direct_message_channel_spec.rb
@@ -29,7 +29,7 @@ describe DirectMessageChannel do
       expect(direct_message_channel.chat_channel_title_for_user(chat_channel, user1)).to eq(
         I18n.t(
           "chat.channel.dm_title.multi_user_truncated",
-          users: users[1..5].map { |u| "@#{u.username}" }.join(", "),
+          users: users[1..5].sort_by(&:username).map { |u| "@#{u.username}" }.join(", "),
           leftover: 2
         )
       )

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -1433,11 +1433,11 @@ acceptance("Discourse Chat - chat preferences", function (needs) {
     assert.equal(currentURL(), "/latest");
   });
 
-  test("There are all 5 settings shown", async function (assert) {
+  test("There are all 6 settings shown", async function (assert) {
     this.chatService.set("sidebarActive", true);
     await visit("/u/eviltrout/preferences/chat");
     assert.equal(currentURL(), "/u/eviltrout/preferences/chat");
-    assert.equal(queryAll(".chat-setting").length, 5);
+    assert.equal(queryAll(".chat-setting").length, 6);
   });
 
   test("The user can save the settings", async function (assert) {
@@ -1450,6 +1450,8 @@ acceptance("Discourse Chat - chat preferences", function (needs) {
     await click("#user_chat_ignore_channel_wide_mention");
     await selectKit("#user_chat_sounds").expand();
     await selectKit("#user_chat_sounds").selectRowByValue("bell");
+    await selectKit("#user_chat_email_frequency").expand();
+    await selectKit("#user_chat_email_frequency").selectRowByValue("never");
 
     await click(".save-changes");
 
@@ -1461,6 +1463,7 @@ acceptance("Discourse Chat - chat preferences", function (needs) {
           chat_sound: "bell",
           only_chat_push_notifications: true,
           ignore_channel_wide_mention: true,
+          chat_email_frequency: "never",
         },
         type: "PUT",
       }),


### PR DESCRIPTION
Reintroduces feature originally added in #759 and later reverted in #803.  We didn't revert migrations, so it's not necessary to add them in this commit.

his PR is similar to https://github.com/discourse/discourse-chat/pull/759 but doesn't use a new table to track which mentions and private messages need to be processed using a new table.

### Light mode:

<img width="2457" alt="Screen Shot 2022-05-20 at 12 00 00" src="https://user-images.githubusercontent.com/5025816/169556932-c9f3b94a-f236-4e9a-a3ff-7c1d6c5968b0.png">


### Dark mode:

<img width="2452" alt="Screen Shot 2022-05-20 at 11 59 35" src="https://user-images.githubusercontent.com/5025816/169556878-5b6af65a-6594-4d30-b341-2be4d8b20f1f.png">



