### PR TITLE
FIX: chatMessageClasses has too many arguments

### DIFF
--- a/assets/javascripts/discourse/components/chat-message.js
+++ b/assets/javascripts/discourse/components/chat-message.js
@@ -310,22 +310,11 @@ export default Component.extend({
     "message.error",
     "isHovered"
   )
-  chatMessageClasses(
-    staged,
-    deletedAt,
-    inReplyTo,
-    actionCode,
-    error,
-    isHovered
-  ) {
+  chatMessageClasses(staged, deletedAt, inReplyTo, error, isHovered) {
     let classNames = ["chat-message"];
 
     if (staged) {
       classNames.push("chat-message-staged");
-    }
-    if (actionCode) {
-      classNames.push("chat-action");
-      classNames.push(`chat-action-${actionCode}`);
     }
     if (deletedAt) {
       classNames.push("deleted");


### PR DESCRIPTION
In 5baf232a597d27da490c021d7fcf2c570bb5f0a8 I removed the
`message.action_code` argument to the `chatMessageClasses`
`discourseComputed` decorator, but I forgot to remove `actionCode`
from the function params and internal to the function.