### PR TITLE
FIX: Fix filter in chat channel fetcher

### DIFF
--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -143,10 +143,11 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
     params.require(:filter)
     filter = params[:filter]&.downcase
     memberships = UserChatChannelMembership.where(user: current_user)
-    public_channels = DiscourseChat::ChatChannelFetcher.public_channels_with_filter(
+    public_channels = DiscourseChat::ChatChannelFetcher.secured_public_channels(
       guardian,
       memberships,
-      filter
+      scope_with_membership: false,
+      filter: filter
     )
 
     users = User.joins(:user_option)

--- a/spec/lib/chat_channel_fetcher_spec.rb
+++ b/spec/lib/chat_channel_fetcher_spec.rb
@@ -1,45 +1,60 @@
 # frozen_string_literal: true
 
 describe DiscourseChat::ChatChannelFetcher do
-  describe ".unread_counts" do
-    fab!(:user_1) { Fabricate(:user) }
-    fab!(:user_2) { Fabricate(:user) }
-    fab!(:chat_channel) { Fabricate(:chat_channel) }
+  fab!(:category) { Fabricate(:category, name: "support") }
+  fab!(:private_category) { Fabricate(:private_category, group: Fabricate(:group)) }
+  fab!(:category_channel) { Fabricate(:chat_channel, chatable: category) }
+  fab!(:topic) { Fabricate(:topic, title: "Some fast moving topic") }
+  fab!(:first_post) { Fabricate(:post, topic: topic) }
+  fab!(:topic_channel) { Fabricate(:chat_channel, chatable: topic) }
+  fab!(:dm_channel) { Fabricate(:direct_message_channel) }
+  fab!(:direct_message_channel) { Fabricate(:chat_channel, chatable: dm_channel) }
+  fab!(:user1) { Fabricate(:user) }
+  fab!(:user2) { Fabricate(:user) }
 
+  def guardian
+    Guardian.new(user1)
+  end
+
+  def memberships
+    UserChatChannelMembership.where(user: user1)
+  end
+
+  describe ".unread_counts" do
     context "user is member of the channel" do
       before do
-        Fabricate(:user_chat_channel_membership, chat_channel: chat_channel, user: user_1)
+        Fabricate(:user_chat_channel_membership, chat_channel: topic_channel, user: user1)
       end
 
       context "has unread messages" do
         before do
-          Fabricate(:chat_message, chat_channel: chat_channel, message: "hi", user: user_2)
-          Fabricate(:chat_message, chat_channel: chat_channel, message: "bonjour", user: user_2)
+          Fabricate(:chat_message, chat_channel: topic_channel, message: "hi", user: user2)
+          Fabricate(:chat_message, chat_channel: topic_channel, message: "bonjour", user: user2)
         end
 
         it "returns the correct count" do
-          unread_counts = subject.unread_counts([chat_channel], user_1)
-          expect(unread_counts[chat_channel.id]).to eq(2)
+          unread_counts = subject.unread_counts([topic_channel], user1)
+          expect(unread_counts[topic_channel.id]).to eq(2)
         end
       end
 
       context "has no unread messages" do
         it "returns the correct count" do
-          unread_counts = subject.unread_counts([chat_channel], user_1)
-          expect(unread_counts[chat_channel.id]).to eq(0)
+          unread_counts = subject.unread_counts([topic_channel], user1)
+          expect(unread_counts[topic_channel.id]).to eq(0)
         end
       end
 
       context "last unread message has been deleted" do
-        fab!(:last_unread) { Fabricate(:chat_message, chat_channel: chat_channel, message: "hi", user: user_2) }
+        fab!(:last_unread) { Fabricate(:chat_message, chat_channel: topic_channel, message: "hi", user: user2) }
 
         before do
           last_unread.update!(deleted_at: Time.zone.now)
         end
 
         it "returns the correct count" do
-          unread_counts = subject.unread_counts([chat_channel], user_1)
-          expect(unread_counts[chat_channel.id]).to eq(0)
+          unread_counts = subject.unread_counts([topic_channel], user1)
+          expect(unread_counts[topic_channel.id]).to eq(0)
         end
       end
     end
@@ -47,45 +62,28 @@ describe DiscourseChat::ChatChannelFetcher do
     context "user is not member of the channel" do
       context "the channel has new messages" do
         before do
-          Fabricate(:chat_message, chat_channel: chat_channel, message: "hi", user: user_2)
+          Fabricate(:chat_message, chat_channel: topic_channel, message: "hi", user: user2)
         end
 
         it "returns the correct count" do
-          unread_counts = subject.unread_counts([chat_channel], user_1)
-          expect(unread_counts[chat_channel.id]).to eq(0)
+          unread_counts = subject.unread_counts([topic_channel], user1)
+          expect(unread_counts[topic_channel.id]).to eq(0)
         end
       end
     end
   end
 
   describe ".all_secured_channel_ids" do
-    fab!(:category) { Fabricate(:category) }
-    fab!(:private_category) { Fabricate(:private_category, group: Fabricate(:group)) }
-    fab!(:category_channel) { Fabricate(:chat_channel, chatable: category) }
-    fab!(:topic) { Fabricate(:topic) }
-    fab!(:topic_channel) { Fabricate(:chat_channel, chatable: topic) }
-    fab!(:dm_channel) { Fabricate(:direct_message_channel) }
-    fab!(:direct_message_channel) { Fabricate(:chat_channel, chatable: dm_channel) }
-    fab!(:user) { Fabricate(:user) }
-
-    before do
-      Fabricate(:post, topic: topic)
-    end
-
-    def guardian
-      Guardian.new(user)
-    end
-
     it "returns nothing by default if the user has no memberships" do
       expect(subject.all_secured_channel_ids(guardian)).to eq([])
     end
 
     context "when the user has memberships to all the channels" do
       before do
-        UserChatChannelMembership.create!(user: user, chat_channel: category_channel, following: true)
-        UserChatChannelMembership.create!(user: user, chat_channel: topic_channel, following: true)
+        UserChatChannelMembership.create!(user: user1, chat_channel: category_channel, following: true)
+        UserChatChannelMembership.create!(user: user1, chat_channel: topic_channel, following: true)
         UserChatChannelMembership.create!(
-          user: user, chat_channel: direct_message_channel, following: true,
+          user: user1, chat_channel: direct_message_channel, following: true,
           desktop_notification_level: UserChatChannelMembership::NOTIFICATION_LEVELS[:always],
           mobile_notification_level: UserChatChannelMembership::NOTIFICATION_LEVELS[:always]
         )
@@ -96,7 +94,7 @@ describe DiscourseChat::ChatChannelFetcher do
       end
 
       it "returns all the channels if the user is a member of the DM channel also" do
-        DirectMessageUser.create!(user: user, direct_message_channel: dm_channel)
+        DirectMessageUser.create!(user: user1, direct_message_channel: dm_channel)
         expect(subject.all_secured_channel_ids(guardian)).to match_array([
           topic_channel.id, category_channel.id, direct_message_channel.id
         ])
@@ -105,22 +103,90 @@ describe DiscourseChat::ChatChannelFetcher do
       it "does not include the topic channel if the topic is in a private category the user cannot see" do
         topic.update(category: private_category)
         expect(subject.all_secured_channel_ids(guardian)).to match_array([category_channel.id])
-        GroupUser.create(group: private_category.groups.last, user: user)
+        GroupUser.create(group: private_category.groups.last, user: user1)
         expect(subject.all_secured_channel_ids(guardian)).to match_array([topic_channel.id, category_channel.id])
       end
 
       it "does not include the category channel if the category is a private category the user cannot see" do
         category_channel.update(chatable: private_category)
         expect(subject.all_secured_channel_ids(guardian)).to match_array([topic_channel.id])
-        GroupUser.create(group: private_category.groups.last, user: user)
+        GroupUser.create(group: private_category.groups.last, user: user1)
         expect(subject.all_secured_channel_ids(guardian)).to match_array([topic_channel.id, category_channel.id])
       end
 
       it "does not include the topic channel if the topic is a private message the user cannot see" do
         topic.convert_to_private_message(Discourse.system_user)
         expect(subject.all_secured_channel_ids(guardian)).to match_array([category_channel.id])
-        TopicAllowedUser.create(topic: topic, user: user)
+        TopicAllowedUser.create(topic: topic, user: user1)
         expect(subject.all_secured_channel_ids(guardian)).to match_array([topic_channel.id, category_channel.id])
+      end
+    end
+  end
+
+  describe "#secured_public_channels" do
+    let(:scope_with_membership) { false }
+
+    it "does not include DM channels" do
+      expect(subject.secured_public_channels(
+        guardian, memberships, scope_with_membership: scope_with_membership
+      ).map(&:id)).to match_array(
+        [topic_channel.id, category_channel.id]
+      )
+    end
+
+    it "can filter by channel name, topic title, or category name" do
+      expect(subject.secured_public_channels(
+        guardian, memberships, scope_with_membership: scope_with_membership, filter: "support"
+      ).map(&:id)).to match_array([category_channel.id])
+
+      expect(subject.secured_public_channels(
+        guardian, memberships, scope_with_membership: scope_with_membership, filter: "fast moving"
+      ).map(&:id)).to match_array([topic_channel.id])
+
+      topic_channel.update(name: "cool stuff")
+
+      expect(subject.secured_public_channels(
+        guardian, memberships, scope_with_membership: scope_with_membership, filter: "cool stuff"
+      ).map(&:id)).to match_array([topic_channel.id])
+    end
+
+    it "does not show the user topic channels for PMs they cannot access" do
+      topic.convert_to_private_message(Discourse.system_user)
+      expect(subject.secured_public_channels(
+        guardian, memberships, scope_with_membership: scope_with_membership
+      ).map(&:id)).to match_array([category_channel.id])
+    end
+
+    it "does not show the user topic channels for categories they cannot access" do
+      topic.update(category: private_category)
+      expect(subject.secured_public_channels(
+        guardian, memberships, scope_with_membership: scope_with_membership
+      ).map(&:id)).to match_array([category_channel.id])
+    end
+
+    it "does not show the user category channels they cannot access" do
+      category_channel.update(chatable: private_category)
+      expect(subject.secured_public_channels(
+        guardian, memberships, scope_with_membership: scope_with_membership
+      ).map(&:id)).to match_array([topic_channel.id])
+    end
+
+    context "when scoping to the user's channel memberships" do
+      let(:scope_with_membership) { true }
+
+      it "only returns channels where the user is a member and is following the channel" do
+        expect(subject.secured_public_channels(
+          guardian, memberships, scope_with_membership: scope_with_membership
+        ).map(&:id)).to eq([])
+
+        UserChatChannelMembership.create(user: user1, chat_channel: topic_channel, following: true)
+        UserChatChannelMembership.create(user: user1, chat_channel: category_channel, following: true)
+
+        expect(subject.secured_public_channels(
+          guardian, memberships, scope_with_membership: scope_with_membership
+        ).map(&:id)).to match_array(
+          [topic_channel.id, category_channel.id]
+        )
       end
     end
   end


### PR DESCRIPTION
This fixes the filter in the fetcher -- it was only searching
on chat channel name but that's not always there, we need to
filter on topic title and category name as well.

Also the public_channels_with_filter function was redundant,
it shared too much with secured_public_channels, so I just
moved the filter into there.
