### PR TITLE
REFACTOR: move draft logic its own service

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -65,6 +65,7 @@ export default Component.extend({
   targetMessageId: null,
 
   chat: service(),
+  chatDraftHandler: service(),
   router: service(),
   chatComposerPresenceManager: service(),
 
@@ -148,7 +149,7 @@ export default Component.extend({
             this._startLastReadRunner();
           });
       } else {
-        this.set("draft", this.chat.getDraftForChannel("draft"));
+        this.set("draft", this.chatDraftHandler.getDraftForChannel("draft"));
       }
     }
     this.currentUserTimezone = this.currentUser?.resolvedTimezone(
@@ -196,7 +197,7 @@ export default Component.extend({
   },
 
   loadDraftForChannel(channelId) {
-    this.set("draft", this.chat.getDraftForChannel(channelId));
+    this.set("draft", this.chatDraftHandler.getDraftForChannel(channelId));
   },
 
   _fetchMoreMessages(direction) {
@@ -1194,7 +1195,7 @@ export default Component.extend({
         user: draft.replyToMsg.user,
       };
     }
-    this.chat.setDraftForChannel(this.chatChannel, draft);
+    this.chatDraftHandler.setDraftForChannel(this.chatChannel, draft);
     this.set("draft", draft);
   },
 

--- a/assets/javascripts/discourse/services/chat-draft-handler.js
+++ b/assets/javascripts/discourse/services/chat-draft-handler.js
@@ -1,0 +1,49 @@
+import Service from "@ember/service";
+import discourseDebounce from "discourse-common/lib/debounce";
+import { ajax } from "discourse/lib/ajax";
+
+export default class ChatDraftHandler extends Service {
+  init() {
+    super.init(...arguments);
+
+    this.draftStore = {};
+    if (this.currentUser.chat_drafts) {
+      this.currentUser.chat_drafts.forEach((draft) => {
+        this.draftStore[draft.channel_id] = JSON.parse(draft.data);
+      });
+    }
+  }
+
+  _saveDraft(channelId, draft) {
+    const data = { channel_id: channelId };
+    if (draft) {
+      data.data = JSON.stringify(draft);
+    }
+
+    ajax("/chat/drafts", { type: "POST", data });
+  }
+
+  setDraftForChannel(channel, draft) {
+    if (
+      draft &&
+      (draft.value || draft.uploads.length > 0 || draft.replyToMsg)
+    ) {
+      this.draftStore[channel.id] = draft;
+    } else {
+      delete this.draftStore[channel.id];
+      draft = null; // _saveDraft will destroy draft
+    }
+
+    discourseDebounce(this, this._saveDraft, channel.id, draft, 2000);
+  }
+
+  getDraftForChannel(channelId) {
+    return (
+      this.draftStore[channelId] || {
+        value: "",
+        uploads: [],
+        replyToMsg: null,
+      }
+    );
+  }
+}

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -63,13 +63,6 @@ export default Service.extend({
       this._subscribeToChannelEdits();
       this._subscribeToChannelStatusChange();
       this.presenceChannel = this.presence.getChannel("/chat/online");
-      this.draftStore = {};
-
-      if (this.currentUser.chat_drafts) {
-        this.currentUser.chat_drafts.forEach((draft) => {
-          this.draftStore[draft.channel_id] = JSON.parse(draft.data);
-        });
-      }
     }
   },
 
@@ -831,39 +824,6 @@ export default Service.extend({
 
   getDmChannelForUsernames(usernames) {
     return ajax("/chat/direct_messages.json", { data: { usernames } });
-  },
-
-  _saveDraft(channelId, draft) {
-    const data = { channel_id: channelId };
-    if (draft) {
-      data.data = JSON.stringify(draft);
-    }
-
-    ajax("/chat/drafts", { type: "POST", data });
-  },
-
-  setDraftForChannel(channel, draft) {
-    if (
-      draft &&
-      (draft.value || draft.uploads.length > 0 || draft.replyToMsg)
-    ) {
-      this.draftStore[channel.id] = draft;
-    } else {
-      delete this.draftStore[channel.id];
-      draft = null; // _saveDraft will destroy draft
-    }
-
-    discourseDebounce(this, this._saveDraft, channel.id, draft, 2000);
-  },
-
-  getDraftForChannel(channelId) {
-    return (
-      this.draftStore[channelId] || {
-        value: "",
-        uploads: [],
-        replyToMsg: null,
-      }
-    );
   },
 
   addToolbarButton() {


### PR DESCRIPTION
I took some inspiration for the syntax from https://github.com/discourse/discourse/blob/a8163a5c0cde06220ad71b2f96a304c28631a38a/app/assets/javascripts/discourse/app/services/presence.js#L246
Tried replacing init with constructor but the injected stuff can't be accessed i.e. this.currentUser

<!-- Checklist for UI / stylesheet changes, delete if not applicable -->

### Ember

- [x] ember-cli
- [x] legacy
