### PR TITLE
FIX: composer uploads were appearing in the last message

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -719,7 +719,7 @@ export default Component.extend(TextareaTextManipulation, {
 
   @action
   uploadsChanged(uploads) {
-    this.set("_uploads", uploads);
+    this.set("_uploads", cloneJSON(uploads));
     this.onValueChange?.(this.value, this._uploads, this.replyToMsg);
   },
 });


### PR DESCRIPTION
Repro steps by Joffrey

- open a chat channel
- type a message and add an upload
- wait few seconds (at least 2, to ensure the upload is stored)
- remove the upload (wait at least 2 seconds again)
- post the message (it should be posted without the upload)
- add an upload, it should appear under the composer AND the last posted message