### PR TITLE
FEATURE: Add a button to switch back to small chat

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -25,6 +25,7 @@ import { spinnerHTML } from "discourse/helpers/loading-spinner";
 import { decorateGithubOneboxBody } from "discourse/initializers/onebox-decorators";
 import highlightSyntax from "discourse/lib/highlight-syntax";
 import { applyLocalDates } from "discourse/lib/local-dates";
+import { defaultHomepage } from "discourse/lib/utilities";
 
 const MAX_RECENT_MSGS = 100;
 const STICKY_SCROLL_LENIENCE = 4;
@@ -67,6 +68,7 @@ export default Component.extend({
   chat: service(),
   router: service(),
   chatComposerPresenceManager: service(),
+  chatWindowStore: service("chat-window-store"),
 
   getCachedChannelDetails: null,
   clearCachedChannelDetails: null,
@@ -1169,11 +1171,26 @@ export default Component.extend({
     if (this.chatChannel.chatable_url) {
       return this.router.transitionTo(this.chatChannel.chatable_url);
     }
+    return false;
   },
 
   @action
   onChannelTitleClick() {
     return this._goToChatableUrl();
+  },
+
+  @action
+  onCloseFullScreen(channel) {
+    // update local storage
+    this.chatWindowStore.fullPage = false;
+
+    // navigate to chatable url or homepage on compress
+    if (this._goToChatableUrl() === false) {
+      this.router.transitionTo(`discovery.${defaultHomepage()}`);
+    }
+
+    // re-open chat as docked window
+    this.appEvents.trigger("chat:open-channel", channel, { hello: 'test' });
   },
 
   @action

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1182,7 +1182,7 @@ export default Component.extend({
   @action
   onCloseFullScreen(channel) {
     // update local storage
-    this.chatWindowStore.fullPage = false;
+    this.chatWindowStore.set("fullPage", false);
 
     // navigate to chatable url or homepage on compress
     if (this._goToChatableUrl() === false) {
@@ -1190,7 +1190,7 @@ export default Component.extend({
     }
 
     // re-open chat as docked window
-    this.appEvents.trigger("chat:open-channel", channel, { hello: 'test' });
+    this.appEvents.trigger("chat:open-channel", channel);
   },
 
   @action

--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -253,7 +253,7 @@ export default Component.extend({
       activeChannel: null,
     });
 
-    this.chatWindowStore.fullPage = true
+    this.chatWindowStore.set("fullPage", true);
 
     if (channel) {
       return this.router.transitionTo(

--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -16,6 +16,7 @@ export default Component.extend({
   classNameBindings: [":topic-chat-float-container", "hidden"],
   chat: service(),
   router: service(),
+  chatWindowStore: service("chat-window-store"),
 
   hidden: true,
   loading: false,
@@ -252,6 +253,8 @@ export default Component.extend({
       activeChannel: null,
     });
 
+    this.chatWindowStore.fullPage = true
+
     if (channel) {
       return this.router.transitionTo(
         "chat.channel",
@@ -344,7 +347,7 @@ export default Component.extend({
       this.set("activeChannel", null);
     }
 
-    if (this.site.mobileView || this.chat.isChatPage) {
+    if (this.site.mobileView) {
       return this.chat.openChannel(channel);
     }
 
@@ -363,6 +366,19 @@ export default Component.extend({
       expectPageChange: false,
       view: CHAT_VIEW,
     };
+
+    if (this.chatWindowStore.fullPage) {
+      if (channel) {
+        return this.router.transitionTo(
+          "chat.channel",
+          channel.id,
+          channel.title
+        );
+      }
+
+      return this.router.transitionTo("chat");
+    }
+
     this.chat.setActiveChannel(channel);
     this.setProperties(channelInfo);
     return Promise.resolve();

--- a/assets/javascripts/discourse/services/chat-window-store.js
+++ b/assets/javascripts/discourse/services/chat-window-store.js
@@ -1,0 +1,25 @@
+import KeyValueStore from "discourse/lib/key-value-store";
+import Service from "@ember/service";
+
+const FULL_PAGE = "fullPage";
+const STORE_NAMESPACE_CHAT_WINDOW = "discourse_chat_window_";
+
+export default Service.extend({
+  init() {
+    this._super(...arguments);
+
+    this.store = new KeyValueStore(STORE_NAMESPACE_CHAT_WINDOW);
+
+    if (!this.store.getObject(FULL_PAGE)) {
+      this.fullPage = false;
+    }
+  },
+
+  get fullPage() {
+    return this.store.getObject(FULL_PAGE) || false;
+  },
+
+  set fullPage(value) {
+    this.store.setObject({ key: FULL_PAGE, value: value });
+  },
+});

--- a/assets/javascripts/discourse/services/chat-window-store.js
+++ b/assets/javascripts/discourse/services/chat-window-store.js
@@ -20,6 +20,6 @@ export default Service.extend({
   },
 
   set fullPage(value) {
-    this.store.setObject({ key: FULL_PAGE, value: value });
+    this.store.setObject({ key: FULL_PAGE, value });
   },
 });

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -49,6 +49,7 @@ export default Service.extend({
   router: service(),
   sidebarActive: false,
   unreadUrgentCount: null,
+  chatWindowStore: service("chat-window-store"),
   _chatOpen: false,
   _fetchingChannels: null,
   _fullScreenChatOpen: false,
@@ -90,11 +91,15 @@ export default Service.extend({
 
   @discourseComputed("router.currentRouteName")
   isChatPage(routeName) {
-    return (
+    let chatPage = (
       routeName === "chat" ||
       routeName === "chat.channel" ||
       routeName === "chat.loading"
     );
+    if (chatPage) {
+      this.set('chatWindowFullPage', true);
+    }
+    return chatPage;
   },
 
   isBrowsePage: equal("router.currentRouteName", "chat.browse"),
@@ -125,6 +130,10 @@ export default Service.extend({
         );
       });
     });
+  },
+
+  set chatWindowFullPage(value) {
+    return this.chatWindowStore.fullPage = value;
   },
 
   get fullScreenChatOpen() {

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -91,13 +91,12 @@ export default Service.extend({
 
   @discourseComputed("router.currentRouteName")
   isChatPage(routeName) {
-    let chatPage = (
+    let chatPage =
       routeName === "chat" ||
       routeName === "chat.channel" ||
-      routeName === "chat.loading"
-    );
+      routeName === "chat.loading";
     if (chatPage) {
-      this.set('chatWindowFullPage', true);
+      this.set("chatWindowFullPage", true);
     }
     return chatPage;
   },
@@ -133,7 +132,7 @@ export default Service.extend({
   },
 
   set chatWindowFullPage(value) {
-    return this.chatWindowStore.fullPage = value;
+    return this.chatWindowStore.set("fullPage", value);
   },
 
   get fullScreenChatOpen() {

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -20,6 +20,13 @@
         {{chat-channel-status channel=chatChannel}}
       </div>
 
+      {{flat-button
+        class="chat-full-screen-button"
+        icon="discourse-compress"
+        action=(action "onCloseFullScreen" chatChannel)
+        title="chat.close_full_page"
+      }}
+
       {{chat-channel-archive-status channel=chatChannel}}
     </div>
   </div>

--- a/assets/javascripts/discourse/widgets/chat-header-icon.js
+++ b/assets/javascripts/discourse/widgets/chat-header-icon.js
@@ -75,6 +75,7 @@ export default createWidget("header-chat-link", {
     }
 
     if (this.site.mobileView || this.chat.sidebarActive) {
+      this.chat.set("chatWindowFullPage", true);
       return this.router.transitionTo("chat");
     } else {
       this.appEvents.trigger("chat:toggle-open");

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -108,6 +108,7 @@ en:
         description: "Do not send notifications for channel-wide mentions (@here and @all)"
       open: "Open chat"
       open_full_page: "Open full-screen chat"
+      close_full_page: "Close full-screen chat"
       open_message: "Open message in chat"
       placeholder_self: "Jot something down"
       placeholder_others: "Chat with %{messageRecipient}"

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -546,6 +546,7 @@ acceptance("Discourse Chat - without unread", function (needs) {
 
   test("Reply-to is stored in draft", async function (assert) {
     this.chatService.set("sidebarActive", false);
+    this.chatService.set("chatWindowFullPage", false);
     await visit("/latest");
     this.appEvents.trigger("chat:toggle-open");
     await chatSettled();
@@ -1177,6 +1178,7 @@ acceptance(
     test("Chat float opens on header icon click when sidebar is not installed", async function (assert) {
       await visit("/t/internationalization-localization/280");
       this.chatService.set("sidebarActive", false);
+      this.chatService.set("chatWindowFullPage", false);
       await click(".header-dropdown-toggle.open-chat");
       assert.ok(visible(".topic-chat-float-container"), "chat float is open");
     });
@@ -1536,6 +1538,7 @@ acceptance("Discourse Chat - image uploads", function (needs) {
   test("uploading files in chat works", async function (assert) {
     await visit("/t/internationalization-localization/280");
     this.container.lookup("service:chat").set("sidebarActive", false);
+    this.container.lookup("service:chat").set("chatWindowFullPage", false);
     await click(".header-dropdown-toggle.open-chat");
 
     assert.ok(visible(".topic-chat-float-container"), "chat float is open");
@@ -1595,6 +1598,7 @@ acceptance("Discourse Chat - image uploads", function (needs) {
     assert.ok(exists(".d-editor-input"), "the composer input is visible");
 
     this.container.lookup("service:chat").set("sidebarActive", false);
+    this.container.lookup("service:chat").set("chatWindowFullPage", false);
     await click(".header-dropdown-toggle.open-chat");
     assert.ok(visible(".topic-chat-float-container"), "chat float is open");
 

--- a/test/javascripts/unit/lib/chat-window-store-test.js
+++ b/test/javascripts/unit/lib/chat-window-store-test.js
@@ -1,0 +1,32 @@
+import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+
+discourseModule(
+  "Discourse Chat | Unit | chat-window-store",
+  function (hooks) {
+    hooks.beforeEach(function () {
+      this.chatWindowStore = this.container.lookup(
+        "service:chat-window-store"
+      );
+    });
+
+    test("defaults", function (assert) {
+      assert.strictEqual(this.chatWindowStore.fullPage, false);
+    });
+
+    test("fullPage", function (assert) {
+      this.chatWindowStore.fullPage = true
+      assert.strictEqual(this.chatWindowStore.fullPage, true);
+    });
+
+    test("fullPageFalse", function (assert) {
+      this.chatWindowStore.fullPage = false
+      assert.strictEqual(this.chatWindowStore.fullPage, false);
+    });
+
+    test("fullPageNull", function (assert) {
+      this.chatWindowStore.fullPage = null
+      assert.strictEqual(this.chatWindowStore.fullPage, false);
+    });
+  }
+);

--- a/test/javascripts/unit/lib/chat-window-store-test.js
+++ b/test/javascripts/unit/lib/chat-window-store-test.js
@@ -1,32 +1,27 @@
 import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 
-discourseModule(
-  "Discourse Chat | Unit | chat-window-store",
-  function (hooks) {
-    hooks.beforeEach(function () {
-      this.chatWindowStore = this.container.lookup(
-        "service:chat-window-store"
-      );
-    });
+discourseModule("Discourse Chat | Unit | chat-window-store", function (hooks) {
+  hooks.beforeEach(function () {
+    this.chatWindowStore = this.container.lookup("service:chat-window-store");
+  });
 
-    test("defaults", function (assert) {
-      assert.strictEqual(this.chatWindowStore.fullPage, false);
-    });
+  test("defaults", function (assert) {
+    assert.strictEqual(this.chatWindowStore.fullPage, false);
+  });
 
-    test("fullPage", function (assert) {
-      this.chatWindowStore.set("fullPage", true);
-      assert.strictEqual(this.chatWindowStore.fullPage, true);
-    });
+  test("fullPage", function (assert) {
+    this.chatWindowStore.set("fullPage", true);
+    assert.strictEqual(this.chatWindowStore.fullPage, true);
+  });
 
-    test("fullPageFalse", function (assert) {
-      this.chatWindowStore.set("fullPage", false);
-      assert.strictEqual(this.chatWindowStore.fullPage, false);
-    });
+  test("fullPageFalse", function (assert) {
+    this.chatWindowStore.set("fullPage", false);
+    assert.strictEqual(this.chatWindowStore.fullPage, false);
+  });
 
-    test("fullPageNull", function (assert) {
-      this.chatWindowStore.set("fullPage", null);
-      assert.strictEqual(this.chatWindowStore.fullPage, false);
-    });
-  }
-);
+  test("fullPageNull", function (assert) {
+    this.chatWindowStore.set("fullPage", null);
+    assert.strictEqual(this.chatWindowStore.fullPage, false);
+  });
+});

--- a/test/javascripts/unit/lib/chat-window-store-test.js
+++ b/test/javascripts/unit/lib/chat-window-store-test.js
@@ -15,17 +15,17 @@ discourseModule(
     });
 
     test("fullPage", function (assert) {
-      this.chatWindowStore.fullPage = true
+      this.chatWindowStore.set("fullPage", true);
       assert.strictEqual(this.chatWindowStore.fullPage, true);
     });
 
     test("fullPageFalse", function (assert) {
-      this.chatWindowStore.fullPage = false
+      this.chatWindowStore.set("fullPage", false);
       assert.strictEqual(this.chatWindowStore.fullPage, false);
     });
 
     test("fullPageNull", function (assert) {
-      this.chatWindowStore.fullPage = null
+      this.chatWindowStore.set("fullPage", null);
       assert.strictEqual(this.chatWindowStore.fullPage, false);
     });
   }


### PR DESCRIPTION
This feature, in addition to adding a button to get back to small chat
from being in the full-page chat, adds *memory* to the window size.
This means that if you prefer to open chat in full-size when using the
sidebar it will remember which preference you have set when opening
channels.

See: https://meta.discourse.org/t/221388
