### PR TITLE
DEV: allows plugins to enable markdown features

### DIFF
--- a/app/core_ext/plugin_instance.rb
+++ b/app/core_ext/plugin_instance.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+DiscoursePluginRegistry.define_register(:chat_markdown_features, Set)
+
+class Plugin::Instance
+  def discourse_chat
+    DiscourseChatPluginApiExtensions
+  end
+
+  module DiscourseChatPluginApiExtensions
+    def self.enable_markdown_feature(name)
+      DiscoursePluginRegistry.chat_markdown_features << name
+    end
+  end
+end

--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -179,7 +179,7 @@ class ChatMessage < ActiveRecord::Base
   def self.cook(message, opts = {})
     cooked = PrettyText.cook(
       message,
-      features_override: MARKDOWN_FEATURES,
+      features_override: MARKDOWN_FEATURES + DiscoursePluginRegistry.chat_markdown_features.to_a,
       markdown_it_rules: MARKDOWN_IT_RULES,
       force_quote_link: true
     )

--- a/plugin.rb
+++ b/plugin.rb
@@ -53,6 +53,7 @@ add_admin_route 'chat.admin.title', 'chat'
 
 # Site setting validators must be loaded before initialize
 require_relative "lib/validators/chat_default_channel_validator.rb"
+require_relative "app/core_ext/plugin_instance.rb"
 
 after_initialize do
   module ::DiscourseChat

--- a/spec/integration/plugin_api_spec.rb
+++ b/spec/integration/plugin_api_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Plugin API for discourse_chat' do
+  before do
+    SiteSetting.chat_enabled = true
+  end
+
+  let(:metadata) do
+    metadata = Plugin::Metadata.new
+    metadata.name = 'test'
+    metadata
+  end
+
+  let(:plugin_instance) do
+    plugin = Plugin::Instance.new(nil, "/tmp/test.rb")
+    plugin.metadata = metadata
+    plugin
+  end
+
+  context 'discourse_chat.enable_markdown_feature' do
+    it 'stores the markdown feature' do
+      plugin_instance.discourse_chat.enable_markdown_feature(:foo)
+
+      expect(DiscoursePluginRegistry.chat_markdown_features.include?(:foo)).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
Usage in plugin.rb:

```ruby
if respond_to?(:discourse_chat)
  discourse_chat&.enable_markdown_feature('discourse-video')
end
```
