### PR TITLE
FIX: Add gallery to collapser

### DIFF
--- a/assets/javascripts/discourse/components/chat-message-collapser.js
+++ b/assets/javascripts/discourse/components/chat-message-collapser.js
@@ -41,6 +41,10 @@ export default class ChatMessageCollapser extends Component {
       return this.imageCooked();
     }
 
+    if (hasGallery(this.cooked)) {
+      return this.galleryCooked();
+    }
+
     return [];
   }
 
@@ -97,6 +101,25 @@ export default class ChatMessageCollapser extends Component {
           `<a target="_blank" class="chat-message-collapser-link-small" rel="noopener noreferrer" href="${link}">${
             alt || link
           }</a>`
+        );
+        acc.push({ header, body: e, needsCollapser: true });
+      } else {
+        acc.push({ body: e, needsCollapser: false });
+      }
+      return acc;
+    }, []);
+  }
+
+  galleryCooked() {
+    const elements = Array.prototype.slice.call(domFromString(this.cooked));
+
+    return elements.reduce((acc, e) => {
+      if (galleryPredicate(e)) {
+        const link = e.firstElementChild.href;
+        const title = e.firstElementChild.firstElementChild.textContent;
+        e.firstElementChild.removeChild(e.firstElementChild.firstElementChild);
+        const header = htmlSafe(
+          `<a target="_blank" class="chat-message-collapser-link-small" rel="noopener noreferrer" href="${link}">${title}</a>`
         );
         acc.push({ header, body: e, needsCollapser: true });
       } else {
@@ -166,11 +189,26 @@ function hasImage(cooked) {
   return elements.some((e) => imagePredicate(e));
 }
 
+function galleryPredicate(e) {
+  return (
+    e.firstElementChild &&
+    e.firstElementChild.nodeName === "A" &&
+    e.firstElementChild.firstElementChild &&
+    e.firstElementChild.firstElementChild.classList.contains("outer-box")
+  );
+}
+
+function hasGallery(cooked) {
+  const elements = Array.prototype.slice.call(domFromString(cooked));
+  return elements.some((e) => galleryPredicate(e));
+}
+
 export function isCollapsible(cooked, uploads) {
   return (
     hasYoutube(cooked) ||
     hasImageOnebox(cooked) ||
     hasUploads(uploads) ||
-    hasImage(cooked)
+    hasImage(cooked) ||
+    hasGallery(cooked)
   );
 }

--- a/test/javascripts/components/chat-message-collapser-test.js
+++ b/test/javascripts/components/chat-message-collapser-test.js
@@ -40,7 +40,12 @@ const imageCooked =
 
 const galleryCooked =
   "<p>written text</p>" +
-  '<div class="onebox imgur-album"><a href="https://imgur.com/gallery/yyVx5lJ"><span class="outer-box"><span><span class="album-title">Le tomtom album</span>    </span>  </span>  <img src="https://i.imgur.com/3mkbqo5.jpeg?fb" title="Solution" height="315" width="600"></a></div>' +
+  '<div class="onebox imgur-album">' +
+  '<a href="https://imgur.com/gallery/yyVx5lJ">' +
+  '<span class="outer-box"><span><span class="album-title">Le tomtom album</span></span></span>' +
+  '<img src="https://i.imgur.com/3mkbqo5.jpeg?fb" title="Solution" height="315" width="600">' +
+  "</a>" +
+  "</div>" +
   "<p>more written text</p>";
 
 discourseModule(

--- a/test/javascripts/components/chat-message-collapser-test.js
+++ b/test/javascripts/components/chat-message-collapser-test.js
@@ -38,6 +38,11 @@ const imageCooked =
   "<p>and even more</p>" +
   '<p><img src="http://cat3.com" class="emoji"></p>';
 
+const galleryCooked =
+  "<p>written text</p>" +
+  '<div class="onebox imgur-album"><a href="https://imgur.com/gallery/yyVx5lJ"><span class="outer-box"><span><span class="album-title">Le tomtom album</span>    </span>  </span>  <img src="https://i.imgur.com/3mkbqo5.jpeg?fb" title="Solution" height="315" width="600"></a></div>' +
+  "<p>more written text</p>";
+
 discourseModule(
   "Discourse Chat | Component | chat message collapser youtube",
   function (hooks) {
@@ -514,6 +519,80 @@ discourseModule(
         assert.equal(links.length, 2);
         assert.equal(images.length, 3, "shows images and emoji");
         assert.equal(collapser.length, 2);
+      },
+    });
+  }
+);
+
+discourseModule(
+  "Discourse Chat | Component | chat message collapser gallaries",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    componentTest("removes album title overlay", {
+      template: hbs`{{chat-message-collapser cooked=cooked}}`,
+
+      beforeEach() {
+        this.set("cooked", galleryCooked);
+      },
+
+      async test(assert) {
+        assert.notOk(visible(".album-title"), "album title removed");
+      },
+    });
+
+    componentTest("shows gallery link", {
+      template: hbs`{{chat-message-collapser cooked=cooked}}`,
+
+      beforeEach() {
+        this.set("cooked", galleryCooked);
+      },
+
+      async test(assert) {
+        assert.ok(
+          query(".chat-message-collapser-link-small").innerText.includes(
+            "Le tomtom album"
+          )
+        );
+      },
+    });
+
+    componentTest("shows all user written text", {
+      template: hbs`{{chat-message-collapser cooked=cooked}}`,
+
+      beforeEach() {
+        this.set("cooked", galleryCooked);
+      },
+
+      async test(assert) {
+        const text = document.querySelectorAll(".chat-message-collapser p");
+
+        assert.equal(text.length, 2, "shows all written text");
+        assert.strictEqual(text[0].innerText, "written text");
+        assert.strictEqual(text[1].innerText, "more written text");
+      },
+    });
+
+    componentTest("collapses and expands images", {
+      template: hbs`{{chat-message-collapser cooked=cooked}}`,
+
+      beforeEach() {
+        this.set("cooked", galleryCooked);
+      },
+
+      async test(assert) {
+        assert.ok(visible("img"), "image visible initially");
+
+        await click(
+          document.querySelectorAll(".chat-message-collapser-opened")[0],
+          "close preview"
+        );
+
+        assert.notOk(visible("img"), "image hidden");
+
+        await click(".chat-message-collapser-closed");
+
+        assert.ok(visible("img"), "image visible initially");
       },
     });
   }


### PR DESCRIPTION
Allows galleries (google photos, imgur, flickr) to be resized and collapsed. Example gallery: https://imgur.com/gallery/yyVx5lJ

Fullscreen

<img width="348" alt="Screenshot 2022-05-10 at 12 24 35 AM" src="https://user-images.githubusercontent.com/1555215/167454508-02440794-c400-4923-9199-2ff3f187e355.png">

Docked
<img width="432" alt="Screenshot 2022-05-10 at 12 25 25 AM" src="https://user-images.githubusercontent.com/1555215/167454607-52530df8-a7c2-483e-ad65-5d73c19295a4.png">

- [x] chat-scoped -- core unaffected

### View mode

- [x] docked (windowed/drawer)
- [x] isolated (full-screen)

### Browsers

- [x] safari
- [x] chrome
- [x] firefox

### Device

- [x] desktop – wide screen
- [x] mobile – `?mobile_view=1`

### Ember

- [x] ember-cli
- [x] legacy
