### PR TITLE
DEV: Refactor duplicate message blocker into class

### DIFF
--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -205,6 +205,8 @@ end
 #  name                    :string
 #  description             :text
 #  status                  :integer          default("open"), not null
+#  user_count              :integer          default(0), not null
+#  last_message_sent_at    :datetime         not null
 #
 # Indexes
 #

--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -33,9 +33,7 @@ class ChatMessage < ActiveRecord::Base
 
   def validate_message(has_uploads:)
     WatchedWordsValidator.new(attributes: [:message]).validate(self)
-    if block_duplicate?
-      self.errors.add(:base, I18n.t("chat.errors.duplicate_message"))
-    end
+    DiscourseChat::DuplicateMessageValidator.new(self).validate
 
     if !has_uploads && message_too_short?
       self.errors.add(
@@ -211,37 +209,6 @@ class ChatMessage < ActiveRecord::Base
   end
 
   private
-
-  def block_duplicate?
-    sensitivity = SiteSetting.chat_duplicate_message_sensitivity
-    return false if sensitivity.zero?
-
-    # Check if the length of the message is too short to check for a duplicate message
-    return false if message.length < calc_min_message_length_for_duplicates(sensitivity)
-
-    # Check if there are enough users in the channel to check for a duplicate message
-    return false if (chat_channel.user_count || 0) < calc_min_user_count_for_duplicates(sensitivity)
-
-    chat_channel.chat_messages
-      .where("created_at > ?", calc_in_the_past_seconds_for_duplicates(sensitivity).seconds.ago)
-      .where(message: message)
-      .exists?
-  end
-
-  def calc_min_user_count_for_duplicates(sensitivity)
-    # Line generated from 0.1 sensitivity = 100 users and 1.0 sensitivity = 5 users.
-    (-1.0 * 105.5 * sensitivity + 110.55).to_i
-  end
-
-  def calc_min_message_length_for_duplicates(sensitivity)
-    # Line generated from 0.1 sensitivity = 30 chars and 1.0 sensitivity = 10 chars.
-    (-1.0 * 22.2 * sensitivity + 32.22).to_i
-  end
-
-  def calc_in_the_past_seconds_for_duplicates(sensitivity)
-    # Line generated from 0.1 sensitivity = 10 seconds and 1.0 sensitivity = 60 seconds.
-    (55.55 * sensitivity + 4.5).to_i
-  end
 
   def message_too_short?
     message.length < SiteSetting.chat_minimum_message_length

--- a/app/models/user_chat_channel_membership.rb
+++ b/app/models/user_chat_channel_membership.rb
@@ -38,17 +38,17 @@ end
 #
 # Table name: user_chat_channel_memberships
 #
-#  id                                :bigint           not null, primary key
-#  user_id                           :integer          not null
-#  chat_channel_id                   :integer          not null
-#  last_read_message_id              :integer
-#  following                         :boolean          default(FALSE), not null
-#  muted                             :boolean          default(FALSE), not null
-#  desktop_notification_level        :integer          default("mention"), not null
-#  mobile_notification_level         :integer          default("mention"), not null
-#  created_at                        :datetime         not null
-#  updated_at                        :datetime         not null
-#  last_read_message_when_emailed_id :integer
+#  id                                  :bigint           not null, primary key
+#  user_id                             :integer          not null
+#  chat_channel_id                     :integer          not null
+#  last_read_message_id                :integer
+#  following                           :boolean          default(FALSE), not null
+#  muted                               :boolean          default(FALSE), not null
+#  desktop_notification_level          :integer          default("mention"), not null
+#  mobile_notification_level           :integer          default("mention"), not null
+#  created_at                          :datetime         not null
+#  updated_at                          :datetime         not null
+#  last_unread_mention_when_emailed_id :integer
 #
 # Indexes
 #

--- a/lib/duplicate_message_validator.rb
+++ b/lib/duplicate_message_validator.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class DiscourseChat::DuplicateMessageValidator
+  attr_reader :chat_message
+
+  def initialize(chat_message)
+    @chat_message = chat_message
+  end
+
+  def validate
+    return if SiteSetting.chat_duplicate_message_sensitivity.zero?
+    matrix = DiscourseChat::DuplicateMessageValidator.sensitivity_matrix(
+      SiteSetting.chat_duplicate_message_sensitivity
+    )
+
+    # Check if the length of the message is too short to check for a duplicate message
+    return if chat_message.message.length < matrix[:min_message_length]
+
+    # Check if there are enough users in the channel to check for a duplicate message
+    return if (chat_message.chat_channel.user_count || 0) < matrix[:min_user_count]
+
+    # Check if the same duplicate message has been posted in the last N seconds by any user
+    return if !chat_message.chat_channel.chat_messages
+      .where("created_at > ?", matrix[:min_past_seconds].seconds.ago)
+      .where(message: chat_message.message)
+      .exists?
+
+    chat_message.errors.add(:base, I18n.t("chat.errors.duplicate_message"))
+  end
+
+  def self.sensitivity_matrix(sensitivity)
+    {
+      # 0.1 sensitivity = 100 users and 1.0 sensitivity = 5 users.
+      min_user_count: (-1.0 * 105.5 * sensitivity + 110.55).to_i,
+
+      # 0.1 sensitivity = 30 chars and 1.0 sensitivity = 10 chars.
+      min_message_length: (-1.0 * 22.2 * sensitivity + 32.22).to_i,
+
+      # 0.1 sensitivity = 10 seconds and 1.0 sensitivity = 60 seconds.
+      min_past_seconds: (55.55 * sensitivity + 4.5).to_i
+    }
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -125,6 +125,7 @@ after_initialize do
   load File.expand_path('../lib/chat_notifier.rb', __FILE__)
   load File.expand_path('../lib/chat_seeder.rb', __FILE__)
   load File.expand_path('../lib/chat_transcript_service.rb', __FILE__)
+  load File.expand_path('../lib/duplicate_message_validator.rb', __FILE__)
   load File.expand_path('../lib/message_mover.rb', __FILE__)
   load File.expand_path('../lib/chat_message_bookmarkable.rb', __FILE__)
   load File.expand_path('../lib/chat_channel_archive_service.rb', __FILE__)

--- a/spec/lib/duplicate_message_validator_spec.rb
+++ b/spec/lib/duplicate_message_validator_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DiscourseChat::DuplicateMessageValidator do
+  let(:chat_channel) { Fabricate(:chat_channel) }
+
+  def message_blocked?(message)
+    chat_message = Fabricate.build(:chat_message, message: message, chat_channel: chat_channel)
+    described_class.new(chat_message).validate
+    chat_message.errors.full_messages.include?(I18n.t("chat.errors.duplicate_message"))
+  end
+
+  it "adds no errors when chat_duplicate_message_sensitivity is 0" do
+    SiteSetting.chat_duplicate_message_sensitivity = 0
+    expect(message_blocked?("test")).to eq(false)
+  end
+
+  it "errors if the message meets the requirements for sensitivity 0.1" do
+    SiteSetting.chat_duplicate_message_sensitivity = 0.1
+
+    chat_channel.update!(user_count: 100)
+    message = "this is a 30 char message for test"
+    dupe = Fabricate(:chat_message, created_at: 1.second.ago, message: message, chat_channel: chat_channel)
+    expect(message_blocked?(message)).to eq(true)
+
+    expect(message_blocked?("blah")).to eq(false)
+
+    dupe.update!(created_at: 11.seconds.ago)
+    expect(message_blocked?(message)).to eq(false)
+  end
+
+  it "errors if the message meets the requirements for sensitivity 0.5" do
+    SiteSetting.chat_duplicate_message_sensitivity = 0.5
+    chat_channel.update!(user_count: 57)
+    message = "this is a 21 char msg"
+    dupe = Fabricate(:chat_message, created_at: 1.second.ago, message: message, chat_channel: chat_channel)
+    expect(message_blocked?(message)).to eq(true)
+
+    expect(message_blocked?("blah")).to eq(false)
+
+    dupe.update!(created_at: 33.seconds.ago)
+    expect(message_blocked?(message)).to eq(false)
+  end
+
+  it "errors if the message meets the requirements for sensitivity 1.0" do
+    SiteSetting.chat_duplicate_message_sensitivity = 1.0
+    chat_channel.update!(user_count: 5)
+    message = "10 char msg"
+    dupe = Fabricate(:chat_message, created_at: 1.second.ago, message: message, chat_channel: chat_channel)
+    expect(message_blocked?(message)).to eq(true)
+
+    expect(message_blocked?("blah")).to eq(false)
+
+    dupe.update!(created_at: 61.seconds.ago)
+    expect(message_blocked?(message)).to eq(false)
+  end
+
+  describe "#sensitivity_matrix" do
+    describe "#min_user_count" do
+      it "calculates correctly for each of the major points from 0.1 to 1.0" do
+        expect(described_class.sensitivity_matrix(0.1)[:min_user_count]).to eq(100)
+        expect(described_class.sensitivity_matrix(0.2)[:min_user_count]).to eq(89)
+        expect(described_class.sensitivity_matrix(0.3)[:min_user_count]).to eq(78)
+        expect(described_class.sensitivity_matrix(0.4)[:min_user_count]).to eq(68)
+        expect(described_class.sensitivity_matrix(0.5)[:min_user_count]).to eq(57)
+        expect(described_class.sensitivity_matrix(0.6)[:min_user_count]).to eq(47)
+        expect(described_class.sensitivity_matrix(0.7)[:min_user_count]).to eq(36)
+        expect(described_class.sensitivity_matrix(0.8)[:min_user_count]).to eq(26)
+        expect(described_class.sensitivity_matrix(0.9)[:min_user_count]).to eq(15)
+        expect(described_class.sensitivity_matrix(1.0)[:min_user_count]).to eq(5)
+      end
+    end
+
+    describe "#min_message_length" do
+      it "calculates correctly for each of the major points from 0.1 to 1.0" do
+        expect(described_class.sensitivity_matrix(0.1)[:min_message_length]).to eq(30)
+        expect(described_class.sensitivity_matrix(0.2)[:min_message_length]).to eq(27)
+        expect(described_class.sensitivity_matrix(0.3)[:min_message_length]).to eq(25)
+        expect(described_class.sensitivity_matrix(0.4)[:min_message_length]).to eq(23)
+        expect(described_class.sensitivity_matrix(0.5)[:min_message_length]).to eq(21)
+        expect(described_class.sensitivity_matrix(0.6)[:min_message_length]).to eq(18)
+        expect(described_class.sensitivity_matrix(0.7)[:min_message_length]).to eq(16)
+        expect(described_class.sensitivity_matrix(0.8)[:min_message_length]).to eq(14)
+        expect(described_class.sensitivity_matrix(0.9)[:min_message_length]).to eq(12)
+        expect(described_class.sensitivity_matrix(1.0)[:min_message_length]).to eq(10)
+      end
+    end
+
+    describe "#min_past_seconds" do
+      it "calculates correctly for each of the major points from 0.1 to 1.0" do
+        expect(described_class.sensitivity_matrix(0.1)[:min_past_seconds]).to eq(10)
+        expect(described_class.sensitivity_matrix(0.2)[:min_past_seconds]).to eq(15)
+        expect(described_class.sensitivity_matrix(0.3)[:min_past_seconds]).to eq(21)
+        expect(described_class.sensitivity_matrix(0.4)[:min_past_seconds]).to eq(26)
+        expect(described_class.sensitivity_matrix(0.5)[:min_past_seconds]).to eq(32)
+        expect(described_class.sensitivity_matrix(0.6)[:min_past_seconds]).to eq(37)
+        expect(described_class.sensitivity_matrix(0.7)[:min_past_seconds]).to eq(43)
+        expect(described_class.sensitivity_matrix(0.8)[:min_past_seconds]).to eq(48)
+        expect(described_class.sensitivity_matrix(0.9)[:min_past_seconds]).to eq(54)
+        expect(described_class.sensitivity_matrix(1.0)[:min_past_seconds]).to eq(60)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We introduced duplicate message blocking in d1597107d2c0d2dbd18ce96ef71f82dd3d004063
but put the blocker logic which is quite specific inside the
ChatMessage model, and without many specs. This commit refactors
the methods and logic into a DuplicateMessageValidator class
and adds additional specs.

The numbers used for the calculations are quite mysterious, but
hopefully the specs cover the common use cases. The default for the
setting is 0.5, min is 0, and the max is 1.0.

Also added a couple of missing model annotations.