### PR TITLE
REFACTOR: ChatNotifier mention types expansion.

### DIFF
--- a/app/jobs/regular/create_chat_mention_notifications.rb
+++ b/app/jobs/regular/create_chat_mention_notifications.rb
@@ -8,72 +8,111 @@ module Jobs
       return if @chat_message.nil? || @chat_message.revisions.where("created_at > ?", args[:timestamp]).any?
 
       @creator = @chat_message.user
-      @memberships = UserChatChannelMembership.includes(:user).where(
-        user_id: args[:user_ids],
-        chat_channel_id: @chat_message.chat_channel_id,
-        following: true
-      )
       @chat_channel = @chat_message.chat_channel
       @is_direct_message_channel = @chat_channel.direct_message_channel?
-      @user_ids_to_group_mention_map = args[:user_ids_to_group_mention_map] || {}
-      @memberships.each do |membership|
-        is_read = DiscourseChat::ChatNotifier.user_has_seen_message?(membership, @chat_message.id)
-        identifier_info = (args["user_ids_to_identifier_map"] || {})[membership.user_id.to_s]
-        send_mention_notification_to_user(membership.user, identifier_info, is_read)
-        send_os_notifications(membership, identifier_info) unless is_read
+      @already_notified_user_ids = args[:already_notified_user_ids] || []
+      user_ids_to_notify = args[:to_notify_ids_map] || {}
+
+      user_ids_to_notify.each do |mention_type, ids|
+        process_mentions(ids, mention_type.to_sym)
       end
     end
 
-    def send_mention_notification_to_user(user, identifier_info, is_read)
+    private
+
+    def get_memberships(user_ids)
+      UserChatChannelMembership.includes(:user).where(
+        user_id: (user_ids - @already_notified_user_ids),
+        chat_channel_id: @chat_message.chat_channel_id,
+        following: true
+      )
+    end
+
+    def build_data_for(membership, identifier_type:)
       data = {
         chat_message_id: @chat_message.id,
         chat_channel_id: @chat_channel.id,
-        chat_channel_title: @chat_channel.title(user),
         mentioned_by_username: @creator.username,
         is_direct_message_channel: @is_direct_message_channel
       }
 
-      data[:chat_channel_title] = @chat_channel.title(user) unless @is_direct_message_channel
-      data[:identifier] = identifier_info["identifier"] if identifier_info.present?
-      data[:is_group_mention] = true if (identifier_info || {})["is_group"]
+      data[:chat_channel_title] = @chat_channel.title(membership.user) unless @is_direct_message_channel
+      return data if identifier_type == :direct_mentions
 
-      notification = Notification.create!(
-        notification_type: Notification.types[:chat_mention],
-        user_id: user.id,
-        high_priority: true,
-        data: data.to_json,
-        read: is_read
-      )
-      ChatMention.create!(notification: notification, user: user, chat_message: @chat_message)
+      case identifier_type
+      when :here_mentions
+        data[:identifier] = 'here'
+      when :global_mentions
+        data[:identifier] = 'all'
+      else
+        data[:is_group_mention] = true
+      end
+
+      data
     end
 
-    def send_os_notifications(membership, identifier_info)
-      return if membership.desktop_notifications_never? && membership.mobile_notifications_never?
-
+    def build_payload_for(membership, identifier_type:)
       translation_prefix = @is_direct_message_channel ?
         "discourse_push_notifications.popup.direct_message_chat_mention" :
         "discourse_push_notifications.popup.chat_mention"
-      translation_suffix = identifier_info ? "other" : "direct"
+      translation_suffix = identifier_type == :direct_mentions ? "direct" : "other"
 
-      payload = {
+      identifier_text = case identifier_type
+                        when :here_mentions
+                          'here'
+                        when :global_mentions
+                          'all'
+        else
+                          ''
+      end
+
+      {
+        translated_title: I18n.t("#{translation_prefix}.#{translation_suffix}",
+          username: @creator.username,
+          identifier: identifier_text,
+          channel: @chat_channel.title(membership.user)
+        ),
         notification_type: Notification.types[:chat_mention],
         username: @creator.username,
-        translated_title: I18n.t("#{translation_prefix}.#{translation_suffix}",
-                                 username: @creator.username,
-                                 identifier: identifier_info ? "@#{identifier_info["identifier"]}" : "",
-                                 channel: @chat_channel.title(membership.user)
-                                ),
         tag: DiscourseChat::ChatNotifier.push_notification_tag(:mention, @chat_channel.id),
         excerpt: @chat_message.push_notification_excerpt,
         post_url: "/chat/channel/#{@chat_channel.id}/#{@chat_channel.title(membership.user)}?messageId=#{@chat_message.id}"
       }
+    end
 
-      unless membership.desktop_notifications_never?
-        MessageBus.publish("/chat/notification-alert/#{membership.user.id}", payload, user_ids: [membership.user.id])
+    def create_notification!(membership, notification_data)
+      is_read = DiscourseChat::ChatNotifier.user_has_seen_message?(membership, @chat_message.id)
+
+      notification = Notification.create!(
+        notification_type: Notification.types[:chat_mention],
+        user_id: membership.user_id,
+        high_priority: true,
+        data: notification_data.to_json,
+        read: is_read
+      )
+      ChatMention.create!(notification: notification, user: membership.user, chat_message: @chat_message)
+    end
+
+    def send_notifications(membership, notification_data, os_payload)
+      create_notification!(membership, notification_data)
+
+      if !membership.desktop_notifications_never?
+        MessageBus.publish("/chat/notification-alert/#{membership.user_id}", os_payload, user_ids: [membership.user_id])
       end
 
-      unless membership.mobile_notifications_never?
-        PostAlerter.push_notification(membership.user, payload)
+      if !membership.mobile_notifications_never?
+        PostAlerter.push_notification(membership.user, os_payload)
+      end
+    end
+
+    def process_mentions(user_ids, mention_type)
+      memberships = get_memberships(user_ids)
+
+      memberships.each do |membership|
+        notification_data = build_data_for(membership, identifier_type: mention_type)
+        payload = build_payload_for(membership, identifier_type: mention_type)
+
+        send_notifications(membership, notification_data, payload)
       end
     end
   end

--- a/app/services/chat_publisher.rb
+++ b/app/services/chat_publisher.rb
@@ -98,8 +98,8 @@ module ChatPublisher
     )
   end
 
-  def self.publish_new_mention(user, chat_channel_id, chat_message_id)
-    MessageBus.publish("/chat/#{chat_channel_id}/new-mentions", { message_id: chat_message_id }.as_json, user_ids: [user.id])
+  def self.publish_new_mention(user_id, chat_channel_id, chat_message_id)
+    MessageBus.publish("/chat/#{chat_channel_id}/new-mentions", { message_id: chat_message_id }.as_json, user_ids: [user_id])
   end
 
   def self.publish_new_direct_message_channel(chat_channel, users)
@@ -117,14 +117,14 @@ module ChatPublisher
     MessageBus.publish("/topic/#{topic_id}", reload_topic: true)
   end
 
-  def self.publish_inaccessible_mentions(user, chat_message, cannot_chat_users, without_membership)
+  def self.publish_inaccessible_mentions(user_id, chat_message, cannot_chat_users, without_membership)
     MessageBus.publish("/chat/#{chat_message.chat_channel_id}", {
         type: :mention_warning,
         chat_message_id: chat_message.id,
         cannot_see: ActiveModel::ArraySerializer.new(cannot_chat_users, each_serializer: BasicUserSerializer).as_json,
         without_membership: ActiveModel::ArraySerializer.new(without_membership, each_serializer: BasicUserSerializer).as_json,
       },
-      user_ids: [user.id]
+      user_ids: [user_id]
     )
   end
 

--- a/lib/chat_notifier.rb
+++ b/lib/chat_notifier.rb
@@ -196,7 +196,7 @@ class DiscourseChat::ChatNotifier
   def expand_group_mentions(to_notify, already_covered_ids)
     return [] if mentionable_groups.empty?
 
-    mentionable_groups.each { |g| to_notify[g.name.downcase.to_sym] = [] }
+    mentionable_groups.each { |g| to_notify[g.name.downcase] = [] }
 
     reached_by_group = chat_users
       .joins(:groups).where(groups: mentionable_groups)
@@ -206,7 +206,7 @@ class DiscourseChat::ChatNotifier
 
     grouped[:already_participating].each do |user|
       group = user.groups.detect { |g| mentionable_groups.include?(g) }
-      to_notify[group.name.downcase.to_sym] << user.id
+      to_notify[group.name.downcase] << user.id
     end
     already_covered_ids.concat(grouped[:already_participating])
 

--- a/lib/chat_notifier.rb
+++ b/lib/chat_notifier.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 class DiscourseChat::ChatNotifier
-  def self.user_has_seen_message?(membership, chat_message_id)
-    (membership.last_read_message_id || 0) >= chat_message_id
-  end
+  class << self
+    def user_has_seen_message?(membership, chat_message_id)
+      (membership.last_read_message_id || 0) >= chat_message_id
+    end
 
-  def self.push_notification_tag(type, chat_channel_id)
-    "#{Discourse.current_hostname}-chat-#{type}-#{chat_channel_id}"
-  end
+    def push_notification_tag(type, chat_channel_id)
+      "#{Discourse.current_hostname}-chat-#{type}-#{chat_channel_id}"
+    end
 
-  def self.notify_edit(chat_message:, timestamp:)
-    instance = new(chat_message, timestamp)
-    instance.notify_edit
-  end
+    def notify_edit(chat_message:, timestamp:)
+      new(chat_message, timestamp).notify_edit
+    end
 
-  def self.notify_new(chat_message:, timestamp:)
-    instance = new(chat_message, timestamp)
-    instance.notify_new
+    def notify_new(chat_message:, timestamp:)
+      new(chat_message, timestamp).notify_new
+    end
   end
 
   def initialize(chat_message, timestamp)
@@ -25,22 +25,34 @@ class DiscourseChat::ChatNotifier
     @user = @chat_message.user
   end
 
-  def notify_edit
-    update_mention_notifications
-  end
+  ### Public API
 
   def notify_new
-    mentioned_user_ids = create_mention_notifications
-    notify_watching_users(except: [@user.id] + mentioned_user_ids)
+    to_notify = list_users_to_notify
+    inaccessible = to_notify.extract!(:unreachable, :welcome_to_join)
+    mentioned_user_ids = to_notify.extract!(:all_mentioned_user_ids)[:all_mentioned_user_ids]
+
+    mentioned_user_ids.each do |member_id|
+      ChatPublisher.publish_new_mention(member_id, @chat_channel.id, @chat_message.id)
+    end
+
+    notify_creator_of_inaccessible_mentions(
+      inaccessible[:unreachable], inaccessible[:welcome_to_join]
+    )
+
+    enqueue_mentioned_job(to_notify)
+    notify_watching_users(except: mentioned_user_ids << @user.id)
+
+    to_notify
   end
 
-  private
-
-  def update_mention_notifications
+  def notify_edit
     existing_notifications = ChatMention.includes(:user, :notification).where(chat_message: @chat_message)
     already_notified_user_ids = existing_notifications.map(&:user_id)
-    set_mentioned_users
-    mentioned_user_ids = @mentioned_with_membership.map(&:id)
+
+    to_notify = list_users_to_notify
+    inaccessible = to_notify.extract!(:unreachable, :welcome_to_join)
+    mentioned_user_ids = to_notify.extract!(:all_mentioned_user_ids)[:all_mentioned_user_ids]
 
     needs_deletion = already_notified_user_ids - mentioned_user_ids
     needs_deletion.each do |user_id|
@@ -52,175 +64,169 @@ class DiscourseChat::ChatNotifier
     needs_notification_ids = mentioned_user_ids - already_notified_user_ids
     return if needs_notification_ids.blank?
 
-    notify_creator_of_inaccessible_mentions
-    enqueue_mentioned_job(needs_notification_ids)
+    notify_creator_of_inaccessible_mentions(
+      inaccessible[:unreachable], inaccessible[:welcome_to_join]
+    )
+
+    enqueue_mentioned_job(to_notify, already_notified_user_ids: already_notified_user_ids)
+
+    to_notify
   end
 
-  def create_mention_notifications
-    mentioned_user_ids = []
-    set_mentioned_users
+  private
 
-    @mentioned_with_membership.each do |target_user|
-      mentioned_user_ids.push(target_user.id)
-      ChatPublisher.publish_new_mention(target_user, @chat_channel.id, @chat_message.id)
-    end
+  def list_users_to_notify
+    {}.tap do |to_notify|
+      # The order of these methods is the precedence
+      # between different mention types.
 
-    notify_creator_of_inaccessible_mentions
-    enqueue_mentioned_job(mentioned_user_ids)
-    mentioned_user_ids
-  end
+      already_covered_ids = []
 
-  def notify_creator_of_inaccessible_mentions
-    if @cannot_chat_users.any? || @mentioned_without_membership.any?
-      ChatPublisher.publish_inaccessible_mentions(@user, @chat_message, @cannot_chat_users, @mentioned_without_membership)
+      expand_direct_mentions(to_notify, already_covered_ids)
+      expand_group_mentions(to_notify, already_covered_ids)
+      expand_here_mention(to_notify, already_covered_ids)
+      expand_global_mention(to_notify, already_covered_ids)
+
+      to_notify[:all_mentioned_user_ids] = already_covered_ids
     end
   end
 
-  def enqueue_mentioned_job(user_ids)
-    Jobs.enqueue_in(3.seconds, :create_chat_mention_notifications, {
-      chat_message_id: @chat_message.id,
-      user_ids: user_ids,
-      user_ids_to_identifier_map: user_ids_to_identifier_map.as_json,
-      user_ids_to_group_mention_map: user_ids_to_group_mention_map,
-      timestamp: @timestamp.iso8601(6)
-    })
+  def chat_users
+    users = User.includes(:do_not_disturb_timings, :push_subscriptions, :user_chat_channel_memberships)
+
+    users
+      .distinct
+      .joins('LEFT OUTER JOIN user_chat_channel_memberships uccm ON uccm.user_id = users.id')
+      .joins(:user_option)
+      .real
+      .not_suspended
+      .where(user_options: { chat_enabled: true })
+      .where.not(username_lower: @user.username.downcase)
   end
 
-  def user_ids_to_identifier_map
-    # A user might be directly mentioned by username, @here, @all, @group_name or a combo.
-    # Here we need to set the identifier if the user wasn't mentioned directly so that both
-    # OS notifications and core notifications can correctly display what identifier they were
-    # mentioned by. Loop through @all, @here, then group mentions, finally directly mentioned user_ids with each loop
-    # overriding the previous identifier so directly mentioned users will always be mentioned as such.
-    map = {}
-    [
-      [@global_mentioned_users.map(&:id), :all],
-      [@here_mentioned_users.map(&:id), :here]
-    ].each do |user_ids, identifier|
-      user_ids.each { |user_id| map[user_id] = { is_group: false, identifier: identifier } }
-    end
+  def rest_of_the_channel
+    chat_users
+      .where(user_chat_channel_memberships: { following: true, chat_channel_id: @chat_channel.id })
+  end
 
-    group_mentioned_users.each do |user|
-      group_name = (user.groups.map(&:name) & group_name_mentions).first
-      map[user.id] = { is_group: true, identifier: group_name }
-    end
-
-    @directly_mentioned_users.each { |user| map[user.id] = nil }
-    map
+  def members_accepting_channel_wide_notifications
+    rest_of_the_channel.where(user_options: { ignore_channel_wide_mention: [false, nil] })
   end
 
   def direct_mentions_from_cooked
     @direct_mentions_from_cooked ||= Nokogiri::HTML5.fragment(@chat_message.cooked).css(".mention").map(&:text)
   end
 
-  def group_name_mentions
-    @group_mentions_from_cooked ||= Nokogiri::HTML5.fragment(@chat_message.cooked).css(".mention-group").map(&:text).map { |m| m[1..-1] }
-  end
-
-  def group_mentioned_users
-    @group_mentioned_users ||= begin
-                                 if group_name_mentions.empty?
-                                   return []
-                                 else
-                                   mentionable_groups = Group
-                                     .mentionable(@user, include_public: false)
-                                     .where(name: group_name_mentions)
-                                   users_preloaded_query(include_groups: false)
-                                     .joins(:groups)
-                                     .where(groups: mentionable_groups)
-                                 end
-                               end
-  end
-
-  def user_ids_to_group_mention_map
-    map = {}
-    group_mentioned_users.each do |user|
-      group_name = (user.groups.map(&:name) & group_name_mentions).first
-      map[user.id] = group_name
-    end
-    map
-  end
-
-  def mentioned_usernames
-    # Drop the `@` character from start of each mention
-    @mentioned_usernames ||= direct_mentions_from_cooked.map { |mention| mention[1..-1] }
-  end
-
-  def set_mentioned_users
-    @global_mentioned_users = direct_mentions_from_cooked.include?("@all") ?
-      members_of_channel(exclude: @user.username, is_channel_mention: true) :
-      []
-
-    @here_mentioned_users = direct_mentions_from_cooked.include?("@here") ? get_users_here : []
-
-    @directly_mentioned_users = mentioned_by_username(
-      exclude: @user.username,
-      usernames: mentioned_usernames
-    )
-
-    users = (@global_mentioned_users + @here_mentioned_users + group_mentioned_users + @directly_mentioned_users).uniq
-
-    can_chat_users, @cannot_chat_users = filter_users_who_can_chat(users)
-    @mentioned_with_membership, @mentioned_without_membership = filter_with_and_without_membership(can_chat_users)
-  end
-
-  def get_users_here
-    users = members_of_channel(exclude: @user.username, is_channel_mention: true).where("last_seen_at > ?", 5.minutes.ago)
-    usernames = users.map(&:username)
-    other_mentioned_usernames = mentioned_usernames
-      .reject { |username| username == "here" || usernames.include?(username) }
-    if other_mentioned_usernames.any?
-      users = users.or(
-        members_of_channel(
-          exclude: @user.username,
-          usernames: other_mentioned_usernames,
-          is_channel_mention: true
-        )
-      )
-    end
-
-    users
-  end
-
-  def filter_with_and_without_membership(users)
-    users.partition do |user|
-      user.user_chat_channel_memberships.any? { |m| m.chat_channel_id == @chat_channel.id && m.following == true }
+  def normalized_mentions(mentions)
+    mentions.reduce([]) do |memo, mention|
+      %w[@here @all].include?(mention.downcase) ? memo : (memo << mention[1..-1].downcase)
     end
   end
 
-  def mentioned_by_username(exclude:, usernames:)
-    users_preloaded_query.where(username_lower: (usernames.map(&:downcase) - [exclude.downcase]))
-  end
+  def expand_global_mention(to_notify, already_covered_ids)
+    typed_global_mention = direct_mentions_from_cooked.include?("@all")
 
-  def members_of_channel(exclude:, usernames: nil, is_channel_mention: false)
-    users = users_preloaded_query
-      .where(user_chat_channel_memberships: { following: true, chat_channel_id: @chat_channel.id })
-      .where.not(username_lower: exclude.downcase)
-    users = users.where(username_lower: usernames.map(&:downcase)) if usernames
-    users = users.where(user_options: { ignore_channel_wide_mention: [false, nil] }) if is_channel_mention
-    users
-  end
+    if typed_global_mention
+      to_notify[:global_mentions] = members_accepting_channel_wide_notifications
+        .where.not(username_lower: normalized_mentions(direct_mentions_from_cooked))
+        .where.not(id: already_covered_ids)
+        .pluck(:id)
 
-  def users_preloaded_query(include_groups: true)
-    users = User.includes(:do_not_disturb_timings, :push_subscriptions, :user_chat_channel_memberships)
-
-    if include_groups
-      users = users.includes(:groups)
+      already_covered_ids.concat(to_notify[:global_mentions])
+    else
+      to_notify[:global_mentions] = []
     end
-
-    users
-      .joins(:user_chat_channel_memberships)
-      .joins(:user_option)
-      .real
-      .not_suspended
-      .where(user_options: { chat_enabled: true })
   end
 
-  def filter_users_who_can_chat(users)
-    users.partition do |user|
+  def expand_here_mention(to_notify, already_covered_ids)
+    typed_here_mention = direct_mentions_from_cooked.include?("@here")
+
+    if typed_here_mention
+      to_notify[:here_mentions] = members_accepting_channel_wide_notifications
+        .where("last_seen_at > ?", 5.minutes.ago)
+        .where.not(username_lower: normalized_mentions(direct_mentions_from_cooked))
+        .where.not(id: already_covered_ids)
+        .pluck(:id)
+
+      already_covered_ids.concat(to_notify[:here_mentions])
+    else
+      to_notify[:here_mentions] = []
+    end
+  end
+
+  def group_users_to_notify(users)
+    potential_participants, unreachable = users.partition do |user|
       guardian = Guardian.new(user)
       guardian.can_chat?(user) && guardian.can_see_chat_channel?(@chat_channel)
     end
+
+    participants, welcome_to_join = potential_participants.partition do |participant|
+      participant.user_chat_channel_memberships.any? { |m| m.chat_channel_id == @chat_channel.id && m.following == true }
+    end
+
+    {
+      already_participating: participants || [],
+      welcome_to_join: welcome_to_join || [],
+      unreachable: unreachable || []
+    }
+  end
+
+  def expand_direct_mentions(to_notify, already_covered_ids)
+    direct_mentions = chat_users
+      .where(username_lower: normalized_mentions(direct_mentions_from_cooked))
+      .where.not(id: already_covered_ids)
+
+    grouped = group_users_to_notify(direct_mentions)
+
+    to_notify[:direct_mentions] = grouped[:already_participating].map(&:id)
+    to_notify[:welcome_to_join] = grouped[:welcome_to_join]
+    to_notify[:unreachable] = grouped[:unreachable]
+    already_covered_ids.concat(to_notify[:direct_mentions])
+  end
+
+  def group_name_mentions
+    @group_mentions_from_cooked ||= Nokogiri::HTML5.fragment(@chat_message.cooked).css(".mention-group").map(&:text)
+  end
+
+  def mentionable_groups
+    @mentionable_groups ||= Group.mentionable(@user, include_public: false)
+      .where('LOWER(name) IN (?)', normalized_mentions(group_name_mentions))
+  end
+
+  def expand_group_mentions(to_notify, already_covered_ids)
+    return [] if mentionable_groups.empty?
+
+    mentionable_groups.each { |g| to_notify[g.name.downcase.to_sym] = [] }
+
+    reached_by_group = chat_users
+      .joins(:groups).where(groups: mentionable_groups)
+      .where.not(id: already_covered_ids)
+
+    grouped = group_users_to_notify(reached_by_group)
+
+    grouped[:already_participating].each do |user|
+      group = user.groups.detect { |g| mentionable_groups.include?(g) }
+      to_notify[group.name.downcase.to_sym] << user.id
+    end
+    already_covered_ids.concat(grouped[:already_participating])
+
+    to_notify[:welcome_to_join] = to_notify[:welcome_to_join].concat(grouped[:welcome_to_join])
+    to_notify[:unreachable] = to_notify[:unreachable].concat(grouped[:unreachable])
+  end
+
+  def notify_creator_of_inaccessible_mentions(unreachable, welcome_to_join)
+    return if unreachable.empty? && welcome_to_join.empty?
+
+    ChatPublisher.publish_inaccessible_mentions(@user.id, @chat_message, unreachable, welcome_to_join)
+  end
+
+  def enqueue_mentioned_job(to_notify, already_notified_user_ids: [])
+    Jobs.enqueue_in(3.seconds, :create_chat_mention_notifications, {
+      chat_message_id: @chat_message.id,
+      to_notify_ids_map: to_notify.as_json,
+      already_notified_user_ids: already_notified_user_ids,
+      timestamp: @timestamp.iso8601(6)
+    })
   end
 
   def notify_watching_users(except: [])

--- a/spec/jobs/regular/create_chat_mention_notifications_spec.rb
+++ b/spec/jobs/regular/create_chat_mention_notifications_spec.rb
@@ -1,0 +1,411 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Jobs::CreateChatMentionNotifications do
+  fab!(:user_1) { Fabricate(:user) }
+  fab!(:user_2) { Fabricate(:user) }
+  fab!(:public_channel) { Fabricate(:chat_channel) }
+
+  let!(:personal_chat_channel) { DiscourseChat::DirectMessageChannelCreator.create!([user_1, user_2]) }
+
+  before do
+    @chat_group = Fabricate(:group, users: [user_1, user_2])
+    @personal_chat_channel = DiscourseChat::DirectMessageChannelCreator.create!([user_1, user_2])
+
+    [user_1, user_2].each { |u| Fabricate(:user_chat_channel_membership, chat_channel: public_channel, user: u) }
+  end
+
+  def create_chat_message(channel: public_channel, user: user_1)
+    Fabricate(:chat_message, chat_channel: channel, user: user, created_at: 10.minutes.ago)
+  end
+
+  def track_desktop_notification(user: user_2, message:, to_notify_ids_map:, already_notified_user_ids: [])
+    MessageBus.track_publish("/chat/notification-alert/#{user.id}") do
+      subject.execute(
+        chat_message_id: message.id,
+        timestamp: message.created_at,
+        to_notify_ids_map: to_notify_ids_map,
+        already_notified_user_ids: already_notified_user_ids
+      )
+    end.first
+  end
+
+  def track_core_notification(user: user_2, message:, to_notify_ids_map:)
+    subject.execute(
+      chat_message_id: message.id,
+      timestamp: message.created_at,
+      to_notify_ids_map: to_notify_ids_map
+    )
+
+    Notification.where(user: user, notification_type: Notification.types[:chat_mention]).last
+  end
+
+  describe 'scenarios where we should skip sending notifications' do
+    let(:to_notify_ids_map) do
+      { here_mentions: [user_2.id] }
+    end
+
+    it "does nothing if there is a newer version of the message" do
+      message = create_chat_message
+      ChatMessageRevision.create!(chat_message: message, old_message: 'a', new_message: 'b')
+
+      PostAlerter.expects(:push_notification).never
+
+      desktop_notification = track_desktop_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+      expect(desktop_notification).to be_nil
+
+      created_notification = Notification.where(user: user_2, notification_type: Notification.types[:chat_mention]).last
+      expect(created_notification).to be_nil
+    end
+
+    it 'does nothing when user is not following the channel' do
+      message = create_chat_message
+
+      UserChatChannelMembership.where(chat_channel: public_channel, user: user_2).update!(following: false)
+
+      PostAlerter.expects(:push_notification).never
+
+      desktop_notification = track_desktop_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+      expect(desktop_notification).to be_nil
+
+      created_notification = Notification.where(user: user_2, notification_type: Notification.types[:chat_mention]).last
+      expect(created_notification).to be_nil
+    end
+
+    it "does nothing when user doesn't have a membership record" do
+      message = create_chat_message
+
+      UserChatChannelMembership.find_by(chat_channel: public_channel, user: user_2).destroy!
+
+      PostAlerter.expects(:push_notification).never
+
+      desktop_notification = track_desktop_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+      expect(desktop_notification).to be_nil
+
+      created_notification = Notification.where(user: user_2, notification_type: Notification.types[:chat_mention]).last
+      expect(created_notification).to be_nil
+    end
+
+    it 'does nothing if user is included in the already_notified_user_ids' do
+      message = create_chat_message
+
+      PostAlerter.expects(:push_notification).never
+
+      desktop_notification = track_desktop_notification(
+        message: message, to_notify_ids_map: to_notify_ids_map,
+        already_notified_user_ids: [user_2.id]
+      )
+      expect(desktop_notification).to be_nil
+
+      created_notification = Notification.where(user: user_2, notification_type: Notification.types[:chat_mention]).last
+      expect(created_notification).to be_nil
+    end
+
+    it 'does nothing if user is not participating in a private channel' do
+      user_3 = Fabricate(:user)
+      @chat_group.add(user_3)
+      to_notify_map = { direct_mentions: [user_3.id] }
+
+      message = create_chat_message(channel: @personal_chat_channel)
+
+      PostAlerter.expects(:push_notification).never
+
+      desktop_notification = track_desktop_notification(
+        message: message, to_notify_ids_map: to_notify_map,
+      )
+      expect(desktop_notification).to be_nil
+
+      created_notification = Notification.where(user: user_3, notification_type: Notification.types[:chat_mention]).last
+      expect(created_notification).to be_nil
+    end
+
+    it 'skips desktop notifications based on user preferences' do
+      message = create_chat_message
+      UserChatChannelMembership
+        .find_by(chat_channel: public_channel, user: user_2)
+        .update!(desktop_notification_level: UserChatChannelMembership::NOTIFICATION_LEVELS[:never])
+
+        desktop_notification = track_desktop_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+
+      expect(desktop_notification).to be_nil
+    end
+
+    it 'skips push notifications based on user preferences' do
+      message = create_chat_message
+      UserChatChannelMembership
+        .find_by(chat_channel: public_channel, user: user_2)
+        .update!(mobile_notification_level: UserChatChannelMembership::NOTIFICATION_LEVELS[:never])
+
+      PostAlerter.expects(:push_notification).never
+
+      subject.execute(
+        chat_message_id: message.id,
+        timestamp: message.created_at,
+        to_notify_ids_map: to_notify_ids_map
+      )
+    end
+  end
+
+  shared_examples 'creates different notifications with basic data' do
+    let(:expected_channel_title) { public_channel.title(user_2) }
+
+    it 'works for desktop notifications' do
+      message = create_chat_message
+
+      desktop_notification = track_desktop_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+
+      expect(desktop_notification).to be_present
+      expect(desktop_notification.data[:notification_type]).to eq(Notification.types[:chat_mention])
+      expect(desktop_notification.data[:username]).to eq(user_1.username)
+      expect(desktop_notification.data[:tag]).to eq(
+        DiscourseChat::ChatNotifier.push_notification_tag(:mention, public_channel.id)
+      )
+      expect(desktop_notification.data[:excerpt]).to eq(message.push_notification_excerpt)
+      expect(desktop_notification.data[:post_url]).to eq(
+        "/chat/channel/#{public_channel.id}/#{expected_channel_title}?messageId=#{message.id}"
+      )
+    end
+
+    it 'works for push notifications' do
+      message = create_chat_message
+
+      PostAlerter.expects(:push_notification).with(
+        user_2,
+        {
+          notification_type: Notification.types[:chat_mention],
+          username: user_1.username,
+          tag: DiscourseChat::ChatNotifier.push_notification_tag(:mention, public_channel.id),
+          excerpt: message.push_notification_excerpt,
+          post_url: "/chat/channel/#{public_channel.id}/#{expected_channel_title}?messageId=#{message.id}",
+          translated_title: payload_translated_title
+        }
+      )
+
+      subject.execute(
+        chat_message_id: message.id,
+        timestamp: message.created_at,
+        to_notify_ids_map: to_notify_ids_map
+      )
+    end
+
+    it 'works for core notifications' do
+      message = create_chat_message
+
+      created_notification = track_core_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+
+      expect(created_notification).to be_present
+      expect(created_notification.high_priority).to eq(true)
+      expect(created_notification.read).to eq(false)
+
+      data_hash = created_notification.data_hash
+
+      expect(data_hash[:chat_message_id]).to eq(message.id)
+      expect(data_hash[:chat_channel_id]).to eq(public_channel.id)
+      expect(data_hash[:mentioned_by_username]).to eq(user_1.username)
+      expect(data_hash[:is_direct_message_channel]).to eq(false)
+      expect(data_hash[:chat_channel_title]).to eq(expected_channel_title)
+
+      chat_mention = ChatMention.where(notification: created_notification, user: user_2, chat_message: message)
+      expect(chat_mention).to be_present
+    end
+  end
+
+  describe '#execute' do
+    describe 'global mention notifications' do
+      let(:to_notify_ids_map) do
+        { global_mentions: [user_2.id] }
+      end
+
+      let(:payload_translated_title) do
+        I18n.t("discourse_push_notifications.popup.chat_mention.other",
+          username: user_1.username,
+          identifier: '@all',
+          channel: public_channel.title(user_2)
+        )
+      end
+
+      include_examples 'creates different notifications with basic data'
+
+      it 'includes global mention specific data to core notifications' do
+        message = create_chat_message
+
+        created_notification = track_core_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+
+        data_hash = created_notification.data_hash
+
+        expect(data_hash[:identifier]).to eq('all')
+      end
+
+      it 'includes global mention specific data to desktop notifications' do
+        message = create_chat_message
+
+        desktop_notification = track_desktop_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+
+        expect(desktop_notification.data[:translated_title]).to eq(payload_translated_title)
+      end
+
+      context 'on private channels' do
+        it 'users a different translated title' do
+          message = create_chat_message(channel: @personal_chat_channel)
+
+          desktop_notification = track_desktop_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+
+          expected_title = I18n.t("discourse_push_notifications.popup.direct_message_chat_mention.other",
+            username: user_1.username,
+            identifier: '@all',
+          )
+
+          expect(desktop_notification.data[:translated_title]).to eq(expected_title)
+        end
+      end
+    end
+
+    describe 'here mention notifications' do
+      let(:to_notify_ids_map) do
+        { here_mentions: [user_2.id] }
+      end
+
+      let(:payload_translated_title) do
+        I18n.t("discourse_push_notifications.popup.chat_mention.other",
+          username: user_1.username,
+          identifier: '@here',
+          channel: public_channel.title(user_2)
+        )
+      end
+
+      include_examples 'creates different notifications with basic data'
+
+      it 'includes here mention specific data to core notifications' do
+        message = create_chat_message
+
+        created_notification = track_core_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+        data_hash = created_notification.data_hash
+
+        expect(data_hash[:identifier]).to eq('here')
+      end
+
+      it 'includes here mention specific data to desktop notifications' do
+        message = create_chat_message
+
+        desktop_notification = track_desktop_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+
+        expect(desktop_notification.data[:translated_title]).to eq(payload_translated_title)
+      end
+
+      context 'on private channels' do
+        it 'users a different translated title' do
+          message = create_chat_message(channel: @personal_chat_channel)
+
+          desktop_notification = track_desktop_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+
+          expected_title = I18n.t("discourse_push_notifications.popup.direct_message_chat_mention.other",
+            username: user_1.username,
+            identifier: '@here',
+          )
+
+          expect(desktop_notification.data[:translated_title]).to eq(expected_title)
+        end
+      end
+    end
+
+    describe 'direct mention notifications' do
+      let(:to_notify_ids_map) do
+        { direct_mentions: [user_2.id] }
+      end
+
+      let(:payload_translated_title) do
+        I18n.t("discourse_push_notifications.popup.chat_mention.direct",
+          username: user_1.username,
+          identifier: '',
+          channel: public_channel.title(user_2)
+        )
+      end
+
+      include_examples 'creates different notifications with basic data'
+
+      it 'includes here mention specific data to core notifications' do
+        message = create_chat_message
+
+        created_notification = track_core_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+        data_hash = created_notification.data_hash
+
+        expect(data_hash[:identifier]).to be_nil
+      end
+
+      it 'includes here mention specific data to desktop notifications' do
+        message = create_chat_message
+
+        desktop_notification = track_desktop_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+
+        expect(desktop_notification.data[:translated_title]).to eq(payload_translated_title)
+      end
+
+      context 'on private channels' do
+        it 'users a different translated title' do
+          message = create_chat_message(channel: @personal_chat_channel)
+
+          desktop_notification = track_desktop_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+
+          expected_title = I18n.t("discourse_push_notifications.popup.direct_message_chat_mention.direct",
+            username: user_1.username,
+            identifier: '',
+          )
+
+          expect(desktop_notification.data[:translated_title]).to eq(expected_title)
+        end
+      end
+    end
+
+    describe 'group mentions' do
+      let(:to_notify_ids_map) do
+        {
+          @chat_group.name.to_sym => [user_2.id]
+        }
+      end
+
+      let(:payload_translated_title) do
+        I18n.t("discourse_push_notifications.popup.chat_mention.other",
+          username: user_1.username,
+          identifier: "@#{@chat_group.name}",
+          channel: public_channel.title(user_2)
+        )
+      end
+
+      include_examples 'creates different notifications with basic data'
+
+      it 'includes here mention specific data to core notifications' do
+        message = create_chat_message
+
+        created_notification = track_core_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+        data_hash = created_notification.data_hash
+
+        expect(data_hash[:identifier]).to be_nil
+        expect(data_hash[:is_group_mention]).to eq(true)
+      end
+
+      it 'includes here mention specific data to desktop notifications' do
+        message = create_chat_message
+
+        desktop_notification = track_desktop_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+
+        expect(desktop_notification.data[:translated_title]).to eq(payload_translated_title)
+      end
+
+      context 'on private channels' do
+        it 'users a different translated title' do
+          message = create_chat_message(channel: @personal_chat_channel)
+
+          desktop_notification = track_desktop_notification(message: message, to_notify_ids_map: to_notify_ids_map)
+
+          expected_title = I18n.t("discourse_push_notifications.popup.direct_message_chat_mention.other",
+            username: user_1.username,
+            identifier: "@#{@chat_group.name}",
+          )
+
+          expect(desktop_notification.data[:translated_title]).to eq(expected_title)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/chat_notifier_spec.rb
+++ b/spec/lib/chat_notifier_spec.rb
@@ -173,7 +173,7 @@ describe DiscourseChat::ChatNotifier do
       end
 
       let(:mention) { "hello @#{group.name}!" }
-      let(:list_key) { group.name.to_sym }
+      let(:list_key) { group.name }
 
       include_examples 'ensure only channel members are notified'
     end
@@ -227,7 +227,7 @@ describe DiscourseChat::ChatNotifier do
           messages = MessageBus.track_publish("/chat/#{personal_chat_channel.id}") do
             to_notify = described_class.new(msg, msg.created_at).notify_new
 
-            expect(to_notify[group.name.to_sym]).to contain_exactly(user_2.id)
+            expect(to_notify[group.name]).to contain_exactly(user_2.id)
           end
 
           unreachable_msg = messages.first

--- a/spec/lib/chat_notifier_spec.rb
+++ b/spec/lib/chat_notifier_spec.rb
@@ -1,0 +1,302 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DiscourseChat::ChatNotifier do
+  describe '#notify_new' do
+    fab!(:channel) { Fabricate(:chat_channel) }
+    fab!(:user_1) { Fabricate(:user) }
+    fab!(:user_2) { Fabricate(:user) }
+
+    before do
+      @chat_group = Fabricate(:group, users: [user_1, user_2])
+      SiteSetting.chat_allowed_groups = @chat_group.id
+
+      [user_1, user_2].each { |u| Fabricate(:user_chat_channel_membership, chat_channel: channel, user: u) }
+    end
+
+    def build_cooked_msg(message_body, user, chat_channel: channel)
+      ChatMessage.new(
+        chat_channel: chat_channel, user: user,
+        message: message_body, created_at: 5.minutes.ago
+      ).tap(&:cook)
+    end
+
+    shared_examples 'channel-wide mentions' do
+      it "returns an empty list when the message doesn't include a channel mention" do
+        msg = build_cooked_msg(mention.gsub('@', ''), user_1)
+
+        to_notify = described_class.new(msg, msg.created_at).notify_new
+
+        expect(to_notify[list_key]).to be_empty
+      end
+
+      it 'will never include someone who is not accepting channel-wide notifications' do
+        user_2.user_option.update!(ignore_channel_wide_mention: true)
+        msg = build_cooked_msg(mention, user_1)
+
+        to_notify = described_class.new(msg, msg.created_at).notify_new
+
+        expect(to_notify[list_key]).to be_empty
+      end
+
+      it 'includes all members of a channel except the sender' do
+        msg = build_cooked_msg(mention, user_1)
+
+        to_notify = described_class.new(msg, msg.created_at).notify_new
+
+        expect(to_notify[list_key]).to contain_exactly(user_2.id)
+      end
+    end
+
+    shared_examples 'ensure only channel members are notified' do
+      it 'will never include someone outside the channel' do
+        user3 = Fabricate(:user)
+        @chat_group.add(user3)
+        another_channel = Fabricate(:chat_channel)
+        Fabricate(:user_chat_channel_membership, chat_channel: another_channel, user: user3)
+        msg = build_cooked_msg(mention, user_1)
+
+        to_notify = described_class.new(msg, msg.created_at).notify_new
+
+        expect(to_notify[list_key]).to contain_exactly(user_2.id)
+      end
+
+      it 'will never include someone not following the channel anymore' do
+        user3 = Fabricate(:user)
+        @chat_group.add(user3)
+        Fabricate(:user_chat_channel_membership, following: false, chat_channel: channel, user: user3)
+        msg = build_cooked_msg(mention, user_1)
+
+        to_notify = described_class.new(msg, msg.created_at).notify_new
+
+        expect(to_notify[list_key]).to contain_exactly(user_2.id)
+      end
+
+      it 'will never include someone who is suspended' do
+        user3 = Fabricate(:user, suspended_till: 2.years.from_now)
+        @chat_group.add(user3)
+        Fabricate(:user_chat_channel_membership, following: true, chat_channel: channel, user: user3)
+
+        msg = build_cooked_msg(mention, user_1)
+
+        to_notify = described_class.new(msg, msg.created_at).notify_new
+
+        expect(to_notify[list_key]).to contain_exactly(user_2.id)
+      end
+    end
+
+    describe 'global_mentions' do
+      let(:mention) { 'hello @all!' }
+      let(:list_key) { :global_mentions }
+
+      include_examples 'channel-wide mentions'
+      include_examples 'ensure only channel members are notified'
+    end
+
+    describe 'here_mentions' do
+      let(:mention) { 'hello @here!' }
+      let(:list_key) { :here_mentions }
+
+      before do
+        user_2.update!(last_seen_at: 4.minutes.ago)
+      end
+
+      include_examples 'channel-wide mentions'
+      include_examples 'ensure only channel members are notified'
+
+      it 'includes users seen less than 5 minutes ago' do
+        msg = build_cooked_msg(mention, user_1)
+
+        to_notify = described_class.new(msg, msg.created_at).notify_new
+
+        expect(to_notify[list_key]).to contain_exactly(user_2.id)
+      end
+
+      it 'excludes users seen more than 5 minutes ago' do
+        user_2.update!(last_seen_at: 6.minutes.ago)
+        msg = build_cooked_msg(mention, user_1)
+
+        to_notify = described_class.new(msg, msg.created_at).notify_new
+
+        expect(to_notify[list_key]).to be_empty
+      end
+
+      it 'excludes users mentioned directly' do
+        msg = build_cooked_msg("hello @here @#{user_2.username}!", user_1)
+
+        to_notify = described_class.new(msg, msg.created_at).notify_new
+
+        expect(to_notify[list_key]).to be_empty
+      end
+    end
+
+    describe 'direct_mentions' do
+      it 'only include mentioned users' do
+        user_3 = Fabricate(:user)
+        @chat_group.add(user_3)
+        another_channel = Fabricate(:chat_channel)
+        Fabricate(:user_chat_channel_membership, chat_channel: another_channel, user: user_3)
+        msg = build_cooked_msg("Is @#{user_3.username} here? And @#{user_2.username}", user_1)
+
+        to_notify = described_class.new(msg, msg.created_at).notify_new
+
+        expect(to_notify[:direct_mentions]).to contain_exactly(user_2.id)
+      end
+
+      it "include users as direct mentions even if there's a @here mention" do
+        msg = build_cooked_msg("Hello @here and @#{user_2.username}", user_1)
+
+        to_notify = described_class.new(msg, msg.created_at).notify_new
+
+        expect(to_notify[:here_mentions]).to be_empty
+        expect(to_notify[:direct_mentions]).to contain_exactly(user_2.id)
+      end
+
+      it "include users as direct mentions even if there's a @all mention" do
+        msg = build_cooked_msg("Hello @all and @#{user_2.username}", user_1)
+
+        to_notify = described_class.new(msg, msg.created_at).notify_new
+
+        expect(to_notify[:global_mentions]).to be_empty
+        expect(to_notify[:direct_mentions]).to contain_exactly(user_2.id)
+      end
+    end
+
+    describe 'group mentions' do
+      fab!(:user_3) { Fabricate(:user) }
+      fab!(:group) { Fabricate(:public_group, users: [user_2, user_3], mentionable_level: Group::ALIAS_LEVELS[:everyone]) }
+      fab!(:other_channel) { Fabricate(:chat_channel) }
+
+      before do
+        @chat_group.add(user_3)
+      end
+
+      let(:mention) { "hello @#{group.name}!" }
+      let(:list_key) { group.name.to_sym }
+
+      include_examples 'ensure only channel members are notified'
+    end
+
+    describe 'unreachable users' do
+      fab!(:user_3) { Fabricate(:user) }
+
+      it 'notify poster of users who are not allowed to use chat' do
+        msg = build_cooked_msg("Hello @#{user_3.username}", user_1)
+
+        messages = MessageBus.track_publish("/chat/#{channel.id}") do
+          to_notify = described_class.new(msg, msg.created_at).notify_new
+
+          expect(to_notify[:direct_mentions]).to be_empty
+        end
+
+        unreachable_msg = messages.first
+
+        expect(unreachable_msg).to be_present
+        expect(unreachable_msg.data[:without_membership]).to be_empty
+        unreachable_users = unreachable_msg.data[:cannot_see].map { |u| u[:id] }
+        expect(unreachable_users).to contain_exactly(user_3.id)
+      end
+
+      context 'in a personal message' do
+        let(:personal_chat_channel) { DiscourseChat::DirectMessageChannelCreator.create!([user_1, user_2]) }
+
+        before { @chat_group.add(user_3) }
+
+        it 'notify posts of users who are not participating in a personal message' do
+          msg = build_cooked_msg("Hello @#{user_3.username}", user_1, chat_channel: personal_chat_channel)
+
+          messages = MessageBus.track_publish("/chat/#{personal_chat_channel.id}") do
+            to_notify = described_class.new(msg, msg.created_at).notify_new
+
+            expect(to_notify[:direct_mentions]).to be_empty
+          end
+
+          unreachable_msg = messages.first
+
+          expect(unreachable_msg).to be_present
+          expect(unreachable_msg.data[:without_membership]).to be_empty
+          unreachable_users = unreachable_msg.data[:cannot_see].map { |u| u[:id] }
+          expect(unreachable_users).to contain_exactly(user_3.id)
+        end
+
+        it 'notify posts of users who are part of the mentioned group but participanting' do
+          group = Fabricate(:public_group, users: [user_2, user_3], mentionable_level: Group::ALIAS_LEVELS[:everyone])
+          msg = build_cooked_msg("Hello @#{group.name}", user_1, chat_channel: personal_chat_channel)
+
+          messages = MessageBus.track_publish("/chat/#{personal_chat_channel.id}") do
+            to_notify = described_class.new(msg, msg.created_at).notify_new
+
+            expect(to_notify[group.name.to_sym]).to contain_exactly(user_2.id)
+          end
+
+          unreachable_msg = messages.first
+
+          expect(unreachable_msg).to be_present
+          expect(unreachable_msg.data[:without_membership]).to be_empty
+          unreachable_users = unreachable_msg.data[:cannot_see].map { |u| u[:id] }
+          expect(unreachable_users).to contain_exactly(user_3.id)
+        end
+      end
+    end
+
+    describe 'users who can be invited to join the channel' do
+      fab!(:user_3) { Fabricate(:user) }
+
+      before { @chat_group.add(user_3) }
+
+      it 'can invite chat user without channel membership' do
+        msg = build_cooked_msg("Hello @#{user_3.username}", user_1)
+
+        messages = MessageBus.track_publish("/chat/#{channel.id}") do
+          to_notify = described_class.new(msg, msg.created_at).notify_new
+
+          expect(to_notify[:direct_mentions]).to be_empty
+        end
+
+        not_participating_msg = messages.first
+
+        expect(not_participating_msg).to be_present
+        expect(not_participating_msg.data[:cannot_see]).to be_empty
+        not_participating_users = not_participating_msg.data[:without_membership].map { |u| u[:id] }
+        expect(not_participating_users).to contain_exactly(user_3.id)
+      end
+
+      it 'can invite chat user who no longer follows the channel' do
+        Fabricate(:user_chat_channel_membership, chat_channel: channel, user: user_3, following: false)
+        msg = build_cooked_msg("Hello @#{user_3.username}", user_1)
+
+        messages = MessageBus.track_publish("/chat/#{channel.id}") do
+          to_notify = described_class.new(msg, msg.created_at).notify_new
+
+          expect(to_notify[:direct_mentions]).to be_empty
+        end
+
+        not_participating_msg = messages.first
+
+        expect(not_participating_msg).to be_present
+        expect(not_participating_msg.data[:cannot_see]).to be_empty
+        not_participating_users = not_participating_msg.data[:without_membership].map { |u| u[:id] }
+        expect(not_participating_users).to contain_exactly(user_3.id)
+      end
+
+      it 'can invite other group members to channel' do
+        group = Fabricate(:public_group, users: [user_2, user_3], mentionable_level: Group::ALIAS_LEVELS[:everyone])
+        msg = build_cooked_msg("Hello @#{group.name}", user_1)
+
+        messages = MessageBus.track_publish("/chat/#{channel.id}") do
+          to_notify = described_class.new(msg, msg.created_at).notify_new
+
+          expect(to_notify[:direct_mentions]).to be_empty
+        end
+
+        not_participating_msg = messages.first
+
+        expect(not_participating_msg).to be_present
+        expect(not_participating_msg.data[:cannot_see]).to be_empty
+        not_participating_users = not_participating_msg.data[:without_membership].map { |u| u[:id] }
+        expect(not_participating_users).to contain_exactly(user_3.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When we want to notify users of a chat message, the `ChatNotifier` is our only source of truth. This service selects and groups the users by mention types, expanding direct, group, and channel-wide mentions. It also filters
unreachable users we can't notify because they don't have chat access or are not participating if the channel is private.

 It doesn't send notifications itself but generates a "map" and gives it to a scheduled job. This structure includes all the users to notify and the mention type metadata, which we need in order to ship different data in the
notifications.

The current implementation has a bug that includes group members who aren't participating in a private conversation if the message mentions a group. The scheduled job has an additional membership check, so it doesn't cause any
problems right now, but if another component uses this map to do other things, there's a risk it will leak private messages.

It happens because the application of the expansion rules and the map generation are happening in two different points, and we don't apply the `can_see_chat_channel?` filter during the later. The duplication makes the  logic more
error-prone, so this PR refactor the class to do both in a single step, avoiding losing information or missing filters. It also adds some unit tests to complement the acceptance ones we already have.
