### PR TITLE
FIX: Message order consistency

### DIFF
--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -187,8 +187,10 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
       messages = messages.where("id #{condition} ?", message_id.to_i)
     end
 
-    order = direction == FUTURE ? :asc : :desc
-    messages = messages.order(created_at: order).limit(page_size).to_a
+    # NOTE: This order is reversed when we return the ChatView below if the direction
+    # is not FUTURE.
+    order = direction == FUTURE ? "ASC" : "DESC"
+    messages = messages.order("created_at #{order}, id #{order}").limit(page_size).to_a
 
     can_load_more_past = nil
     can_load_more_future = nil

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -188,7 +188,7 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
     end
 
     order = direction == FUTURE ? :asc : :desc
-    messages = messages.order(id: order).limit(page_size).to_a
+    messages = messages.order(created_at: order).limit(page_size).to_a
 
     can_load_more_past = nil
     can_load_more_future = nil

--- a/lib/message_mover.rb
+++ b/lib/message_mover.rb
@@ -57,7 +57,7 @@ class DiscourseChat::MessageMover
   private
 
   def find_messages(message_ids, channel)
-    ChatMessage.where(id: message_ids, chat_channel_id: channel.id).order(created_at: :asc)
+    ChatMessage.where(id: message_ids, chat_channel_id: channel.id).order("created_at ASC, id ASC")
   end
 
   def create_temp_table
@@ -84,17 +84,10 @@ class DiscourseChat::MessageMover
   # We purposefully omit in_reply_to_id when creating the messages in the
   # new channel, because it could be pointing to a message that has not
   # been moved.
-  #
-  # NOTE: The contortions with ROW_NUMBER along with beginning the created_at
-  # time 5 seconds in the future are to ensure that the moved messages are
-  # always added to the end of the messages stream (which is ordered by
-  # created_at in ChatController) and spaced out appropriately for ordering
-  # in 0.5 second increments, so not all the timestamps appear identical in the UI.
   def create_destination_messages_in_channel(destination_channel)
     query_args = {
       message_ids: @ordered_source_message_ids,
-      destination_channel_id: destination_channel.id,
-      future_start: Time.zone.now + 5.seconds
+      destination_channel_id: destination_channel.id
     }
     moved_message_ids = DB.query_single(<<~SQL, query_args)
       INSERT INTO chat_messages(chat_channel_id, user_id, message, cooked, cooked_version, created_at, updated_at)
@@ -103,10 +96,8 @@ class DiscourseChat::MessageMover
              message,
              cooked,
              cooked_version,
-             :future_start::timestamp + (
-                ROW_NUMBER() OVER (ORDER BY chat_messages.created_at) * interval '1 second' / 2
-             ),
-             CURRENT_TIMESTAMP
+             CLOCK_TIMESTAMP(),
+             CLOCK_TIMESTAMP()
       FROM chat_messages
       WHERE id IN (:message_ids)
       RETURNING id

--- a/spec/lib/message_mover_spec.rb
+++ b/spec/lib/message_mover_spec.rb
@@ -81,14 +81,18 @@ describe DiscourseChat::MessageMover do
       )
     end
 
-    it "preserves the order of the messages in the destination channel" do
+    it "preserves the order of the messages in the destination channel with slightly spaced out future created_at dates" do
+      freeze_time
       move!
-      moved_messages = ChatMessage.where(chat_channel: destination_channel).order("created_at ASC").last(3)
+      moved_messages = ChatMessage.where(chat_channel: destination_channel).order(created_at: :asc).last(3)
       expect(moved_messages.map(&:message)).to eq([
         "the first to be moved",
         "message deux @testmovechat",
         "the third message"
       ])
+      expect(moved_messages.first.created_at).to eq_time(Time.zone.now + 5.5.seconds)
+      expect(moved_messages.second.created_at).to eq_time(Time.zone.now + 6.seconds)
+      expect(moved_messages.third.created_at).to eq_time(Time.zone.now + 6.5.seconds)
     end
 
     it "updates references for reactions, uploads, revisions, mentions, etc." do

--- a/spec/lib/message_mover_spec.rb
+++ b/spec/lib/message_mover_spec.rb
@@ -81,18 +81,14 @@ describe DiscourseChat::MessageMover do
       )
     end
 
-    it "preserves the order of the messages in the destination channel with slightly spaced out future created_at dates" do
-      freeze_time
+    it "preserves the order of the messages in the destination channel" do
       move!
-      moved_messages = ChatMessage.where(chat_channel: destination_channel).order(created_at: :asc).last(3)
+      moved_messages = ChatMessage.where(chat_channel: destination_channel).order("created_at ASC, id ASC").last(3)
       expect(moved_messages.map(&:message)).to eq([
         "the first to be moved",
         "message deux @testmovechat",
         "the third message"
       ])
-      expect(moved_messages.first.created_at).to eq_time(Time.zone.now + 5.5.seconds)
-      expect(moved_messages.second.created_at).to eq_time(Time.zone.now + 6.seconds)
-      expect(moved_messages.third.created_at).to eq_time(Time.zone.now + 6.5.seconds)
     end
 
     it "updates references for reactions, uploads, revisions, mentions, etc." do
@@ -103,7 +99,7 @@ describe DiscourseChat::MessageMover do
       webhook_event = Fabricate(:chat_webhook_event, chat_message: message3)
       move!
 
-      moved_messages = ChatMessage.where(chat_channel: destination_channel).order(:created_at).last(3)
+      moved_messages = ChatMessage.where(chat_channel: destination_channel).order("created_at ASC, id ASC").last(3)
       expect(reaction.reload.chat_message_id).to eq(moved_messages.first.id)
       expect(upload.reload.chat_message_id).to eq(moved_messages.first.id)
       expect(mention.reload.chat_message_id).to eq(moved_messages.second.id)

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe DiscourseChat::ChatController do
       expect(response.status).to eq(400)
     end
 
-    it "returns the latest messages" do
+    it "returns the latest messages in created_at order" do
       get "/chat/#{chat_channel.id}/messages.json", params: { page_size: page_size }
       messages = response.parsed_body["chat_messages"]
       expect(messages.count).to eq(page_size)
-      expect(messages.first["id"]).to be < messages.last["id"]
+      expect(messages.first["created_at"].to_time).to be < messages.last["created_at"].to_time
     end
 
     it "returns `can_flag=true` for public channels" do
@@ -136,12 +136,12 @@ RSpec.describe DiscourseChat::ChatController do
     end
 
     describe "scrolling to the past" do
-      it "returns the correct messages" do
+      it "returns the correct messages in created_at order" do
         get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_40.id, direction: described_class::PAST, page_size: page_size }
         messages = response.parsed_body["chat_messages"]
         expect(messages.count).to eq(page_size)
-        expect(messages.first["id"]).to eq(message_10.id)
-        expect(messages.last["id"]).to eq(message_39.id)
+        expect(messages.first["created_at"].to_time).to eq_time(message_10.created_at)
+        expect(messages.last["created_at"].to_time).to eq_time(message_39.created_at)
       end
 
       it "returns 'can_load...' properly when there are more past messages" do
@@ -158,12 +158,12 @@ RSpec.describe DiscourseChat::ChatController do
     end
 
     describe "scrolling to the future" do
-      it "returns the correct messages when there are many after" do
+      it "returns the correct messages in created_at order when there are many after" do
         get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_10.id, direction: described_class::FUTURE, page_size: page_size }
         messages = response.parsed_body["chat_messages"]
         expect(messages.count).to eq(page_size)
-        expect(messages.first["id"]).to eq(message_11.id)
-        expect(messages.last["id"]).to eq(message_40.id)
+        expect(messages.first["created_at"].to_time).to eq_time(message_11.created_at)
+        expect(messages.last["created_at"].to_time).to eq_time(message_40.created_at)
       end
 
       it "return 'can_load..' properly when there are future messages" do

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe DiscourseChat::ChatController do
       expect(response.status).to eq(400)
     end
 
-    it "returns the latest messages in created_at order" do
+    it "returns the latest messages in created_at, id order" do
       get "/chat/#{chat_channel.id}/messages.json", params: { page_size: page_size }
       messages = response.parsed_body["chat_messages"]
       expect(messages.count).to eq(page_size)
@@ -136,7 +136,7 @@ RSpec.describe DiscourseChat::ChatController do
     end
 
     describe "scrolling to the past" do
-      it "returns the correct messages in created_at order" do
+      it "returns the correct messages in created_at, id order" do
         get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_40.id, direction: described_class::PAST, page_size: page_size }
         messages = response.parsed_body["chat_messages"]
         expect(messages.count).to eq(page_size)
@@ -158,7 +158,7 @@ RSpec.describe DiscourseChat::ChatController do
     end
 
     describe "scrolling to the future" do
-      it "returns the correct messages in created_at order when there are many after" do
+      it "returns the correct messages in created_at, id order when there are many after" do
         get "/chat/#{chat_channel.id}/messages.json", params: { message_id: message_10.id, direction: described_class::FUTURE, page_size: page_size }
         messages = response.parsed_body["chat_messages"]
         expect(messages.count).to eq(page_size)


### PR DESCRIPTION
In https://meta.discourse.org/t/moving-chat-messages-to-a-new-channel-jumbled-them-all-up/227301
we were having issues with moved messages between channels
being jumbled up. During investigations it was found that
the ChatController /messages route ordered messages by ID
but everything else, including the message mover, ordered by
created_at.

This commit makes things consistent by changing the /messages
route to also order by created_at, then ID. This should make it so the
order is always consistent in the UI and also for moved messages.