### PR TITLE
UI: slightly improve look of message actions on desktop

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-message-actions-desktop.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message-actions-desktop.hbs
@@ -29,7 +29,7 @@
     {{#if secondaryButtons.length}}
       {{dropdown-select-box
         class="more-buttons"
-        options=(hash icon="ellipsis-h")
+        options=(hash icon="ellipsis-v")
         content=secondaryButtons
         onChange=(action "handlesecondaryButtons")
       }}

--- a/assets/stylesheets/common/chat-message.scss
+++ b/assets/stylesheets/common/chat-message.scss
@@ -320,7 +320,7 @@
     }
   }
 
-  .more-buttons {
+  .more-buttons.dropdown-select-box {
     .select-kit-header {
       background: none;
       border: 1px solid var(--primary-low);
@@ -358,6 +358,24 @@
             color: var(--primary);
           }
         }
+      }
+    }
+
+    .select-kit-body {
+      padding: 0.5rem;
+      box-shadow: shadow("card");
+      border: 1px solid var(--primary-low);
+    }
+
+    .select-kit-row {
+      .texts .name {
+        font-size: var(--font-0);
+        font-weight: 500;
+      }
+
+      .icons .d-icon {
+        font-size: var(--font-0);
+        color: var(--primary-medium);
       }
     }
   }


### PR DESCRIPTION
Before:
<img width="271" alt="Screenshot 2022-05-19 at 16 30 01" src="https://user-images.githubusercontent.com/339945/169320274-bdd4b03b-8882-40e4-8365-d0852b84499a.png">

After:
<img width="259" alt="Screenshot 2022-05-19 at 16 28 07" src="https://user-images.githubusercontent.com/339945/169320124-1d33b446-d837-4867-a1b6-16ec8e9726c4.png">

