### PR TITLE
REFACTOR: chat-message-info

### DIFF
--- a/app/serializers/chat_message_serializer.rb
+++ b/app/serializers/chat_message_serializer.rb
@@ -13,7 +13,7 @@ class ChatMessageSerializer < ApplicationSerializer
     :edited,
     :reactions
 
-  has_one :user, serializer: BasicUserSerializer, embed: :objects
+  has_one :user, serializer: UserCardSerializer, embed: :objects
   has_one :chat_webhook_event, serializer: ChatWebhookEventSerializer, embed: :objects
   has_one :in_reply_to, serializer: ChatInReplyToSerializer, embed: :objects
   has_many :uploads, serializer: UploadSerializer, embed: :objects

--- a/assets/javascripts/discourse/components/chat-message-avatar.js
+++ b/assets/javascripts/discourse/components/chat-message-avatar.js
@@ -1,0 +1,5 @@
+import Component from "@ember/component";
+
+export default class ChatMessageAvatar extends Component {
+  tagName = "";
+}

--- a/assets/javascripts/discourse/components/chat-message-info.js
+++ b/assets/javascripts/discourse/components/chat-message-info.js
@@ -1,0 +1,55 @@
+import I18n from "I18n";
+import { computed } from "@ember/object";
+import Component from "@ember/component";
+import { prioritizeNameInUx } from "discourse/lib/settings";
+
+export default class ChatMessageInfo extends Component {
+  tagName = "";
+  message = null;
+  details = null;
+
+  @computed("message.user")
+  get name() {
+    if (!this.message?.user) {
+      return I18n.t("chat.user_deleted");
+    }
+
+    return this.prioritizeName
+      ? this.message.user.name
+      : this.message.user.username;
+  }
+
+  @computed("message.user.name")
+  get prioritizeName() {
+    return (
+      this.siteSettings.display_name_on_posts &&
+      prioritizeNameInUx(this.message?.user?.name)
+    );
+  }
+
+  @computed("message.user")
+  get usernameClasses() {
+    const user = this.message?.user;
+
+    const classes = this.prioritizeName ? ["is-full-name"] : ["is-username"];
+
+    if (!user) {
+      return classes;
+    }
+
+    if (user.staff) {
+      classes.push("is-staff");
+    }
+    if (user.admin) {
+      classes.push("is-admin");
+    }
+    if (user.moderator) {
+      classes.push("is-moderator");
+    }
+    if (user.groupModerator) {
+      classes.push("is-category-moderator");
+    }
+
+    return classes.join(" ");
+  }
+}

--- a/assets/javascripts/discourse/components/chat-message.js
+++ b/assets/javascripts/discourse/components/chat-message.js
@@ -14,7 +14,6 @@ import { cancel, later, schedule } from "@ember/runloop";
 import { clipboardCopy } from "discourse/lib/utilities";
 import { inject as service } from "@ember/service";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import { prioritizeNameInUx } from "discourse/lib/settings";
 import { Promise } from "rsvp";
 
 let _chatMessageDecorators = [];
@@ -332,43 +331,6 @@ export default Component.extend({
       classNames.push("chat-message-selected");
     }
     return classNames.join(" ");
-  },
-
-  @discourseComputed("message.user")
-  name(user) {
-    if (!user) {
-      return I18n.t("chat.user_deleted");
-    }
-    return this.prioritizeName ? user.name : user.username;
-  },
-
-  @discourseComputed("message.user.name")
-  prioritizeName(name) {
-    return this.siteSettings.display_name_on_posts && prioritizeNameInUx(name);
-  },
-
-  @discourseComputed("message.user")
-  usernameClasses(user) {
-    const classes = this.prioritizeName
-      ? ["full-name names first"]
-      : ["username names first"];
-
-    if (!user) {
-      return classes;
-    }
-    if (user.staff) {
-      classes.push("staff");
-    }
-    if (user.admin) {
-      classes.push("admin");
-    }
-    if (user.moderator) {
-      classes.push("moderator");
-    }
-    if (user.groupModerator) {
-      classes.push("category-moderator");
-    }
-    return classes.join(" ");
   },
 
   @discourseComputed("message", "message.deleted_at", "chatChannel.status")

--- a/assets/javascripts/discourse/templates/components/chat-message-avatar.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message-avatar.hbs
@@ -1,0 +1,11 @@
+<div class="chat-message-avatar">
+  {{#if @message.chat_webhook_event.emoji}}
+    {{chat-emoji-avatar emoji=@message.chat_webhook_event.emoji}}
+  {{else}}
+    {{#if @message.user}}
+      {{chat-user-avatar user=@message.user avatarSize="medium"}}
+    {{else}}
+      {{chat-emoji-avatar emoji=":wastebasket:"}}
+    {{/if}}
+  {{/if}}
+</div>

--- a/assets/javascripts/discourse/templates/components/chat-message-info.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message-info.hbs
@@ -1,0 +1,41 @@
+<div class="chat-message-info">
+  {{#if @message.chat_webhook_event}}
+    {{#if @message.chat_webhook_event.username}}
+      <span class="chat-message-info__username {{this.usernameClasses}}">
+        {{@message.chat_webhook_event.username}}
+      </span>
+    {{/if}}
+
+    <span class="chat-message-info__bot-indicator">
+      {{i18n "chat.bot"}}
+    </span>
+  {{else}}
+    <span
+      role="button"
+      class="chat-message-info__username {{this.usernameClasses}} clickable"
+      data-user-card={{@message.user.username}}
+    >
+      <span class="chat-message-info__username__name">{{this.name}}</span>
+
+      <span class="chat-message-info__user-avatar-flair">
+        {{user-avatar-flair user=@message.user}}
+      </span>
+    </span>
+  {{/if}}
+
+  <span class="chat-message-info__date">
+    {{format-chat-date @message @details}}
+  </span>
+
+  {{#if (or @message.reviewable_id (eq @message.user_flag_status 0))}}
+    <span class="chat-message-info__flag">
+      {{#if @message.reviewable_id}}
+        {{#link-to "review.show" @message.reviewable_id}}
+          {{d-icon "flag" title="chat.flagged"}}
+        {{/link-to}}
+      {{else if (eq @message.user_flag_status 0)}}
+        {{d-icon "flag" title="chat.you_flagged"}}
+      {{/if}}
+    </span>
+  {{/if}}
+</div>

--- a/assets/javascripts/discourse/templates/components/chat-message-left-gutter.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message-left-gutter.hbs
@@ -1,0 +1,19 @@
+<div class="chat-message-left-gutter">
+  {{#if @message.reviewable_id}}
+    {{#link-to
+      "review.show"
+      @message.reviewable_id
+      class="chat-message-left-gutter__flag"
+    }}
+      {{d-icon "flag" title="chat.flagged"}}
+    {{/link-to}}
+  {{else if (eq @message.user_flag_status 0)}}
+    <div class="chat-message-left-gutter__flag">
+      {{d-icon "flag" title="chat.you_flagged"}}
+    </div>
+  {{else}}
+    <span class="chat-message-left-gutter__date">
+      {{format-chat-date @message @details "tiny"}}
+    </span>
+  {{/if}}
+</div>

--- a/assets/javascripts/discourse/templates/components/chat-message.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message.hbs
@@ -70,60 +70,14 @@
         {{/if}}
 
         {{#if hideUserInfo}}
-          <div class="chat-message-left-gutter">
-            {{#if message.reviewable_id}}
-              {{#link-to "review.show" message.reviewable_id class="chat-message-flagged"}}
-                {{d-icon "flag" title="chat.flagged"}}
-              {{/link-to}}
-            {{else if (eq message.user_flag_status 0)}}
-              <div class="chat-message-flagged">
-                {{d-icon "flag" title="chat.you_flagged"}}
-              </div>
-            {{else}}
-              {{format-chat-date message details "tiny"}}
-            {{/if}}
-          </div>
+          {{chat-message-left-gutter message=@message details=@details}}
         {{else}}
-          {{#if message.chat_webhook_event.emoji}}
-            {{chat-emoji-avatar emoji=message.chat_webhook_event.emoji}}
-          {{else}}
-            {{#if message.user}}
-              {{chat-user-avatar user=message.user avatarSize="medium"}}
-            {{else}}
-              {{chat-emoji-avatar emoji=":wastebasket:"}}
-            {{/if}}
-          {{/if}}
+          {{chat-message-avatar message=@message}}
         {{/if}}
 
         <div class="chat-message-content">
           {{#unless hideUserInfo}}
-            <div class="chat-message-sender-data">
-              <span class={{usernameClasses}}>
-                {{#if message.chat_webhook_event.username}}
-                  {{message.chat_webhook_event.username}}
-                {{else}}
-                  <span role="button" class="clickable" data-user-card={{message.user.username}}>
-                    {{name}}
-                  </span>
-                {{/if}}
-              </span>
-
-              {{#if message.chat_webhook_event}}
-                <span class="tc-bot-indicator">{{i18n "chat.bot"}}</span>
-              {{/if}}
-
-              {{format-chat-date message details}}
-
-              {{#if message.reviewable_id}}
-                {{#link-to "review.show" message.reviewable_id class="chat-message-flagged"}}
-                  {{d-icon "flag" title="chat.flagged"}}
-                {{/link-to}}
-              {{else if (eq message.user_flag_status 0)}}
-                <div class="chat-message-flagged">
-                  {{d-icon "flag" title="chat.you_flagged"}}
-                </div>
-              {{/if}}
-            </div>
+            {{chat-message-info message=@message details=@details}}
           {{/unless}}
 
           {{#chat-message-text

--- a/assets/stylesheets/common/chat-message-info.scss
+++ b/assets/stylesheets/common/chat-message-info.scss
@@ -1,0 +1,80 @@
+.chat-message-info {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.chat-message-info__username {
+  display: inline-flex;
+  align-items: center;
+
+  & + .chat-message-info__bot-indicator,
+  & + .chat-message-info__date {
+    margin-left: 0.25em;
+  }
+}
+
+.chat-message-info__username__name {
+  color: var(--secondary-low);
+  font-weight: 700;
+  @include ellipsis;
+  max-width: 180px;
+}
+
+.chat-message-info__bot-indicator {
+  text-transform: uppercase;
+  padding: 0.25em;
+  background: var(--primary-low);
+  border-radius: 3px;
+  font-size: var(--font-down-2);
+
+  & + .chat-message-info__date {
+    margin-left: 0.25em;
+  }
+}
+
+.chat-message-info__user-avatar-flair {
+  $size: 16px;
+  $icon-size: $size / 1.8;
+  margin-left: 0.25em;
+
+  .avatar-flair {
+    background-size: $size;
+    height: $size;
+    width: $size;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-repeat: no-repeat;
+
+    .d-icon {
+      height: $icon-size;
+      width: $icon-size;
+    }
+  }
+
+  & + .chat-message-info__date {
+    margin-left: 0.25em;
+  }
+}
+
+.chat-message-info__date {
+  color: var(--primary-high);
+  font-size: var(--font-down-1);
+
+  &:hover,
+  &:focus {
+    .chat-time {
+      color: var(--primary);
+    }
+  }
+
+  & + .chat-message-info__flag {
+    margin-left: 0.25em;
+  }
+}
+
+.chat-message-info__flag {
+  color: var(--secondary-medium);
+}

--- a/assets/stylesheets/common/chat-message-left-gutter.scss
+++ b/assets/stylesheets/common/chat-message-left-gutter.scss
@@ -1,0 +1,24 @@
+.chat-message-left-gutter {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-shrink: 0;
+  width: var(--message-left-width);
+}
+
+.chat-message-left-gutter__date {
+  color: var(--primary-high);
+  font-size: var(--font-down-1);
+
+  &:hover,
+  &:focus {
+    .chat-time {
+      color: var(--primary);
+    }
+  }
+}
+
+.chat-message-left-gutter__flag {
+  color: var(--secondary-medium);
+  padding-left: calc(50% - 15px);
+}

--- a/assets/stylesheets/common/chat-message.scss
+++ b/assets/stylesheets/common/chat-message.scss
@@ -66,15 +66,6 @@
     }
   }
 
-  .chat-message-left-gutter {
-    flex-shrink: 0;
-    width: var(--message-left-width);
-
-    .chat-message-flagged {
-      padding-left: 0.6em;
-    }
-  }
-
   &.chat-action {
     background-color: var(--highlight-medium);
   }
@@ -140,15 +131,6 @@
     word-break: break-word;
     overflow-wrap: break-word;
     min-width: 0;
-  }
-
-  .tc-bot-indicator {
-    text-transform: uppercase;
-    padding: 0.25em;
-    background: var(--primary-low);
-    border-radius: 3px;
-    font-size: var(--font-down-2);
-    margin-left: -0.25em;
   }
 
   .chat-message-text {
@@ -283,7 +265,7 @@
   padding-top: 0.25em;
   pointer-events: none;
   right: 0.25em;
-  top: -0.75em;
+  top: -1.5em;
   z-index: 2;
 }
 
@@ -432,29 +414,6 @@
       width: auto;
       margin: 0;
     }
-  }
-}
-
-.chat-message-sender-data {
-  color: var(--secondary-medium);
-  width: 100%;
-
-  .names {
-    color: var(--secondary-low);
-    display: inline-block;
-    vertical-align: bottom;
-    margin-right: 0.3em;
-
-    &.first {
-      font-weight: bold;
-    }
-
-    span {
-      margin-right: 0;
-    }
-  }
-  .chat-message-flagged {
-    margin-left: 0.2em;
   }
 }
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -14,6 +14,8 @@ register_asset 'stylesheets/common/d-progress-bar.scss'
 register_asset 'stylesheets/common/incoming-chat-webhooks.scss'
 register_asset 'stylesheets/mobile/chat-message.scss', :mobile
 register_asset 'stylesheets/common/chat-message.scss'
+register_asset 'stylesheets/common/chat-message-left-gutter.scss'
+register_asset 'stylesheets/common/chat-message-info.scss'
 register_asset 'stylesheets/common/direct-message-creator.scss'
 register_asset 'stylesheets/common/chat-message-collapser.scss'
 register_asset 'stylesheets/common/chat-message-images.scss'

--- a/test/javascripts/components/chat-message-avatar-test.js
+++ b/test/javascripts/components/chat-message-avatar-test.js
@@ -1,0 +1,52 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import hbs from "htmlbars-inline-precompile";
+import {
+  discourseModule,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+
+discourseModule(
+  "Discourse Chat | Component | chat-message-avatar",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    componentTest("chat_webhook_event", {
+      template: hbs`{{chat-message-avatar message=message}}`,
+
+      beforeEach() {
+        this.set("message", { chat_webhook_event: { emoji: ":heart:" } });
+      },
+
+      async test(assert) {
+        assert.equal(query(".chat-emoji-avatar .emoji").title, "heart");
+      },
+    });
+
+    componentTest("user", {
+      template: hbs`{{chat-message-avatar message=message}}`,
+
+      beforeEach() {
+        this.set("message", { user: { username: "discobot" } });
+      },
+
+      async test(assert) {
+        assert.ok(exists('.chat-user-avatar [data-user-card="discobot"]'));
+      },
+    });
+
+    componentTest("nothing", {
+      template: hbs`{{chat-message-avatar message=message}}`,
+
+      beforeEach() {
+        this.set("message", {});
+      },
+
+      async test(assert) {
+        assert.equal(query(".chat-emoji-avatar .emoji").title, "wastebasket");
+      },
+    });
+  }
+);

--- a/test/javascripts/components/chat-message-info-test.js
+++ b/test/javascripts/components/chat-message-info-test.js
@@ -1,0 +1,117 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import hbs from "htmlbars-inline-precompile";
+import {
+  discourseModule,
+  exists,
+  query,
+} from "discourse/tests/helpers/qunit-helpers";
+import I18n from "I18n";
+
+discourseModule(
+  "Discourse Chat | Component | chat-message-info",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    componentTest("chat_webhook_event", {
+      template: hbs`{{chat-message-info message=message}}`,
+
+      beforeEach() {
+        this.set("message", { chat_webhook_event: { username: "discobot" } });
+      },
+
+      async test(assert) {
+        assert.equal(
+          query(".chat-message-info__username").innerText.trim(),
+          this.message.chat_webhook_event.username
+        );
+        assert.equal(
+          query(".chat-message-info__bot-indicator").innerText.trim(),
+          I18n.t("chat.bot")
+        );
+      },
+    });
+
+    componentTest("user", {
+      template: hbs`{{chat-message-info message=message}}`,
+
+      beforeEach() {
+        this.set("message", { user: { username: "discobot" } });
+      },
+
+      async test(assert) {
+        assert.equal(
+          query(".chat-message-info__username").innerText.trim(),
+          this.message.user.username
+        );
+      },
+    });
+
+    componentTest("date", {
+      template: hbs`{{chat-message-info message=message}}`,
+
+      beforeEach() {
+        this.set("message", { created_at: moment() });
+      },
+
+      async test(assert) {
+        assert.ok(exists(".chat-message-info__date"));
+      },
+    });
+
+    componentTest("no user", {
+      template: hbs`{{chat-message-info message=message}}`,
+
+      beforeEach() {
+        this.set("message", {});
+      },
+      async test(assert) {
+        assert.equal(
+          query(".chat-message-info__username").innerText.trim(),
+          I18n.t("chat.user_deleted")
+        );
+      },
+    });
+
+    componentTest("flair", {
+      template: hbs`{{chat-message-info message=message}}`,
+
+      beforeEach() {
+        this.set("message", { user: { flair_url: "fa-adjust" } });
+      },
+
+      async test(assert) {
+        assert.ok(exists(".avatar-flair .d-icon-adjust"));
+      },
+    });
+
+    componentTest("reviewable", {
+      template: hbs`{{chat-message-info message=message}}`,
+
+      beforeEach() {
+        this.set("message", {
+          user: { username: "discobot" },
+          user_flag_status: 0,
+        });
+      },
+
+      async test(assert) {
+        assert.equal(
+          query(".chat-message-info__flag > .svg-icon-title").title,
+          I18n.t("chat.you_flagged")
+        );
+
+        this.set("message", {
+          user: { username: "discobot" },
+          reviewable_id: 1,
+        });
+
+        assert.equal(
+          query(".chat-message-info__flag a .svg-icon-title").title,
+          I18n.t("chat.flagged")
+        );
+      },
+    });
+  }
+);

--- a/test/javascripts/components/chat-message-test.js
+++ b/test/javascripts/components/chat-message-test.js
@@ -79,7 +79,7 @@ discourseModule("Discourse Chat | Component | chat-message", function (hooks) {
     async test(assert) {
       assert.equal(
         query(
-          ".chat-message .chat-message-sender-data .username"
+          ".chat-message .chat-message-info .username"
         ).innerText.trim(),
         I18n.t("chat.user_deleted")
       );


### PR DESCRIPTION
Not this commit will also allow primary group flair to show next to username.

<!-- Checklist for UI / stylesheet changes, delete if not applicable -->

- [ ] chat-scoped -- core unaffected

### View mode

- [ ] docked (windowed/drawer)
- [ ] isolated (full-screen)

### Browsers

- [ ] safari
- [ ] chrome
- [ ] firefox

### Device

- [ ] desktop – wide screen
- [ ] mobile – `?mobile_view=1`

### Ember

- [ ] ember-cli
- [ ] legacy
