### PR TITLE
UX: Make some UI elements unselectable

### DIFF
--- a/assets/stylesheets/common/chat-message.scss
+++ b/assets/stylesheets/common/chat-message.scss
@@ -274,6 +274,8 @@
 }
 
 .chat-msgactions-hover {
+  @include unselectable;
+
   position: absolute;
   opacity: 0;
   padding-left: 4em;

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -458,6 +458,7 @@ body.composer-open .topic-chat-float-container {
 }
 
 .chat-user-avatar {
+  @include unselectable;
   display: flex;
   align-items: center;
 
@@ -529,6 +530,8 @@ body.composer-open .topic-chat-float-container {
 }
 
 .tc-reply-display {
+  @include unselectable;
+
   display: flex;
   align-items: center;
   text-overflow: ellipsis;


### PR DESCRIPTION
This improves copy'n'paste experience:

Before:
```
lorem ipsum

​​
another message

​​

lorem ipsum

cvx 8:31 pm
heh

​​
sup
```

After:
```
lorem ipsum

another message

cvx 8:31 pm
heh

sup
```

---

(checklist: should be fine in all cases :P)