### PR TITLE
FEATURE: Implement oneboxes for chat

### DIFF
--- a/assets/stylesheets/common/chat-onebox.scss
+++ b/assets/stylesheets/common/chat-onebox.scss
@@ -1,0 +1,33 @@
+.chat-onebox {
+  .chat-onebox-body {
+    .chat-onebox-title {
+      margin-bottom: 3px;
+    }
+
+    .chat-onebox-description {
+      color: var(--primary-medium);
+    }
+
+    .chat-onebox-members-count {
+      color: var(--primary-medium);
+      margin-top: 1em;
+      margin-bottom: 3px;
+    }
+
+    .chat-onebox-members {
+      align-items: center;
+      color: var(--primary-medium);
+      display: flex;
+
+      .avatar {
+        aspect-ratio: 30 / 30;
+      }
+    }
+  }
+}
+
+.discourse-chat-transcript {
+  .chat-transcript-user-avatar .avatar {
+    aspect-ratio: 20 / 20;
+  }
+}

--- a/assets/stylesheets/common/chat-transcript.scss
+++ b/assets/stylesheets/common/chat-transcript.scss
@@ -21,8 +21,7 @@
   }
 
   .chat-transcript-channel {
-    font-size: var(--font-down-2-rem);
-    padding-left: 0.5rem;
+    font-size: var(--font-down-1-rem);
   }
 
   .chat-transcript-username {
@@ -33,7 +32,7 @@
   .chat-transcript-datetime {
     color: var(--primary-high);
     font-size: var(--font-down-2-rem);
-    padding-left: 0.5rem;
+    padding: 0 0.5rem;
 
     a {
       color: var(--primary-high);
@@ -52,6 +51,8 @@
 
   .chat-transcript-user {
     display: flex;
+    flex-wrap: wrap-reverse;
+    gap: 0.25rem 0;
     align-items: baseline;
 
     .chat-transcript-user-avatar {

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1402,27 +1402,3 @@ body.has-full-page-chat {
     display: inline;
   }
 }
-
-.chat-onebox {
-  .chat-onebox-body {
-    .chat-onebox-title {
-      margin-bottom: 3px;
-    }
-
-    .chat-onebox-description {
-      color: var(--primary-medium);
-    }
-
-    .chat-onebox-members-count {
-      color: var(--primary-medium);
-      margin-top: 1em;
-      margin-bottom: 3px;
-    }
-
-    .chat-onebox-members {
-      align-items: center;
-      color: var(--primary-medium);
-      display: flex;
-    }
-  }
-}

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1402,3 +1402,27 @@ body.has-full-page-chat {
     display: inline;
   }
 }
+
+.chat-onebox {
+  .chat-onebox-body {
+    .chat-onebox-title {
+      margin-bottom: 3px;
+    }
+
+    .chat-onebox-description {
+      color: var(--primary-medium);
+    }
+
+    .chat-onebox-members-count {
+      color: var(--primary-medium);
+      margin-top: 1em;
+      margin-bottom: 3px;
+    }
+
+    .chat-onebox-members {
+      align-items: center;
+      color: var(--primary-medium);
+      display: flex;
+    }
+  }
+}

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -95,6 +95,11 @@ en:
 
     personal_chat: "personal chat"
 
+    onebox:
+      inline_to_message: '#%{chat_channel} - Message #%{message_id} by %{username}'
+      inline_to_channel: 'Chat #%{chat_channel}'
+      inline_to_topic_channel: 'Chat for Topic %{topic_title}'
+
   discourse_push_notifications:
     popup:
       chat_mention:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -96,9 +96,17 @@ en:
     personal_chat: "personal chat"
 
     onebox:
-      inline_to_message: '#%{chat_channel} - Message #%{message_id} by %{username}'
+      inline_to_message: 'Message #%{message_id} by %{username} – #%{chat_channel}'
       inline_to_channel: 'Chat #%{chat_channel}'
       inline_to_topic_channel: 'Chat for Topic %{topic_title}'
+
+      x_members:
+        one: "%{count} member"
+        other: "%{count} members"
+
+      and_x_others:
+        one: "and %{count} other"
+        other: "and %{count} others"
 
   discourse_push_notifications:
     popup:

--- a/lib/onebox/templates/discourse_chat.mustache
+++ b/lib/onebox/templates/discourse_chat.mustache
@@ -1,7 +1,7 @@
 {{^cooked}}
 <aside class="onebox chat-onebox">
   <article class="onebox-body chat-onebox-body">
-    <h3>
+    <h3 class="chat-onebox-title">
       <a href="{{url}}">
         {{#is_category}}
           <span class="category-chat-badge" style="color: #{{color}}">
@@ -16,6 +16,18 @@
         <span class="clear-badge">{{{channel_name}}}</span>
       </a>
     </h3>
+    {{#description}}
+      <div class="chat-onebox-description">{{description}}</div>
+    {{/description}}
+    <div class="chat-onebox-members-count">{{user_count_str}}</div>
+    <div class="chat-onebox-members">
+      {{#users}}
+        <a class="trigger-user-card" data-user-card="{{username}}" aria-hidden="true" tabindex="-1">
+          <img loading="lazy" alt="{{username}}" width="30" height="30" src="{{avatar_url}}" class="avatar" style="aspect-ratio: 30 / 30;">
+        </a>
+      {{/users}}
+      {{remaining_user_count_str}}
+    </div>
   </article>
   <div class="clearfix"></div>
 </aside>
@@ -25,7 +37,9 @@
 <div class="discourse-chat-transcript" data-message-id="{{message_id}}" data-username="{{username}}" data-datetime="{{created_at}}" data-channel-name="{{channel_name}}" data-channel-id="{{channel_id}}">
   <div class="chat-transcript-user">
     <div class="chat-transcript-user-avatar">
-      <img loading="lazy" alt="" width="20" height="20" src="{{avatar_url}}" class="avatar" style="aspect-ratio: 20 / 20;">
+      <a class="trigger-user-card" data-user-card="{{username}}" aria-hidden="true" tabindex="-1">
+        <img loading="lazy" alt="{{username}}" width="20" height="20" src="{{avatar_url}}" class="avatar" style="aspect-ratio: 20 / 20;">
+      </a>
     </div>
   <div class="chat-transcript-username">{{username}}</div>
     <div class="chat-transcript-datetime">

--- a/lib/onebox/templates/discourse_chat.mustache
+++ b/lib/onebox/templates/discourse_chat.mustache
@@ -23,13 +23,12 @@
     <div class="chat-onebox-members">
       {{#users}}
         <a class="trigger-user-card" data-user-card="{{username}}" aria-hidden="true" tabindex="-1">
-          <img loading="lazy" alt="{{username}}" width="30" height="30" src="{{avatar_url}}" class="avatar" style="aspect-ratio: 30 / 30;">
+          <img loading="lazy" alt="{{username}}" width="30" height="30" src="{{avatar_url}}" class="avatar">
         </a>
       {{/users}}
       {{remaining_user_count_str}}
     </div>
   </article>
-  <div class="clearfix"></div>
 </aside>
 {{/cooked}}
 
@@ -38,7 +37,7 @@
   <div class="chat-transcript-user">
     <div class="chat-transcript-user-avatar">
       <a class="trigger-user-card" data-user-card="{{username}}" aria-hidden="true" tabindex="-1">
-        <img loading="lazy" alt="{{username}}" width="20" height="20" src="{{avatar_url}}" class="avatar" style="aspect-ratio: 20 / 20;">
+        <img loading="lazy" alt="{{username}}" width="20" height="20" src="{{avatar_url}}" class="avatar">
       </a>
     </div>
   <div class="chat-transcript-username">{{username}}</div>

--- a/lib/onebox/templates/discourse_chat.mustache
+++ b/lib/onebox/templates/discourse_chat.mustache
@@ -1,0 +1,50 @@
+{{^cooked}}
+<aside class="onebox chat-onebox">
+  <article class="onebox-body chat-onebox-body">
+    <h3>
+      <a href="{{url}}">
+        {{#is_category}}
+          <span class="category-chat-badge" style="color: #{{color}}">
+            <svg class="fa d-icon d-icon-hashtag svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#hashtag"></use></svg>
+          </span>
+        {{/is_category}}
+        {{#is_topic}}
+          <span class="topic-chat-icon">
+            <svg class="fa d-icon d-icon-far-comments svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#far-comments"></use></svg>
+          </span>
+        {{/is_topic}}
+        <span class="clear-badge">{{{channel_name}}}</span>
+      </a>
+    </h3>
+  </article>
+  <div class="clearfix"></div>
+</aside>
+{{/cooked}}
+
+{{#cooked}}
+<div class="discourse-chat-transcript" data-message-id="{{message_id}}" data-username="{{username}}" data-datetime="{{created_at}}" data-channel-name="{{channel_name}}" data-channel-id="{{channel_id}}">
+  <div class="chat-transcript-user">
+    <div class="chat-transcript-user-avatar">
+      <img loading="lazy" alt="" width="20" height="20" src="//127.0.0.1:4200/letter_avatar_proxy/v4/letter/b/3be4f8/40.png" class="avatar" style="aspect-ratio: 20 / 20;">
+    </div>
+  <div class="chat-transcript-username">{{username}}</div>
+    <div class="chat-transcript-datetime">
+      <a href="{{message_url}}" title="{{created_at}}">{{created_at}}</a>
+    </div>
+    <a class="chat-transcript-channel" href="/chat/chat_channels/{{channel_id}}">
+      {{#is_category}}
+        <span class="category-chat-badge" style="color: #{{color}}">
+          <svg class="fa d-icon d-icon-hashtag svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#hashtag"></use></svg>
+        </span>
+      {{/is_category}}
+      {{#is_topic}}
+        <span class="topic-chat-icon">
+          <svg class="fa d-icon d-icon-far-comments svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#far-comments"></use></svg>
+        </span>
+      {{/is_topic}}
+      {{channel_name}}
+    </a>
+  </div>
+  <div class="chat-transcript-messages">{{{cooked}}}</div>
+</div>
+{{/cooked}}

--- a/lib/onebox/templates/discourse_chat.mustache
+++ b/lib/onebox/templates/discourse_chat.mustache
@@ -25,7 +25,7 @@
 <div class="discourse-chat-transcript" data-message-id="{{message_id}}" data-username="{{username}}" data-datetime="{{created_at}}" data-channel-name="{{channel_name}}" data-channel-id="{{channel_id}}">
   <div class="chat-transcript-user">
     <div class="chat-transcript-user-avatar">
-      <img loading="lazy" alt="" width="20" height="20" src="//127.0.0.1:4200/letter_avatar_proxy/v4/letter/b/3be4f8/40.png" class="avatar" style="aspect-ratio: 20 / 20;">
+      <img loading="lazy" alt="" width="20" height="20" src="{{avatar_url}}" class="avatar" style="aspect-ratio: 20 / 20;">
     </div>
   <div class="chat-transcript-username">{{username}}</div>
     <div class="chat-transcript-datetime">

--- a/plugin.rb
+++ b/plugin.rb
@@ -30,6 +30,7 @@ register_asset 'stylesheets/mobile/mobile.scss', :mobile
 register_asset 'stylesheets/desktop/desktop.scss', :desktop
 register_asset 'stylesheets/sidebar-extensions.scss'
 register_asset 'stylesheets/common/chat-message-separator.scss'
+register_asset 'stylesheets/common/chat-onebox.scss'
 
 register_svg_icon "comments"
 register_svg_icon "comment-slash"

--- a/plugin.rb
+++ b/plugin.rb
@@ -244,7 +244,7 @@ after_initialize do
     end
 
     Mustache.render(DiscourseChat.onebox_template, args)
-  end
+  end if Oneboxer.respond_to?(:register_local_handler)
 
   InlineOneboxer.register_local_handler('discourse_chat/chat') do |url, route|
     queryParams = CGI.parse(URI.parse(url).query) rescue {}
@@ -278,7 +278,7 @@ after_initialize do
     next if !Guardian.new.can_see_chat_channel?(chat_channel)
 
     { url: url, title: title }
-  end
+  end if InlineOneboxer.respond_to?(:register_local_handler)
 
   if respond_to?(:register_upload_unused)
     register_upload_unused do |uploads|

--- a/plugin.rb
+++ b/plugin.rb
@@ -192,11 +192,13 @@ after_initialize do
 
       chat_channel = message.chat_channel
       user = message.user
-      next if !chat_channel || user
+      next if !chat_channel || !user
     else
       chat_channel = ChatChannel.find_by(id: route[:channel_id])
       next if !chat_channel
     end
+
+    next if !Guardian.new.can_see_chat_channel?(chat_channel)
 
     name = if chat_channel.name.present?
       chat_channel.name
@@ -214,7 +216,9 @@ after_initialize do
     }
 
     if message.present?
+      args[:message_id] = message.id
       args[:username] = message.user.username
+      args[:avatar_url] = message.user.avatar_template_url.gsub("{size}", "20")
       args[:cooked] = message.cooked
       args[:created_at] = message.created_at
     end
@@ -250,6 +254,8 @@ after_initialize do
         I18n.t('chat.onebox.inline_to_topic_channel', topic_title: chat_channel.chatable.title)
       end
     end
+
+    next if !Guardian.new.can_see_chat_channel?(chat_channel)
 
     { url: url, title: title }
   end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -198,7 +198,6 @@ describe 'discourse-chat' do
               <div class="chat-onebox-members-count">0 members</div>
               <div class="chat-onebox-members"></div>
             </article>
-            <div class="clearfix"></div>
         </aside>
 
         HTML
@@ -210,7 +209,7 @@ describe 'discourse-chat' do
           <div class="chat-transcript-user">
             <div class="chat-transcript-user-avatar">
               <a class="trigger-user-card" data-user-card="#{user.username}" aria-hidden="true" tabindex="-1">
-                <img loading="lazy" alt="#{user.username}" width="20" height="20" src="#{user.avatar_template_url.gsub("{size}", "20")}" class="avatar" style="aspect-ratio: 20 / 20;">
+                <img loading="lazy" alt="#{user.username}" width="20" height="20" src="#{user.avatar_template_url.gsub("{size}", "20")}" class="avatar">
               </a>
             </div>
             <div class="chat-transcript-username">#{user.username}</div>

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -178,7 +178,7 @@ describe 'discourse-chat' do
         results = InlineOneboxer.new(["#{chat_url}?messageId=#{chat_message.id}"], skip_cache: true).process
         expect(results).to be_present
         expect(results[0][:url]).to eq("#{chat_url}?messageId=#{chat_message.id}")
-        expect(results[0][:title]).to eq("##{chat_channel.name} - Message ##{chat_message.id} by #{chat_message.user.username}")
+        expect(results[0][:title]).to eq("Message ##{chat_message.id} by #{chat_message.user.username} – ##{chat_channel.name}")
       end
     end
 
@@ -187,40 +187,45 @@ describe 'discourse-chat' do
         expect(Oneboxer.preview(chat_url)).to match_html <<~HTML
           <aside class="onebox chat-onebox">
             <article class="onebox-body chat-onebox-body">
-              <h3>
+              <h3 class="chat-onebox-title">
                 <a href="#{chat_url}">
-                    <span class="topic-chat-icon">
-                      <svg class="fa d-icon d-icon-far-comments svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#far-comments"></use></svg>
-                    </span>
+                  <span class="topic-chat-icon">
+                    <svg class="fa d-icon d-icon-far-comments svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#far-comments"></use></svg>
+                  </span>
                   <span class="clear-badge">#{chat_channel.name}</span>
                 </a>
               </h3>
+              <div class="chat-onebox-members-count">0 members</div>
+              <div class="chat-onebox-members"></div>
             </article>
             <div class="clearfix"></div>
-          </aside>
+        </aside>
+
         HTML
       end
 
       it "renders messages" do
         expect(Oneboxer.preview("#{chat_url}?messageId=#{chat_message.id}")).to match_html <<~HTML
           <div class="discourse-chat-transcript" data-message-id="#{chat_message.id}" data-username="#{user.username}" data-datetime="#{chat_message.created_at}" data-channel-name="#{chat_channel.name}" data-channel-id="#{chat_channel.id}">
-            <div class="chat-transcript-user">
-              <div class="chat-transcript-user-avatar">
-                <img loading="lazy" alt="" width="20" height="20" src="#{user.avatar_template_url.gsub("{size}", "20")}" class="avatar" style="aspect-ratio: 20 / 20;">
-              </div>
+          <div class="chat-transcript-user">
+            <div class="chat-transcript-user-avatar">
+              <a class="trigger-user-card" data-user-card="#{user.username}" aria-hidden="true" tabindex="-1">
+                <img loading="lazy" alt="#{user.username}" width="20" height="20" src="#{user.avatar_template_url.gsub("{size}", "20")}" class="avatar" style="aspect-ratio: 20 / 20;">
+              </a>
+            </div>
             <div class="chat-transcript-username">#{user.username}</div>
               <div class="chat-transcript-datetime">
                 <a href="" title="#{chat_message.created_at}">#{chat_message.created_at}</a>
               </div>
               <a class="chat-transcript-channel" href="/chat/chat_channels/#{chat_channel.id}">
-                 <span class="topic-chat-icon">
-                   <svg class="fa d-icon d-icon-far-comments svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#far-comments"></use></svg>
-                 </span>
+                  <span class="topic-chat-icon">
+                    <svg class="fa d-icon d-icon-far-comments svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#far-comments"></use></svg>
+                  </span>
                 #{chat_channel.name}
               </a>
             </div>
-            <div class="chat-transcript-messages"><p>Hello world!</p></div>
-          </div>
+          <div class="chat-transcript-messages"><p>Hello world!</p></div>
+        </div>
         HTML
       end
     end


### PR DESCRIPTION
This commit implements support for regular and inline oneboxes for chat.
Oneboxes are registered as local onebox using the new plugin API and
are different for links to channels and links to direct messages from
chat.

<!-- Checklist for UI / stylesheet changes, delete if not applicable -->

- [ ] chat-scoped -- core unaffected

### View mode

- [ ] docked (windowed/drawer)
- [ ] isolated (full-screen)

### Browsers

- [ ] safari
- [ ] chrome
- [ ] firefox

### Device

- [ ] desktop – wide screen
- [ ] mobile – `?mobile_view=1`

### Ember

- [ ] ember-cli
- [ ] legacy
