### PR TITLE
FIX: Nicer error message when reacting without membership

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -45,6 +45,7 @@ en:
       max_reactions_limit_reached: "New reactions are not allowed on this message."
       message_move_invalid_channel: "The source and destination channel must be public channels."
       message_move_no_messages_found: "No messages were found with the provided message IDs."
+      cannot_react_without_joining: "You must join the channel first to react to messages. Send a message or join the channel manually from the channel list."
     reviewables:
       actions:
         agree:

--- a/lib/chat_message_reactor.rb
+++ b/lib/chat_message_reactor.rb
@@ -33,11 +33,13 @@ class DiscourseChat::ChatMessageReactor
   private
 
   def validate_channel_membership!
-    raise Discourse::InvalidAccess if !UserChatChannelMembership.exists?(
+    return if UserChatChannelMembership.exists?(
       chat_channel: @chat_channel,
       user: @user,
       following: true
     )
+
+    raise Discourse::InvalidAccess.new(nil, nil, custom_message: "chat.errors.cannot_react_without_joining")
   end
 
   def validate_channel_status!

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -780,6 +780,7 @@ RSpec.describe DiscourseChat::ChatController do
       sign_in(user)
       put "/chat/#{chat_channel_no_memberships.id}/react/#{chat_message_no_memberships.id}.json", params: { emoji: ":heart:", react_action: "add" }
       expect(response.status).to eq(403)
+      expect(response.parsed_body["errors"]).to include(I18n.t("chat.errors.cannot_react_without_joining"))
     end
 
     it "errors when user tries to react to private channel they can't access" do


### PR DESCRIPTION
We previously had the "You are not permitted to view the
requested resource" error pop up if someone tried to react
to a channel message without joining the channel. This
improves the message to be more helpful.

![image](https://user-images.githubusercontent.com/920448/168504298-dcaf9060-099b-42b3-ac5c-52ea339becaa.png)
