### PR TITLE
FIX: Serialize dates using ISO8601

### DIFF
--- a/lib/onebox/templates/discourse_chat.mustache
+++ b/lib/onebox/templates/discourse_chat.mustache
@@ -33,7 +33,7 @@
 {{/cooked}}
 
 {{#cooked}}
-<div class="discourse-chat-transcript" data-message-id="{{message_id}}" data-username="{{username}}" data-datetime="{{created_at}}" data-channel-name="{{channel_name}}" data-channel-id="{{channel_id}}">
+<div class="discourse-chat-transcript" data-message-id="{{message_id}}" data-username="{{username}}" data-datetime="{{created_at_str}}" data-channel-name="{{channel_name}}" data-channel-id="{{channel_id}}">
   <div class="chat-transcript-user">
     <div class="chat-transcript-user-avatar">
       <a class="trigger-user-card" data-user-card="{{username}}" aria-hidden="true" tabindex="-1">

--- a/plugin.rb
+++ b/plugin.rb
@@ -263,6 +263,7 @@ after_initialize do
       args[:avatar_url] = message.user.avatar_template_url.gsub('{size}', '20')
       args[:cooked] = message.cooked
       args[:created_at] = message.created_at
+      args[:created_at_str] = message.created_at.iso8601
     end
 
     Mustache.render(DiscourseChat.onebox_template, args)

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -205,7 +205,7 @@ describe 'discourse-chat' do
 
       it "renders messages" do
         expect(Oneboxer.preview("#{chat_url}?messageId=#{chat_message.id}")).to match_html <<~HTML
-          <div class="discourse-chat-transcript" data-message-id="#{chat_message.id}" data-username="#{user.username}" data-datetime="#{chat_message.created_at}" data-channel-name="#{chat_channel.name}" data-channel-id="#{chat_channel.id}">
+          <div class="discourse-chat-transcript" data-message-id="#{chat_message.id}" data-username="#{user.username}" data-datetime="#{chat_message.created_at.iso8601}" data-channel-name="#{chat_channel.name}" data-channel-id="#{chat_channel.id}">
           <div class="chat-transcript-user">
             <div class="chat-transcript-user-avatar">
               <a class="trigger-user-card" data-user-card="#{user.username}" aria-hidden="true" tabindex="-1">


### PR DESCRIPTION
The date was not showed correctly in Safari because it could not
recognize the date format.

<!-- Checklist for UI / stylesheet changes, delete if not applicable -->

- [ ] chat-scoped -- core unaffected

### View mode

- [ ] docked (windowed/drawer)
- [ ] isolated (full-screen)

### Browsers

- [ ] safari
- [ ] chrome
- [ ] firefox

### Device

- [ ] desktop – wide screen
- [ ] mobile – `?mobile_view=1`

### Ember

- [ ] ember-cli
- [ ] legacy
