### PR TITLE
DEV: Refactor collapser

### DIFF
--- a/assets/javascripts/discourse/components/chat-message-collapser.js
+++ b/assets/javascripts/discourse/components/chat-message-collapser.js
@@ -11,8 +11,40 @@ export default class ChatMessageCollapser extends Component {
   uploads = null;
   cooked = null;
 
+  @computed("uploads")
+  get hasUploads() {
+    return hasUploads(this.uploads);
+  }
+
+  @computed("uploads")
+  get uploadsHeader() {
+    let name = "";
+    if (this.uploads.length === 1) {
+      name = this.uploads[0].original_filename;
+    } else {
+      name = I18n.t("chat.uploaded_files", { count: this.uploads.length });
+    }
+    return `<span class="chat-message-collapser-link-small">${name}</span>`;
+  }
+
   @computed("cooked")
-  get youtubeCooked() {
+  get cookedBodies() {
+    if (hasYoutube(this.cooked)) {
+      return this.youtubeCooked();
+    }
+
+    if (hasImageOnebox(this.cooked)) {
+      return this.imageOneboxCooked();
+    }
+
+    if (hasImage(this.cooked)) {
+      return this.imageCooked();
+    }
+
+    return [];
+  }
+
+  youtubeCooked() {
     const elements = Array.prototype.slice.call(domFromString(this.cooked));
 
     return elements.reduce((acc, e) => {
@@ -35,19 +67,7 @@ export default class ChatMessageCollapser extends Component {
     }, []);
   }
 
-  @computed("uploads")
-  get uploadsHeader() {
-    let name = "";
-    if (this.uploads.length === 1) {
-      name = this.uploads[0].original_filename;
-    } else {
-      name = I18n.t("chat.uploaded_files", { count: this.uploads.length });
-    }
-    return `<span class="chat-message-collapser-link-small">${name}</span>`;
-  }
-
-  @computed("cooked")
-  get imageOneboxCooked() {
+  imageOneboxCooked() {
     const elements = Array.prototype.slice.call(domFromString(this.cooked));
 
     return elements.reduce((acc, e) => {
@@ -66,8 +86,7 @@ export default class ChatMessageCollapser extends Component {
     }, []);
   }
 
-  @computed("cooked")
-  get imageCooked() {
+  imageCooked() {
     const elements = Array.prototype.slice.call(domFromString(this.cooked));
 
     return elements.reduce((acc, e) => {
@@ -85,26 +104,6 @@ export default class ChatMessageCollapser extends Component {
       }
       return acc;
     }, []);
-  }
-
-  @computed("cooked")
-  get hasYoutube() {
-    return hasYoutube(this.cooked);
-  }
-
-  @computed("uploads")
-  get hasUploads() {
-    return hasUploads(this.uploads);
-  }
-
-  @computed("cooked")
-  get hasImageOnebox() {
-    return hasImageOnebox(this.cooked);
-  }
-
-  @computed("cooked")
-  get hasImage() {
-    return hasImage(this.cooked);
   }
 }
 

--- a/assets/javascripts/discourse/components/chat-message-collapser.js
+++ b/assets/javascripts/discourse/components/chat-message-collapser.js
@@ -23,7 +23,11 @@ export default class ChatMessageCollapser extends Component {
         const header = htmlSafe(
           `<a target="_blank" class="chat-message-collapser-link" rel="noopener noreferrer" href="${link}">${title}</a>`
         );
-        acc.push({ header, body: e, needsCollapser: true });
+        const body = document.createElement("div");
+        body.className = "chat-message-collapser-youtube";
+        body.appendChild(e);
+
+        acc.push({ header, body, needsCollapser: true });
       } else {
         acc.push({ body: e, needsCollapser: false });
       }

--- a/assets/javascripts/discourse/templates/components/chat-message-collapser.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message-collapser.hbs
@@ -13,9 +13,7 @@
     {{#each youtubeCooked as |cooked|}}
       {{#if cooked.needsCollapser}}
         {{#collapser header=cooked.header}}
-          <div class="chat-message-collapser-youtube">
-            {{cooked.body}}
-          </div>
+          {{cooked.body}}
         {{/collapser}}
       {{else}}
         {{cooked.body}}

--- a/assets/javascripts/discourse/templates/components/chat-message-collapser.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message-collapser.hbs
@@ -9,30 +9,8 @@
       </div>
     {{/collapser}}
 
-  {{else if hasYoutube}}
-    {{#each youtubeCooked as |cooked|}}
-      {{#if cooked.needsCollapser}}
-        {{#collapser header=cooked.header}}
-          {{cooked.body}}
-        {{/collapser}}
-      {{else}}
-        {{cooked.body}}
-      {{/if}}
-    {{/each}}
-
-  {{else if hasImageOnebox}}
-    {{#each imageOneboxCooked as |cooked|}}
-      {{#if cooked.needsCollapser}}
-        {{#collapser header=cooked.header}}
-          {{cooked.body}}
-        {{/collapser}}
-      {{else}}
-        {{cooked.body}}
-      {{/if}}
-    {{/each}}
-
-  {{else if hasImage}}
-    {{#each imageCooked as |cooked|}}
+  {{else}}
+    {{#each cookedBodies as |cooked|}}
       {{#if cooked.needsCollapser}}
         {{#collapser header=cooked.header}}
           {{cooked.body}}


### PR DESCRIPTION
The main change here is the removal of cases in the template, to make way for https://github.com/discourse/discourse-chat/pull/845.
_____

- [x] chat-scoped -- core unaffected

### View mode

- [x] docked (windowed/drawer)
- [x] isolated (full-screen)

### Browsers

- [x] safari
- [x] chrome
- [x] firefox

### Device

- [x] desktop – wide screen
- [x] mobile – `?mobile_view=1`

### Ember

- [x] ember-cli
- [x] legacy
