### PR TITLE
PERF: Update all decorators to use decorateChatMessage api

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -7,10 +7,8 @@ import discourseComputed, {
   observes,
 } from "discourse-common/utils/decorators";
 import discourseDebounce from "discourse-common/lib/debounce";
-import DiscourseURL from "discourse/lib/url";
 import EmberObject, { action } from "@ember/object";
 import I18n from "I18n";
-import loadScript from "discourse/lib/load-script";
 import userPresent from "discourse/lib/user-presence";
 import { A } from "@ember/array";
 import { ajax } from "discourse/lib/ajax";
@@ -20,12 +18,7 @@ import { cancel, later, next, schedule } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 import { Promise } from "rsvp";
 import { resetIdle } from "discourse/lib/desktop-notifications";
-import { resolveAllShortUrls } from "pretty-text/upload-short-url";
-import { samePrefix } from "discourse-common/lib/get-url";
-import { spinnerHTML } from "discourse/helpers/loading-spinner";
-import { decorateGithubOneboxBody } from "discourse/initializers/onebox-decorators";
-import highlightSyntax from "discourse/lib/highlight-syntax";
-import { applyLocalDates } from "discourse/lib/local-dates";
+
 import { defaultHomepage } from "discourse/lib/utilities";
 
 const MAX_RECENT_MSGS = 100;
@@ -182,7 +175,6 @@ export default Component.extend({
             return;
           }
           this.setMessageProps(messages);
-          this.decorateMessages();
         })
         .catch((err) => {
           throw err;
@@ -254,7 +246,6 @@ export default Component.extend({
             position: loadingPast ? "top" : "bottom",
           };
           this.scrollToMessage(messageId, scrollToMessageArgs);
-          this.decorateMessages();
         }
         this.setCanLoadMoreDetails(messages.resultSetMeta);
       })
@@ -571,18 +562,6 @@ export default Component.extend({
     }
   },
 
-  @action
-  @afterRender
-  decorateMessages() {
-    resolveAllShortUrls(ajax, this.siteSettings, this.element);
-    this.forceLinksToOpenNewTab();
-    lightbox(this.element.querySelectorAll("img:not(.emoji, .avatar)"));
-    this._scrollGithubOneboxes();
-    this._pluginsDecorators();
-    this._highlightCode();
-    this._renderChatTranscriptDates();
-  },
-
   @observes("floatHidden")
   onFloatHiddenChange() {
     if (!this.floatHidden) {
@@ -629,7 +608,6 @@ export default Component.extend({
         this.handleFlaggedMessage(data);
         break;
     }
-    this.decorateMessages();
   },
 
   handleSentMessage(data) {
@@ -1040,7 +1018,6 @@ export default Component.extend({
       data,
     })
       .then(() => {
-        this._resetHighlightForMessage(chatMessage.id);
         this._resetAfterSend();
       })
       .catch(popupAjaxError)
@@ -1277,27 +1254,6 @@ export default Component.extend({
     evt.preventDefault();
   },
 
-  @bind
-  forceLinksToOpenNewTab() {
-    if (this._selfDeleted) {
-      return;
-    }
-
-    const links = this.element.querySelectorAll(
-      ".chat-message-text a:not([target='_blank'])"
-    );
-    for (let linkIndex = 0; linkIndex < links.length; linkIndex++) {
-      const link = links[linkIndex];
-      if (
-        this.currentUser.chat_isolated ||
-        !DiscourseURL.isInternal(link.href) ||
-        !samePrefix(link.href)
-      ) {
-        link.setAttribute("target", "_blank");
-      }
-    }
-  },
-
   focusComposer() {
     if (
       this._selfDeleted ||
@@ -1310,113 +1266,6 @@ export default Component.extend({
     schedule("afterRender", () => {
       document.querySelector(".chat-composer-input")?.focus();
     });
-  },
-
-  _pluginsDecorators() {
-    applyLocalDates(
-      this.element.querySelectorAll(".discourse-local-date"),
-      this.siteSettings
-    );
-
-    if (this.siteSettings.spoiler_enabled) {
-      const applySpoiler = requirejs(
-        "discourse/plugins/discourse-spoiler-alert/lib/apply-spoiler"
-      ).default;
-      this.element.querySelectorAll(".spoiler").forEach((spoiler) => {
-        spoiler.classList.remove("spoiler");
-        spoiler.classList.add("spoiled");
-        applySpoiler(spoiler);
-      });
-    }
-
-    this.element
-      .querySelectorAll(".lazyYT:not(.lazyYT-video-loaded)")
-      .forEach((iframe) => {
-        $(iframe).lazyYT();
-      });
-
-    decorateGithubOneboxBody(this.element);
-  },
-
-  _getScrollParent(node, maxParentSelector) {
-    if (node === null || node.classList.contains(maxParentSelector)) {
-      return null;
-    }
-
-    if (node.scrollHeight > node.clientHeight) {
-      return node;
-    } else {
-      return this._getScrollParent(node.parentNode, maxParentSelector);
-    }
-  },
-
-  _scrollGithubOneboxes() {
-    this.element
-      .querySelectorAll(".onebox.githubblob li.selected")
-      .forEach((line) => {
-        const scrollingElement = this._getScrollParent(line, "onebox");
-
-        // most likely a very small file which doesn’t need scrolling
-        if (!scrollingElement) {
-          return;
-        }
-
-        const scrollBarWidth =
-          scrollingElement.offsetHeight - scrollingElement.clientHeight;
-
-        scrollingElement.scroll({
-          top:
-            line.offsetTop +
-            scrollBarWidth -
-            scrollingElement.offsetHeight / 2 +
-            line.offsetHeight / 2,
-        });
-      });
-  },
-
-  _resetHighlightForMessage(chatMessageId) {
-    document
-      .querySelector(
-        `.chat-message-container[data-id='${chatMessageId}'] .chat-message-text`
-      )
-      ?.classList.remove("hljs-complete");
-  },
-
-  _highlightCode() {
-    document.querySelectorAll(".chat-message-text").forEach((chatMessageEl) => {
-      // no need to do this for every single message every time a message changes
-      if (!chatMessageEl.classList.contains("hljs-complete")) {
-        highlightSyntax(chatMessageEl, this.siteSettings, this.session);
-        chatMessageEl.classList.add("hljs-complete");
-      }
-    });
-  },
-
-  _renderChatTranscriptDates() {
-    document
-      .querySelectorAll(".discourse-chat-transcript")
-      .forEach((transcriptEl) => {
-        const dateTimeRaw = transcriptEl.dataset["datetime"];
-        const dateTimeLinkEl = transcriptEl.querySelector(
-          ".chat-transcript-datetime a"
-        );
-
-        // same as highlight, no need to do this for every single message every time
-        // any message changes
-        if (dateTimeLinkEl.innerText !== "") {
-          return;
-        }
-
-        if (this.currentUserTimezone) {
-          dateTimeLinkEl.innerText = moment
-            .tz(dateTimeRaw, this.currentUserTimezone)
-            .format(I18n.t("dates.long_no_year"));
-        } else {
-          dateTimeLinkEl.innerText = moment(dateTimeRaw).format(
-            I18n.t("dates.long_no_year")
-          );
-        }
-      });
   },
 
   @afterRender
@@ -1435,23 +1284,3 @@ export default Component.extend({
     });
   },
 });
-
-function lightbox(images) {
-  loadScript("/javascripts/jquery.magnific-popup.min.js").then(function () {
-    $(images).magnificPopup({
-      type: "image",
-      closeOnContentClick: false,
-      mainClass: "mfp-zoom-in",
-      tClose: I18n.t("lightbox.close"),
-      tLoading: spinnerHTML,
-      image: {
-        verticalFit: true,
-      },
-      callbacks: {
-        elementParse: (item) => {
-          item.src = item.el[0].src;
-        },
-      },
-    });
-  });
-}

--- a/assets/javascripts/discourse/components/chat-message.js
+++ b/assets/javascripts/discourse/components/chat-message.js
@@ -752,7 +752,6 @@ export default Component.extend({
   @action
   expand() {
     this.message.set("expanded", true);
-    this.afterExpand();
   },
 
   @action

--- a/assets/javascripts/discourse/initializers/chat-decorators.js
+++ b/assets/javascripts/discourse/initializers/chat-decorators.js
@@ -1,0 +1,154 @@
+import { decorateGithubOneboxBody } from "discourse/initializers/onebox-decorators";
+import { withPluginApi } from "discourse/lib/plugin-api";
+import highlightSyntax from "discourse/lib/highlight-syntax";
+import I18n from "I18n";
+import DiscourseURL from "discourse/lib/url";
+import { samePrefix } from "discourse-common/lib/get-url";
+import loadScript from "discourse/lib/load-script";
+import { spinnerHTML } from "discourse/helpers/loading-spinner";
+
+export default {
+  name: "chat-decorators",
+
+  initializeWithPluginApi(api, container) {
+    api.decorateChatMessage((element) => decorateGithubOneboxBody(element), {
+      id: "onebox-github-body",
+    });
+
+    api.decorateChatMessage(
+      (element) => {
+        element
+          .querySelectorAll(".onebox.githubblob li.selected")
+          .forEach((line) => {
+            const scrollingElement = this._getScrollParent(line, "onebox");
+
+            // most likely a very small file which doesn’t need scrolling
+            if (!scrollingElement) {
+              return;
+            }
+
+            const scrollBarWidth =
+              scrollingElement.offsetHeight - scrollingElement.clientHeight;
+
+            scrollingElement.scroll({
+              top:
+                line.offsetTop +
+                scrollBarWidth -
+                scrollingElement.offsetHeight / 2 +
+                line.offsetHeight / 2,
+            });
+          });
+      },
+      {
+        id: "onebox-github-scrolling",
+      }
+    );
+
+    api.decorateChatMessage(
+      (element) =>
+        highlightSyntax(
+          element,
+          container.lookup("site-settings:main"),
+          container.lookup("session:main")
+        ),
+      { id: "highlightSyntax" }
+    );
+
+    api.decorateChatMessage(this.renderChatTranscriptDates, {
+      id: "transcriptDates",
+    });
+
+    api.decorateChatMessage(this.forceLinksToOpenNewTab, {
+      id: "linksNewTab",
+    });
+
+    api.decorateChatMessage(
+      (element) =>
+        this.lightbox(element.querySelectorAll("img:not(.emoji, .avatar)")),
+      {
+        id: "lightbox",
+      }
+    );
+  },
+
+  _getScrollParent(node, maxParentSelector) {
+    if (node === null || node.classList.contains(maxParentSelector)) {
+      return null;
+    }
+
+    if (node.scrollHeight > node.clientHeight) {
+      return node;
+    } else {
+      return this._getScrollParent(node.parentNode, maxParentSelector);
+    }
+  },
+
+  renderChatTranscriptDates(element) {
+    element
+      .querySelectorAll(".discourse-chat-transcript")
+      .forEach((transcriptEl) => {
+        const dateTimeRaw = transcriptEl.dataset["datetime"];
+        const dateTimeLinkEl = transcriptEl.querySelector(
+          ".chat-transcript-datetime a"
+        );
+
+        // same as highlight, no need to do this for every single message every time
+        // any message changes
+        if (dateTimeLinkEl.innerText !== "") {
+          return;
+        }
+
+        if (this.currentUserTimezone) {
+          dateTimeLinkEl.innerText = moment
+            .tz(dateTimeRaw, this.currentUserTimezone)
+            .format(I18n.t("dates.long_no_year"));
+        } else {
+          dateTimeLinkEl.innerText = moment(dateTimeRaw).format(
+            I18n.t("dates.long_no_year")
+          );
+        }
+      });
+  },
+
+  forceLinksToOpenNewTab(element) {
+    const links = element.querySelectorAll(
+      ".chat-message-text a:not([target='_blank'])"
+    );
+    for (let linkIndex = 0; linkIndex < links.length; linkIndex++) {
+      const link = links[linkIndex];
+      if (
+        this.currentUser.chat_isolated ||
+        !DiscourseURL.isInternal(link.href) ||
+        !samePrefix(link.href)
+      ) {
+        link.setAttribute("target", "_blank");
+      }
+    }
+  },
+
+  lightbox(images) {
+    loadScript("/javascripts/jquery.magnific-popup.min.js").then(function () {
+      $(images).magnificPopup({
+        type: "image",
+        closeOnContentClick: false,
+        mainClass: "mfp-zoom-in",
+        tClose: I18n.t("lightbox.close"),
+        tLoading: spinnerHTML,
+        image: {
+          verticalFit: true,
+        },
+        callbacks: {
+          elementParse: (item) => {
+            item.src = item.el[0].src;
+          },
+        },
+      });
+    });
+  },
+
+  initialize(container) {
+    withPluginApi("0.8.42", (api) =>
+      this.initializeWithPluginApi(api, container)
+    );
+  },
+};

--- a/assets/javascripts/discourse/initializers/chat-plugin-decorators.js
+++ b/assets/javascripts/discourse/initializers/chat-plugin-decorators.js
@@ -1,0 +1,58 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { applyLocalDates } from "discourse/lib/local-dates";
+
+export default {
+  name: "chat-plugin-decorators",
+
+  initializeWithPluginApi(api, siteSettings) {
+    api.decorateChatMessage(
+      (element) => {
+        applyLocalDates(
+          element.querySelectorAll(".discourse-local-date"),
+          siteSettings
+        );
+      },
+      {
+        id: "local-dates",
+      }
+    );
+
+    if (siteSettings.spoiler_enabled) {
+      const applySpoiler = requirejs(
+        "discourse/plugins/discourse-spoiler-alert/lib/apply-spoiler"
+      ).default;
+      api.decorateChatMessage(
+        (element) => {
+          element.querySelectorAll(".spoiler").forEach((spoiler) => {
+            spoiler.classList.remove("spoiler");
+            spoiler.classList.add("spoiled");
+            applySpoiler(spoiler);
+          });
+        },
+        {
+          id: "spoiler",
+        }
+      );
+    }
+
+    api.decorateChatMessage(
+      (element) => {
+        element
+          .querySelectorAll(".lazyYT:not(.lazyYT-video-loaded)")
+          .forEach((iframe) => {
+            $(iframe).lazyYT();
+          });
+      },
+      {
+        id: "lazy-yt",
+      }
+    );
+  },
+
+  initialize(container) {
+    const siteSettings = container.lookup("site-settings:main");
+    withPluginApi("0.8.42", (api) =>
+      this.initializeWithPluginApi(api, siteSettings)
+    );
+  },
+};

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -52,7 +52,6 @@
         setReplyTo=(action "setReplyTo")
         replyMessageClicked=(action "replyMessageClicked")
         editButtonClicked=(action "editButtonClicked")
-        afterExpand=(action "decorateMessages")
         selectingMessages=selectingMessages
         onStartSelectingMessages=onStartSelectingMessages
         onSelectMessage=onSelectMessage

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -747,7 +747,7 @@ Widget.triangulate(arg: "test")
     );
     assert.ok(
       exists(
-        ".chat-message-container[data-id='202'] .chat-message-text.hljs-complete code.lang-ruby.hljs"
+        ".chat-message-container[data-id='202'] .chat-message-text code.lang-ruby.hljs"
       ),
       "chat message code block has been highlighted as ruby code"
     );

--- a/test/javascripts/components/chat-message-test.js
+++ b/test/javascripts/components/chat-message-test.js
@@ -22,7 +22,6 @@ discourseModule("Discourse Chat | Component | chat-message", function (hooks) {
       setReplyTo=setReplyTo
       replyMessageClicked=replyMessageClicked
       editButtonClicked=editButtonClicked
-      afterExpand=decorateMessages
       selectingMessages=selectingMessages
       onStartSelectingMessages=onStartSelectingMessages
       onSelectMessage=onSelectMessage


### PR DESCRIPTION
Some transformations were being implemented in the `chat-live-pane` component, rather than using the `chat-message` decoration system. This means that they were often being applied multiple times to the same message.

This commit refactors all the decorators from chat-live-pane so that they use the standard API. This means they can take advantage of the perf improvements from 43ce6e0c65


