### PR TITLE
FIX: better handling of non existing messages

### DIFF
--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -154,8 +154,9 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
       raise Discourse::InvalidParameters.new(:message_id)
     end
 
-    chat_message = ChatMessage.find_by(chat_channel_id: @chat_channel.id, id: params[:message_id])
-    raise Discourse::NotFound unless chat_message
+    unless ChatMessage.exists?(chat_channel_id: @chat_channel.id, id: params[:message_id])
+      raise Discourse::NotFound
+    end
 
     membership.update!(last_read_message_id: params[:message_id])
 

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -149,6 +149,14 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
 
     membership = UserChatChannelMembership.find_by(user: current_user, chat_channel: @chat_channel, following: true)
     raise Discourse::NotFound if membership.nil?
+
+    if membership.last_read_message_id && params[:message_id].to_i < membership.last_read_message_id
+      raise Discourse::InvalidParameters.new(:message_id)
+    end
+
+    chat_message = ChatMessage.find_by(chat_channel_id: @chat_channel.id, id: params[:message_id])
+    raise Discourse::NotFound unless chat_message
+
     membership.update!(last_read_message_id: params[:message_id])
 
     Notification

--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -9,13 +9,14 @@ class ChatMessage < ActiveRecord::Base
   belongs_to :chat_channel
   belongs_to :user
   belongs_to :in_reply_to, class_name: "ChatMessage"
-  has_many :revisions, class_name: "ChatMessageRevision"
-  has_many :reactions, class_name: "ChatMessageReaction"
-  has_many :bookmarks, as: :bookmarkable
-  has_many :chat_uploads
+  has_many :replies, class_name: "ChatMessage", foreign_key: "in_reply_to_id", dependent: :nullify
+  has_many :revisions, class_name: "ChatMessageRevision", dependent: :destroy
+  has_many :reactions, class_name: "ChatMessageReaction", dependent: :destroy
+  has_many :bookmarks, as: :bookmarkable, dependent: :destroy
+  has_many :chat_uploads, dependent: :destroy
   has_many :uploads, through: :chat_uploads
-  has_one :chat_webhook_event
-  has_one :chat_mention
+  has_one :chat_webhook_event, dependent: :destroy
+  has_one :chat_mention, dependent: :destroy
 
   scope :in_public_channel, -> {
     joins(:chat_channel)

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -789,12 +789,14 @@ export default Component.extend({
   },
 
   @bind
-  _updateLastReadMessage() {
+  _updateLastReadMessage(wait = READ_INTERVAL) {
+    cancel(this._updateReadTimer);
+
     if (this._selfDeleted) {
       return;
     }
 
-    return later(
+    this._updateReadTimer = later(
       this,
       () => {
         if (this._selfDeleted) {
@@ -828,9 +830,9 @@ export default Component.extend({
           });
         }
 
-        this._updateReadTimer = this._updateLastReadMessage();
+        this._updateLastReadMessage();
       },
-      READ_INTERVAL
+      wait
     );
   },
 
@@ -840,13 +842,8 @@ export default Component.extend({
 
   _startLastReadRunner() {
     if (!isTesting()) {
-      cancel(this._updateReadTimer);
       next(this, () => {
-        this._updateLastReadMessage();
-        this._updateReadTimer = later(
-          this._updateLastReadMessage,
-          READ_INTERVAL
-        );
+        this._updateLastReadMessage(0);
       });
     }
   },

--- a/db/post_migrate/20220526135414_remove_corrupted_last_read_message_id.rb
+++ b/db/post_migrate/20220526135414_remove_corrupted_last_read_message_id.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class RemoveCorruptedLastReadMessageId < ActiveRecord::Migration[7.0]
+  def change
+    # Delete memberships for deleted channels
+    execute <<~SQL
+      DELETE FROM user_chat_channel_memberships uccm
+      WHERE NOT EXISTS (
+        SELECT FROM chat_channels cc
+        WHERE cc.id = uccm.chat_channel_id
+      );
+    SQL
+
+    # Delete messages for deleted channels
+    execute <<~SQL
+      DELETE FROM chat_messages cm
+      WHERE NOT EXISTS (
+        SELECT FROM chat_channels cc
+        WHERE cc.id = cm.chat_channel_id
+      );
+    SQL
+
+    # Reset highest_channel_message_id if the message cannot be found in the channel
+    execute <<~SQL
+      WITH highest_channel_message_id AS (
+        SELECT chat_channel_id, max(chat_messages.id) as highest_id
+        FROM chat_messages
+        GROUP BY chat_channel_id
+      )
+      UPDATE user_chat_channel_memberships uccm
+      SET last_read_message_id = highest_channel_message_id.highest_id
+      FROM highest_channel_message_id
+      WHERE highest_channel_message_id.chat_channel_id = uccm.chat_channel_id
+      AND uccm.last_read_message_id IS NOT NULL
+      AND uccm.last_read_message_id NOT IN (
+        SELECT id FROM chat_messages WHERE chat_messages.chat_channel_id = uccm.chat_channel_id
+      )
+    SQL
+  end
+end

--- a/db/post_migrate/20220526135414_remove_corrupted_last_read_message_id.rb
+++ b/db/post_migrate/20220526135414_remove_corrupted_last_read_message_id.rb
@@ -105,9 +105,5 @@ class RemoveCorruptedLastReadMessageId < ActiveRecord::Migration[7.0]
         WHERE cm.id = chat_uploads.chat_message_id
       );
     SQL
-
-    # usage has been dropped in https://github.com/discourse/discourse-chat/commit/1c110b71b28411dc7ac3ab9e3950e0bbf38d7970
-    # but apparently table never got dropped
-    drop_table :user_chat_channel_last_reads
   end
 end

--- a/db/post_migrate/20220531105951_drop_user_chat_channel_last_reads.rb
+++ b/db/post_migrate/20220531105951_drop_user_chat_channel_last_reads.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
+require 'migration/table_dropper'
+
+# usage has been dropped in https://github.com/discourse/discourse-chat/commit/1c110b71b28411dc7ac3ab9e3950e0bbf38d7970
+# but table never got dropped
 class DropUserChatChannelLastReads < ActiveRecord::Migration[7.0]
+  DROPPED_TABLES ||= %i{ user_chat_channel_last_reads }
+
   def up
-    # usage has been dropped in https://github.com/discourse/discourse-chat/commit/1c110b71b28411dc7ac3ab9e3950e0bbf38d7970
-    # but apparently table never got dropped
-    drop_table :user_chat_channel_last_reads
+    DROPPED_TABLES.each do |table|
+      Migration::TableDropper.execute_drop(table)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/post_migrate/20220531105951_drop_user_chat_channel_last_reads.rb
+++ b/db/post_migrate/20220531105951_drop_user_chat_channel_last_reads.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DropUserChatChannelLastReads < ActiveRecord::Migration[7.0]
   def up
     # usage has been dropped in https://github.com/discourse/discourse-chat/commit/1c110b71b28411dc7ac3ab9e3950e0bbf38d7970

--- a/db/post_migrate/20220531105951_drop_user_chat_channel_last_reads.rb
+++ b/db/post_migrate/20220531105951_drop_user_chat_channel_last_reads.rb
@@ -1,0 +1,7 @@
+class DropUserChatChannelLastReads < ActiveRecord::Migration[7.0]
+  def up
+    # usage has been dropped in https://github.com/discourse/discourse-chat/commit/1c110b71b28411dc7ac3ab9e3950e0bbf38d7970
+    # but apparently table never got dropped
+    drop_table :user_chat_channel_last_reads
+  end
+end

--- a/spec/jobs/delete_old_chat_messages_spec.rb
+++ b/spec/jobs/delete_old_chat_messages_spec.rb
@@ -58,6 +58,14 @@ describe Jobs::DeleteOldChatMessages do
       SiteSetting.chat_channel_retention_days = 800
       expect { described_class.new.execute }.to change { ChatMessage.in_public_channel.count }.by(0)
     end
+
+    it "resets last_read_message_id from memberships" do
+      SiteSetting.chat_channel_retention_days = 20
+      membership = UserChatChannelMembership.create!(user: Fabricate(:user), chat_channel: public_channel, last_read_message_id: public_days_old_30.id, following: true, desktop_notification_level: 2, mobile_notification_level: 2)
+      described_class.new.execute
+
+      expect(membership.reload.last_read_message_id).to be_nil
+    end
   end
 
   describe "dm channels" do
@@ -73,6 +81,14 @@ describe Jobs::DeleteOldChatMessages do
     it "does nothing when no messages fall in the time range" do
       SiteSetting.chat_dm_retention_days = 800
       expect { described_class.new.execute }.to change { ChatMessage.in_dm_channel.count }.by(0)
+    end
+
+    it "resets last_read_message_id from memberships" do
+      SiteSetting.chat_dm_retention_days = 20
+      membership = UserChatChannelMembership.create!(user: Fabricate(:user), chat_channel: dm_channel, last_read_message_id: dm_days_old_30.id, following: true, desktop_notification_level: 2, mobile_notification_level: 2)
+      described_class.new.execute
+
+      expect(membership.reload.last_read_message_id).to be_nil
     end
   end
 end

--- a/spec/migrations/remove_corrupted_last_read_message_id_spec.rb
+++ b/spec/migrations/remove_corrupted_last_read_message_id_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'RemoveCorruptedLastReadMessageIdMigration' do
+  def run_migration
+    ActiveRecord::Migrator.new(
+      :up,
+      [
+        ActiveRecord::MigrationProxy.new('RemoveCorruptedLastReadMessageId', nil, 'plugins/discourse-chat/db/post_migrate/20220526135414_remove_corrupted_last_read_message_id.rb', '')
+      ],
+      ActiveRecord::SchemaMigration,
+      nil
+    ).run
+  end
+
+  around do |example|
+    ActiveRecord::Migration.suppress_messages do
+      example.run
+    end
+  end
+
+  context 'channel of a membership doesn’t exist' do
+    fab!(:channel_1) { Fabricate(:chat_channel) }
+    fab!(:channel_2) { Fabricate(:chat_channel) }
+    fab!(:uccm_1) { Fabricate(:user_chat_channel_membership, chat_channel: channel_1) }
+    fab!(:uccm_2) { Fabricate(:user_chat_channel_membership, chat_channel: channel_2) }
+
+    before do
+      channel_2.destroy!
+    end
+
+    it 'deletes the membership' do
+      run_migration
+
+      expect(UserChatChannelMembership.exists?(id: uccm_1.id)).to eq(true)
+      expect(ChatChannel.exists?(id: channel_1.id)).to eq(true)
+      expect { channel_2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { uccm_2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context 'message’s channel doesn’t exist' do
+    fab!(:channel_1) { Fabricate(:chat_channel) }
+    fab!(:channel_2) { Fabricate(:chat_channel) }
+    fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }
+    fab!(:message_2) { Fabricate(:chat_message, chat_channel: channel_2) }
+
+    before do
+      channel_2.destroy!
+    end
+
+    it 'deletes the message' do
+      run_migration
+
+      expect(ChatMessage.exists?(id: message_1.id)).to eq(true)
+      expect(ChatChannel.exists?(id: channel_1.id)).to eq(true)
+      expect { channel_2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { message_2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  context 'last_read_message_id’s message can’t be found' do
+    fab!(:channel_1) { Fabricate(:chat_channel) }
+    fab!(:channel_2) { Fabricate(:chat_channel) }
+    fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }
+    fab!(:message_2) { Fabricate(:chat_message, chat_channel: channel_2) }
+    fab!(:message_3) { Fabricate(:chat_message, chat_channel: channel_1) }
+    fab!(:uccm_1) { Fabricate(:user_chat_channel_membership, chat_channel: channel_1, last_read_message_id: message_2.id) }
+    fab!(:uccm_2) { Fabricate(:user_chat_channel_membership, chat_channel: channel_2, last_read_message_id: message_2.id) }
+
+    it 'resets last_read_message_id to highest message id' do
+      run_migration
+
+      expect(uccm_1.last_read_message_id).to eq(message_3.id)
+      expect(uccm_2.last_read_message_id).to eq(message_2.id)
+    end
+  end
+end

--- a/spec/migrations/remove_corrupted_last_read_message_id_spec.rb
+++ b/spec/migrations/remove_corrupted_last_read_message_id_spec.rb
@@ -136,7 +136,7 @@ describe 'RemoveCorruptedLastReadMessageIdMigration' do
       let!(:bookmark_1) { Fabricate(:bookmark, bookmarkable: message_1) }
       let!(:bookmark_2) { Fabricate(:bookmark, bookmarkable: message_2) }
 
-      it 'destroys ChatMessage of this message' do
+      it 'destroys ChatMessage bookmarks of this message' do
         message_1.delete
 
         run_migration

--- a/spec/migrations/remove_corrupted_last_read_message_id_spec.rb
+++ b/spec/migrations/remove_corrupted_last_read_message_id_spec.rb
@@ -76,4 +76,122 @@ describe 'RemoveCorruptedLastReadMessageIdMigration' do
       expect(uccm_2.last_read_message_id).to eq(message_2.id)
     end
   end
+
+  context 'message doesn’t exist' do
+    context 'in reply to' do
+      fab!(:message_1) { Fabricate(:chat_message) }
+      fab!(:message_2) { Fabricate(:chat_message, in_reply_to_id: message_1.id) }
+      fab!(:message_3) { Fabricate(:chat_message, in_reply_to_id: message_2.id) }
+
+      it 'nullifies relationship key to this message' do
+        expect(message_2.in_reply_to_id).to eq(message_1.id)
+
+        message_1.delete
+        run_migration
+
+        expect(message_3.reload.in_reply_to_id).to eq(message_2.id)
+        expect(message_2.reload.in_reply_to_id).to be_nil
+      end
+    end
+
+    context 'revisions' do
+      fab!(:message_1) { Fabricate(:chat_message) }
+      fab!(:message_2) { Fabricate(:chat_message) }
+      fab!(:revision_1) { Fabricate(:chat_message_revision, chat_message: message_1) }
+      fab!(:revision_2) { Fabricate(:chat_message_revision, chat_message: message_2) }
+
+      it 'destroys revisions of this message' do
+        message_1.delete
+
+        run_migration
+
+        expect { revision_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { revision_2.reload }.not_to raise_error
+      end
+    end
+
+    context 'reactions' do
+      fab!(:message_1) { Fabricate(:chat_message) }
+      fab!(:message_2) { Fabricate(:chat_message) }
+      fab!(:reaction_1) { Fabricate(:chat_message_reaction, chat_message: message_1) }
+      fab!(:reaction_2) { Fabricate(:chat_message_reaction, chat_message: message_2) }
+
+      it 'destroys reactions of this message' do
+        message_1.delete
+
+        run_migration
+
+        expect { reaction_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { reaction_2.reload }.not_to raise_error
+      end
+    end
+
+    context 'bookmarks' do
+      before do
+        Bookmark.register_bookmarkable(ChatMessageBookmarkable)
+      end
+
+      fab!(:message_1) { Fabricate(:chat_message) }
+      fab!(:message_2) { Fabricate(:chat_message) }
+      let!(:bookmark_1) { Fabricate(:bookmark, bookmarkable: message_1) }
+      let!(:bookmark_2) { Fabricate(:bookmark, bookmarkable: message_2) }
+
+      it 'destroys ChatMessage of this message' do
+        message_1.delete
+
+        run_migration
+
+        expect { bookmark_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { bookmark_2.reload }.not_to raise_error
+      end
+    end
+
+    context 'mentions' do
+      fab!(:message_1) { Fabricate(:chat_message) }
+      fab!(:message_2) { Fabricate(:chat_message) }
+      fab!(:mention_1) { Fabricate(:chat_mention, chat_message: message_1) }
+      fab!(:mention_2) { Fabricate(:chat_mention, chat_message: message_2) }
+
+      it 'destroys mentions of this message' do
+        message_1.delete
+
+        run_migration
+
+        expect { mention_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { mention_2.reload }.not_to raise_error
+      end
+    end
+
+    context 'chat_webhook_events' do
+      fab!(:message_1) { Fabricate(:chat_message) }
+      fab!(:message_2) { Fabricate(:chat_message) }
+      fab!(:webhook_1) { Fabricate(:chat_webhook_event, chat_message: message_1) }
+      fab!(:webhook_2) { Fabricate(:chat_webhook_event, chat_message: message_2) }
+
+      it 'destroys chat_webhook_events of this message' do
+        message_1.delete
+
+        run_migration
+
+        expect { webhook_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { webhook_2.reload }.not_to raise_error
+      end
+    end
+
+    context 'chat_uploads' do
+      fab!(:message_1) { Fabricate(:chat_message) }
+      fab!(:message_2) { Fabricate(:chat_message) }
+      fab!(:chat_upload_1) { Fabricate(:chat_upload, chat_message: message_1) }
+      fab!(:chat_upload_2) { Fabricate(:chat_upload, chat_message: message_2) }
+
+      it 'destroys uploads and chat_uploads of this message' do
+        message_1.delete
+
+        run_migration
+
+        expect { chat_upload_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { chat_upload_2.reload }.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -700,6 +700,27 @@ RSpec.describe DiscourseChat::ChatController do
         @user_membership = Fabricate(:user_chat_channel_membership, chat_channel: chat_channel, user: user)
       end
 
+      context 'message_id param doesn’t link to a message of the channel' do
+        it 'raises a not found' do
+          put "/chat/#{chat_channel.id}/read/-999.json"
+
+          expect(response.status).to eq(404)
+        end
+      end
+
+      context 'message_id param is inferior to existing last read' do
+        before do
+          @user_membership.update!(last_read_message_id: @message_2.id)
+        end
+
+        it 'raises an invalid request' do
+          put "/chat/#{chat_channel.id}/read/#{@message_1.id}.json"
+
+          expect(response.status).to eq(400)
+          expect(response.parsed_body['errors'][0]).to match(/message_id/)
+        end
+      end
+
       it 'updates timing records' do
         expect {
           put "/chat/#{chat_channel.id}/read/#{@message_1.id}.json"


### PR DESCRIPTION
Before this fix, two conditions (AFAIK) could lead to data corruption:


- delete_old_chat_message job which could delete messages (and not just trash). There was no dependent behavior on related models

- some endpoint would not check if a message related to an impacted channel, eg:

```
PUT /chat/42/read/666.json
```

Where 666 is a message id NOT belonging to the channel with id 42. Moreover, there was no check server side before updating the `last_read_message_id` of a membership that the provided `message_id` was belonging to this channel. As a result we would sometimes store an incorrect `last_read_message_id` which is then used for messages lookup and ends up loading the messages of another channel. We attempt to reduce the chances for the frontend to make an incorrect request.

Note that this issue has been here for quite a long time but has been made more visible by https://github.com/discourse/discourse-chat/commit/17f1e4213a58670265d3ccba959082a7b0442d7a#diff-8903d1d4f083bdb0595643bf27bd4a5d3dfafd49a912bb061c42135971e6aa8dR172 as it's making a bigger use of `last_read_message_id` than before.

---

This commit both attempts to avoid future corrupting and also fixes current corrupted data. This commit also drops a table `user_chat_channel_last_reads` which appears to not be used anymore but is holding references to messages, so better drop it.

