### PR TITLE
FIX: Make the bookmark row highlight work with sidebar

### DIFF
--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -130,7 +130,7 @@
 
     .chat-live-pane,
     .chat-messages-scroll,
-    .chat-message:not(.highlighted):not(.deleted) {
+    .chat-message:not(.highlighted):not(.deleted):not(.chat-message-bookmarked) {
       background: transparent;
     }
 


### PR DESCRIPTION
Was missing a CSS class override to make these yellow highlights work with sidebar:

![image](https://user-images.githubusercontent.com/920448/170157725-7127a697-7b13-4919-ac37-968251076917.png)
