### PR TITLE
FIX: ensures composer transition is over to compute height

### DIFF
--- a/assets/javascripts/discourse/components/full-page-chat.js
+++ b/assets/javascripts/discourse/components/full-page-chat.js
@@ -1,3 +1,4 @@
+import afterTransition from "discourse/lib/after-transition";
 import Component from "@ember/component";
 import discourseComputed, { bind } from "discourse-common/utils/decorators";
 import { action } from "@ember/object";
@@ -102,21 +103,27 @@ export default Component.extend({
   },
 
   _calculateHeight() {
-    const main = document.getElementById("main-outlet"),
-      padBottom = window
-        .getComputedStyle(main, null)
-        .getPropertyValue("padding-bottom"),
-      chatContainerCoords = document
-        .querySelector(".full-page-chat")
-        .getBoundingClientRect();
+    schedule("afterRender", () => {
+      afterTransition(document.querySelector("#reply-control"), () => {
+        const main = document.getElementById("main-outlet");
+        const padBottom = window
+          .getComputedStyle(main, null)
+          .getPropertyValue("padding-bottom");
+        const chatContainerCoords = document
+          .querySelector(".full-page-chat")
+          .getBoundingClientRect();
+        const elHeight =
+          window.innerHeight -
+          chatContainerCoords.y -
+          window.pageYOffset -
+          parseInt(padBottom, 10);
 
-    const elHeight =
-      window.innerHeight -
-      chatContainerCoords.y -
-      window.pageYOffset -
-      parseInt(padBottom, 10);
-
-    document.body.style.setProperty("--full-page-chat-height", `${elHeight}px`);
+        document.body.style.setProperty(
+          "--full-page-chat-height",
+          `${elHeight}px`
+        );
+      });
+    });
   },
 
   _refreshChannel(channelId) {


### PR DESCRIPTION
Before this fix, opening full page chat with a composer opened and then closing the composer could leave the chat in a state where it was not using full height.