### PR TITLE
UX: chat menu popover close button change icon

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-composer-dropdown.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-composer-dropdown.hbs
@@ -8,7 +8,7 @@
       disabled=isDisabled
       class="chat-composer-dropdown__trigger-btn d-popover-trigger"
       title="chat.composer.toggle_toolbar"
-      icon=(if state.isExpanded "minus" "plus")
+      icon=(if state.isExpanded "times" "plus")
     }}
     <ul class="chat-composer-dropdown__list">
       {{#each buttons as |button|}}


### PR DESCRIPTION
<!-- Checklist for UI / stylesheet changes, delete if not applicable -->

- [x] chat-scoped -- core unaffected

### View mode

- [x] docked (windowed/drawer)
- [x] isolated (full-screen)

### Browsers

- [x] safari
- [x] chrome
- [x] firefox

### Device

- [x] desktop – wide screen
- [x] mobile – `?mobile_view=1`

### Ember //I don't know what to pick here

- [ ] ember-cli
- [ ] legacy

Changed the close button to an x instead of a minus.

![Uploading image.png…]()

