### PR TITLE
FIX: Don't hide the new messages indicator beside the channel header

### DIFF
--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -5,8 +5,7 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
   FUTURE_MESSAGE_LIMIT = 40
   PAST = 'past'
   FUTURE = 'future'
-  BOTH = 'both'
-  CHAT_DIRECTIONS = [PAST, FUTURE, BOTH]
+  CHAT_DIRECTIONS = [PAST, FUTURE]
 
   before_action :find_chatable, only: [:enable_chat, :disable_chat]
   before_action :find_chat_message, only: [
@@ -184,12 +183,11 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
     messages = messages.with_deleted if guardian.can_moderate_chat?(@chatable)
 
     if message_id.present?
-      condition = [PAST, BOTH].include?(direction) ? '<' : '>'
+      condition = direction == PAST ? '<' : '>'
       messages = messages.where("id #{condition} ?", message_id.to_i)
     end
 
-    order = :desc
-    order = :asc if direction == FUTURE
+    order = direction == FUTURE ? :asc : :desc
     messages = messages.order(id: order).limit(page_size).to_a
 
     can_load_more_past = nil
@@ -199,9 +197,6 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
       can_load_more_future = messages.size == page_size
     elsif direction == PAST
       can_load_more_past = messages.size == page_size
-    elsif direction == BOTH
-      can_load_more_past = messages.size == page_size
-      can_load_more_future = true
     else
       # When direction is blank, we'll return the latest messages.
       can_load_more_future = false

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -3,6 +3,10 @@
 class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
   PAST_MESSAGE_LIMIT = 20
   FUTURE_MESSAGE_LIMIT = 40
+  PAST = 'past'
+  FUTURE = 'future'
+  BOTH = 'both'
+  CHAT_DIRECTIONS = [PAST, FUTURE, BOTH]
 
   before_action :find_chatable, only: [:enable_chat, :disable_chat]
   before_action :find_chat_message, only: [
@@ -170,37 +174,43 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
   def messages
     set_channel_and_chatable
     page_size = params[:page_size]&.to_i || 1000
-    if page_size > 50 || (params[:before_message_id] && params[:after_message_id])
+    direction = params[:direction].to_s
+    message_id = params[:message_id]
+    if page_size > 50 || (message_id.blank? ^ direction.blank? && (direction.present? && !CHAT_DIRECTIONS.include?(direction)))
       raise Discourse::InvalidParameters
     end
 
     messages = preloaded_chat_message_query.where(chat_channel: @chat_channel)
-
-    order_direction = :desc
-    if params[:before_message_id]
-      messages = messages.where("id < ?", params[:before_message_id])
-    end
-
-    if params[:after_message_id]
-      messages = messages.where("id > ?", params[:after_message_id])
-      order_direction = :asc
-    end
-
     messages = messages.with_deleted if guardian.can_moderate_chat?(@chatable)
-    messages = messages.order(id: order_direction).limit(page_size)
 
-    can_load_more_past = params[:after_message_id] ? nil : messages.count == page_size
-    can_load_more_future = if !params[:before_message_id] && !params[:after_message_id]
-      false
-    elsif params[:before_message_id]
-      nil
-    elsif params[:after_message_id]
-      messages.count == page_size
+    if message_id.present?
+      condition = [PAST, BOTH].include?(direction) ? '<' : '>'
+      messages = messages.where("id #{condition} ?", message_id.to_i)
+    end
+
+    order = :desc
+    order = :asc if direction == FUTURE
+    messages = messages.order(id: order).limit(page_size).to_a
+
+    can_load_more_past = nil
+    can_load_more_future = nil
+
+    if direction == FUTURE
+      can_load_more_future = messages.size == page_size
+    elsif direction == PAST
+      can_load_more_past = messages.size == page_size
+    elsif direction == BOTH
+      can_load_more_past = messages.size == page_size
+      can_load_more_future = true
+    else
+      # When direction is blank, we'll return the latest messages.
+      can_load_more_future = false
+      can_load_more_past = messages.size == page_size
     end
 
     chat_view = ChatView.new(
       chat_channel: @chat_channel,
-      chat_messages: params[:after_message_id] ? messages : messages.to_a.reverse,
+      chat_messages: direction == FUTURE ? messages : messages.reverse,
       user: current_user,
       can_load_more_past: can_load_more_past,
       can_load_more_future: can_load_more_future

--- a/assets/javascripts/discourse/adapters/chat-message.js
+++ b/assets/javascripts/discourse/adapters/chat-message.js
@@ -3,7 +3,7 @@ import RESTAdapter from "discourse/adapters/rest";
 export default RESTAdapter.extend({
   pathFor(store, type, findArgs) {
     if (findArgs.targetMessageId) {
-      return `/chat/lookup/${findArgs.targetMessageId}.json?page_size=${findArgs.pageSize}`;
+      return `/chat/lookup/${findArgs.targetMessageId}.json`;
     }
 
     let path = `/chat/${findArgs.channelId}/messages.json?page_size=${findArgs.pageSize}`;

--- a/assets/javascripts/discourse/adapters/chat-message.js
+++ b/assets/javascripts/discourse/adapters/chat-message.js
@@ -7,11 +7,11 @@ export default RESTAdapter.extend({
     }
 
     let path = `/chat/${findArgs.channelId}/messages.json?page_size=${findArgs.pageSize}`;
-    if (findArgs.beforeMessageId) {
-      path += `&before_message_id=${findArgs.beforeMessageId}`;
+    if (findArgs.messageId) {
+      path += `&message_id=${findArgs.messageId}`;
     }
-    if (findArgs.afterMessageId) {
-      path += `&after_message_id=${findArgs.afterMessageId}`;
+    if (findArgs.direction) {
+      path += `&direction=${findArgs.direction}`;
     }
     return path;
   },

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -179,28 +179,6 @@ RSpec.describe DiscourseChat::ChatController do
       end
     end
 
-    describe 'when direction is both ways' do
-      it 'returns messages before the ID' do
-        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_30.id, direction: described_class::BOTH, page_size: page_size }
-        messages = response.parsed_body["chat_messages"]
-        expect(messages.count).to eq(page_size)
-        expect(messages.first["id"]).to eq(message_0.id)
-        expect(messages.last["id"]).to eq(message_29.id)
-      end
-
-      it "signals there are messages available both ways when the results size matches the page size" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_30.id, direction: described_class::BOTH, page_size: page_size }
-        expect(response.parsed_body["meta"]["can_load_more_past"]).to eq(true)
-        expect(response.parsed_body["meta"]["can_load_more_future"]).to eq(true)
-      end
-
-      it "only signals there are messages available in the past when the results size doesn't matches" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_10.id, direction: described_class::BOTH, page_size: page_size }
-        expect(response.parsed_body["meta"]["can_load_more_past"]).to eq(false)
-        expect(response.parsed_body["meta"]["can_load_more_future"]).to eq(true)
-      end
-    end
-
     describe 'without direction (latest messages)' do
       it 'signals there are no future messages' do
         get "/chat/#{chat_channel.id}/messages.json", params: { page_size: page_size }

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -135,9 +135,9 @@ RSpec.describe DiscourseChat::ChatController do
       expect(reactions[smile_emoji]["reacted"]).to be false
     end
 
-    describe "with 'before_message_id' param" do
+    describe "scrolling to the past" do
       it "returns the correct messages" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { before_message_id: message_40.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_40.id, direction: described_class::PAST, page_size: page_size }
         messages = response.parsed_body["chat_messages"]
         expect(messages.count).to eq(page_size)
         expect(messages.first["id"]).to eq(message_10.id)
@@ -145,21 +145,21 @@ RSpec.describe DiscourseChat::ChatController do
       end
 
       it "returns 'can_load...' properly when there are more past messages" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { before_message_id: message_40.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_40.id, direction: described_class::PAST, page_size: page_size }
         expect(response.parsed_body["meta"]["can_load_more_past"]).to be true
         expect(response.parsed_body["meta"]["can_load_more_future"]).to be_nil
       end
 
       it "returns 'can_load...' properly when there are no past messages" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { before_message_id: message_3.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_3.id, direction: described_class::PAST, page_size: page_size }
         expect(response.parsed_body["meta"]["can_load_more_past"]).to be false
         expect(response.parsed_body["meta"]["can_load_more_future"]).to be_nil
       end
     end
 
-    describe "with 'after_message_id' param" do
+    describe "scrolling to the future" do
       it "returns the correct messages when there are many after" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { after_message_id: message_10.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_10.id, direction: described_class::FUTURE, page_size: page_size }
         messages = response.parsed_body["chat_messages"]
         expect(messages.count).to eq(page_size)
         expect(messages.first["id"]).to eq(message_11.id)
@@ -167,27 +167,63 @@ RSpec.describe DiscourseChat::ChatController do
       end
 
       it "return 'can_load..' properly when there are future messages" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { after_message_id: message_10.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_10.id, direction: described_class::FUTURE, page_size: page_size }
         expect(response.parsed_body["meta"]["can_load_more_past"]).to be_nil
         expect(response.parsed_body["meta"]["can_load_more_future"]).to be true
       end
 
       it "returns 'can_load..' properly when there are no future messages" do
-        get "/chat/#{chat_channel.id}/messages.json", params: { after_message_id: message_60.id, page_size: page_size }
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_60.id, direction: described_class::FUTURE, page_size: page_size }
         expect(response.parsed_body["meta"]["can_load_more_past"]).to be_nil
         expect(response.parsed_body["meta"]["can_load_more_future"]).to be false
       end
     end
 
-    it "errors when both 'after_message_id' and 'before_message_id' are present" do
-      get "/chat/#{chat_channel.id}/messages.json", params: {
-        before_message_id: message_40.id,
-        after_message_id: message_20.id,
-        page_size: page_size
-      }
-      expect(response.status).to eq(400)
+    describe 'when direction is both ways' do
+      it 'returns messages before the ID' do
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_30.id, direction: described_class::BOTH, page_size: page_size }
+        messages = response.parsed_body["chat_messages"]
+        expect(messages.count).to eq(page_size)
+        expect(messages.first["id"]).to eq(message_0.id)
+        expect(messages.last["id"]).to eq(message_29.id)
+      end
+
+      it "signals there are messages available both ways when the results size matches the page size" do
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_30.id, direction: described_class::BOTH, page_size: page_size }
+        expect(response.parsed_body["meta"]["can_load_more_past"]).to eq(true)
+        expect(response.parsed_body["meta"]["can_load_more_future"]).to eq(true)
+      end
+
+      it "only signals there are messages available in the past when the results size doesn't matches" do
+        get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_10.id, direction: described_class::BOTH, page_size: page_size }
+        expect(response.parsed_body["meta"]["can_load_more_past"]).to eq(false)
+        expect(response.parsed_body["meta"]["can_load_more_future"]).to eq(true)
+      end
     end
 
+    describe 'without direction (latest messages)' do
+      it 'signals there are no future messages' do
+        get "/chat/#{chat_channel.id}/messages.json", params: { page_size: page_size }
+
+        expect(response.parsed_body["meta"]["can_load_more_future"]).to eq(false)
+      end
+
+      it 'signals there are more messages in the past' do
+        get "/chat/#{chat_channel.id}/messages.json", params: { page_size: page_size }
+
+        expect(response.parsed_body["meta"]["can_load_more_past"]).to eq(true)
+      end
+
+      it 'signals there are no more messages' do
+        new_channel = Fabricate(:chat_channel)
+        Fabricate(:chat_message, chat_channel: new_channel, user: other_user, message: "message")
+        chat_messages_qty = 1
+
+        get "/chat/#{new_channel.id}/messages.json", params: { page_size: chat_messages_qty + 1 }
+
+        expect(response.parsed_body["meta"]["can_load_more_past"]).to eq(false)
+      end
+    end
   end
 
   describe "#enable_chat" do


### PR DESCRIPTION
Reverts discourse/discourse-chat#835

### Isolated:
<img width="819" alt="Screen Shot 2022-05-09 at 15 30 54" src="https://user-images.githubusercontent.com/5025816/167477571-7f31740f-1953-48d5-8b1d-58b0cb340a05.png">

### Drawer:
<img width="402" alt="Screen Shot 2022-05-09 at 15 32 42" src="https://user-images.githubusercontent.com/5025816/167477598-c8b1c521-11ce-4046-b3e9-49fd55d3229a.png">

### Mobile:
<img width="387" alt="Screen Shot 2022-05-09 at 15 33 55" src="https://user-images.githubusercontent.com/5025816/167477604-b2314d83-1aa8-4054-921c-0f56237a75da.png">
