### PR TITLE
DEV: Remove redundant message mover note

### DIFF
--- a/lib/message_mover.rb
+++ b/lib/message_mover.rb
@@ -102,11 +102,6 @@ class DiscourseChat::MessageMover
     moved_message_ids
   end
 
-  # NOTE: Mentions are created in the CreateChatMentionNotifications job
-  # 3 seconds (or more) after the message is created. If someone is super
-  # quick on the trigger moving them, then there will be no mention or
-  # notification created. We should keep an eye on this and see if it's a
-  # problem in the wild before overcomplicating things.
   def update_references
     DB.exec(<<~SQL)
       UPDATE chat_message_reactions cmr


### PR DESCRIPTION
Since https://github.com/discourse/discourse-chat/pull/854
there is no longer a delay when mentioning other users in
chat, this note is no longer relevant.
