### PR TITLE
FIX: send_unread_mentions_summary is a class method

### DIFF
--- a/lib/chat_mailer.rb
+++ b/lib/chat_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DiscourseChat::ChatMailer
-  def send_unread_mentions_summary
+  def self.send_unread_mentions_summary
     return unless SiteSetting.chat_enabled
 
     users_with_unprocessed_unread_mentions.find_each do |user|
@@ -24,7 +24,7 @@ class DiscourseChat::ChatMailer
 
   private
 
-  def users_with_unprocessed_unread_mentions
+  def self.users_with_unprocessed_unread_mentions
     when_away_frequency = UserOption.chat_email_frequencies[:when_away]
     allowed_group_ids = DiscourseChat.allowed_group_ids
 

--- a/spec/components/chat_mailer_spec.rb
+++ b/spec/components/chat_mailer_spec.rb
@@ -42,7 +42,7 @@ describe DiscourseChat::ChatMailer do
     it 'skips users without chat access' do
       @chatters_group.remove(@user_1)
 
-      subject.send_unread_mentions_summary
+      described_class.send_unread_mentions_summary
 
       asert_summary_skipped
     end
@@ -50,7 +50,7 @@ describe DiscourseChat::ChatMailer do
     it 'skips users with summaries disabled' do
       @user_1.user_option.update(chat_email_frequency: UserOption.chat_email_frequencies[:never])
 
-      subject.send_unread_mentions_summary
+      described_class.send_unread_mentions_summary
 
       asert_summary_skipped
     end
@@ -58,7 +58,7 @@ describe DiscourseChat::ChatMailer do
     it "skips a job if the user haven't read the channel since the last summary" do
       @user_membership.update!(last_unread_mention_when_emailed_id: @chat_message.id)
 
-      subject.send_unread_mentions_summary
+      described_class.send_unread_mentions_summary
 
       asert_summary_skipped
     end
@@ -66,13 +66,13 @@ describe DiscourseChat::ChatMailer do
     it 'skips without chat enabled' do
       @user_1.user_option.update(chat_enabled: false, chat_email_frequency: UserOption.chat_email_frequencies[:when_away])
 
-      subject.send_unread_mentions_summary
+      described_class.send_unread_mentions_summary
 
       asert_summary_skipped
     end
 
     it 'queues a job for users that was mentioned and never read the channel before' do
-      subject.send_unread_mentions_summary
+      described_class.send_unread_mentions_summary
 
       assert_only_queued_once
     end
@@ -80,7 +80,7 @@ describe DiscourseChat::ChatMailer do
     it 'skips the job when the user was mentioned but already read the message' do
       @user_membership.update!(last_read_message_id: @chat_message.id)
 
-      subject.send_unread_mentions_summary
+      described_class.send_unread_mentions_summary
 
       asert_summary_skipped
     end
@@ -88,7 +88,7 @@ describe DiscourseChat::ChatMailer do
     it 'skips the job when the user is not following the channel anymore' do
       @user_membership.update!(last_read_message_id: @chat_message.id - 1, following: false)
 
-      subject.send_unread_mentions_summary
+      described_class.send_unread_mentions_summary
 
       asert_summary_skipped
     end
@@ -98,7 +98,7 @@ describe DiscourseChat::ChatMailer do
       second_channel = Fabricate(:chat_channel)
       Fabricate(:user_chat_channel_membership, user: @user_1, chat_channel: second_channel, last_read_message_id: @chat_message.id - 1)
 
-      subject.send_unread_mentions_summary
+      described_class.send_unread_mentions_summary
 
       asert_summary_skipped
     end
@@ -107,7 +107,7 @@ describe DiscourseChat::ChatMailer do
       chatters_group_2 = Fabricate(:group, users: [@user_1])
       SiteSetting.chat_allowed_groups = [@chatters_group, chatters_group_2].map(&:id).join('|')
 
-      subject.send_unread_mentions_summary
+      described_class.send_unread_mentions_summary
 
       assert_only_queued_once
     end
@@ -115,7 +115,7 @@ describe DiscourseChat::ChatMailer do
     it 'skips users when the mention was deleted' do
       @chat_message.trash!
 
-      subject.send_unread_mentions_summary
+      described_class.send_unread_mentions_summary
 
       asert_summary_skipped
     end
@@ -125,7 +125,7 @@ describe DiscourseChat::ChatMailer do
       unread_message = Fabricate(:chat_message, chat_channel: @chat_channel, user: @sender)
       Fabricate(:chat_mention, user: @user_1, chat_message: unread_message)
 
-      subject.send_unread_mentions_summary
+      described_class.send_unread_mentions_summary
 
       expect_job_enqueued(job: :user_email, args: { type: "chat_summary", user_id: @user_1.id })
       expect(Jobs::UserEmail.jobs.size).to eq(1)
@@ -134,7 +134,7 @@ describe DiscourseChat::ChatMailer do
     it 'skips users who were seen recently' do
       @user_1.update!(last_seen_at: 2.minutes.ago)
 
-      subject.send_unread_mentions_summary
+      described_class.send_unread_mentions_summary
 
       asert_summary_skipped
     end
@@ -146,7 +146,7 @@ describe DiscourseChat::ChatMailer do
       new_message = Fabricate(:chat_message, chat_channel: @chat_channel, user: @sender)
       Fabricate(:chat_mention, user: user_2, chat_message: new_message)
 
-      subject.send_unread_mentions_summary
+      described_class.send_unread_mentions_summary
 
       expect(job_enqueued?(job: :user_email, args: { type: "chat_summary", user_id: @user_1.id })).to eq(false)
       expect_job_enqueued(job: :user_email, args: { type: "chat_summary", user_id: user_2.id })
@@ -158,14 +158,14 @@ describe DiscourseChat::ChatMailer do
 
       it "doesn't send the same summary the summary again if the user haven't read any channel messages since the last one" do
         @user_membership.update!(last_read_message_id: @chat_message.id - 1)
-        subject.send_unread_mentions_summary
+        described_class.send_unread_mentions_summary
 
         expect(@user_membership.reload.last_unread_mention_when_emailed_id).to eq(@chat_message.id)
 
         another_channel_message = Fabricate(:chat_message, chat_channel: @chat_channel, user: @sender)
         Fabricate(:chat_mention, user: @user_1, chat_message: another_channel_message)
 
-        expect { subject.send_unread_mentions_summary }.to change(Jobs::UserEmail.jobs, :size).by(0)
+        expect { described_class.send_unread_mentions_summary }.to change(Jobs::UserEmail.jobs, :size).by(0)
       end
 
       it 'only updates the last_message_read_when_emailed_id on the channel with unread mentions' do
@@ -178,7 +178,7 @@ describe DiscourseChat::ChatMailer do
         )
         @user_membership.update!(last_read_message_id: @chat_message.id - 1)
 
-        subject.send_unread_mentions_summary
+        described_class.send_unread_mentions_summary
 
         expect(@user_membership.reload.last_unread_mention_when_emailed_id).to eq(@chat_message.id)
         expect(another_channel_membership.reload.last_unread_mention_when_emailed_id).to be_nil
@@ -192,7 +192,7 @@ describe DiscourseChat::ChatMailer do
     end
 
     it 'queue a job when the user has unread private mentions' do
-      subject.send_unread_mentions_summary
+      described_class.send_unread_mentions_summary
 
       assert_only_queued_once
     end
@@ -200,7 +200,7 @@ describe DiscourseChat::ChatMailer do
     it 'only queues the job once when the user has mentions and private messages' do
       Fabricate(:chat_mention, user: @user_1, chat_message: @chat_message)
 
-      subject.send_unread_mentions_summary
+      described_class.send_unread_mentions_summary
 
       assert_only_queued_once
     end
@@ -210,7 +210,7 @@ describe DiscourseChat::ChatMailer do
       user_2_membership = Fabricate(:user_chat_channel_membership, user: user_2, chat_channel: @chat_channel, last_read_message_id: @chat_message.id)
       Fabricate(:chat_mention, user: user_2, chat_message: @chat_message)
 
-      subject.send_unread_mentions_summary
+      described_class.send_unread_mentions_summary
 
       assert_only_queued_once
       expect(user_2_membership.reload.last_unread_mention_when_emailed_id).to be_nil

--- a/spec/jobs/scheduled/email_chat_notifications_spec.rb
+++ b/spec/jobs/scheduled/email_chat_notifications_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe Jobs::EmailChatNotifications do
+  before do
+    Jobs.run_immediately!
+  end
+
+  context 'chat is enabled' do
+    before do
+      SiteSetting.chat_enabled = true
+    end
+
+    it 'starts the mailer' do
+      DiscourseChat::ChatMailer.expects(:send_unread_mentions_summary)
+
+      Jobs.enqueue(:email_chat_notifications)
+    end
+  end
+
+  context 'chat is not enabled' do
+    it 'does nothing' do
+      DiscourseChat::ChatMailer.expects(:send_unread_mentions_summary).never
+
+      Jobs.enqueue(:email_chat_notifications)
+    end
+  end
+end


### PR DESCRIPTION
This is currently throwing exceptions:

```
Job exception: undefined method `send_unread_mentions_summary' for DiscourseChat::ChatMailer:Class

/var/www/discourse/plugins/discourse-chat/app/jobs/scheduled/email_chat_notifications.rb:10:in `execute'
/var/www/discourse/app/jobs/base.rb:232:in `block (2 levels) in perform'
rails_multisite-4.0.1/lib/rails_multisite/connection_management.rb:284:in `with_connection'
rails_multisite-4.0.1/lib/rails_multisite/connection_management.rb:77:in `with_connection'
/var/www/discourse/app/jobs/base.rb:221:in `block in perform'
/var/www/discourse/app/jobs/base.rb:217:in `each'
/var/www/discourse/app/jobs/base.rb:217:in `perform'
/var/www/discourse/app/jobs/base.rb:279:in `perform'
mini_scheduler-0.13.0/lib/mini_scheduler/manager.rb:93:in `process_queue'
mini_scheduler-0.13.0/lib/mini_scheduler/manager.rb:37:in `block (2 levels) in initialize'
```
