### PR TITLE
FIX: Make get channel by name work with chatable name

### DIFF
--- a/spec/requests/chat_channel_controller_spec.rb
+++ b/spec/requests/chat_channel_controller_spec.rb
@@ -503,6 +503,20 @@ RSpec.describe DiscourseChat::ChatChannelsController do
       expect(response.parsed_body["chat_channel"]["id"]).to eq(channel.id)
     end
 
+    it "can find channel by chatable title/name" do
+      sign_in(user)
+
+      channel.update!(chatable: Fabricate(:topic, title: "A topic that is a chatable"))
+      get "/chat/chat_channels/#{UrlHelper.encode_component("A topic that is a chatable")}.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["chat_channel"]["id"]).to eq(channel.id)
+
+      channel.update!(chatable: Fabricate(:category, name: "Support Chat"))
+      get "/chat/chat_channels/#{UrlHelper.encode_component("Support Chat")}.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["chat_channel"]["id"]).to eq(channel.id)
+    end
+
     it "gives a not found error if the channel cannot be found by name or id" do
       channel.destroy
       sign_in(user)


### PR DESCRIPTION
We do not force all channels to have a name, so the route
to get a channel by name needs to work with the chatable
names as well (e.g. category.name and topic.fancy_title).
Note that this does not take into account DM channels where
getting them by name is kind of tricky.

The chat transcript service currently converts the channel
attribute (e.g. channel="Music Lounge") into a link using the
channel title in the /chat/chat_channels/:title format. A better
fit rather than the somewhat unreliable and tricky channel
title would be perhaps to use a channel ID instead...but that
does have its own issues for the transcript. We should discuss
internally.