### PR TITLE
FIX: prevents destroyed/deleted chatable to crash admin page

### DIFF
--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -154,6 +154,9 @@ class ChatChannel < ActiveRecord::Base
 
   def self.public_channels
     where(chatable_type: public_channel_chatable_types)
+      .where("topics.id IS NOT NULL OR categories.id IS NOT NULL")
+      .joins("LEFT JOIN categories ON categories.id = chat_channels.chatable_id AND chat_channels.chatable_type = 'Category'")
+      .joins("LEFT JOIN topics ON topics.id = chat_channels.chatable_id AND chat_channels.chatable_type = 'Topic' AND topics.deleted_at IS NULL")
   end
 
   def self.is_enabled?(t)

--- a/spec/models/chat_channel_spec.rb
+++ b/spec/models/chat_channel_spec.rb
@@ -154,6 +154,42 @@ describe ChatChannel do
     end
   end
 
+  describe ".public_channels" do
+    context 'a topic used as chatable is destroyed' do
+      fab!(:topic_channel_1) { Fabricate(:chat_channel, chatable: Fabricate(:topic)) }
+      fab!(:topic_channel_2) { Fabricate(:chat_channel, chatable: Fabricate(:topic)) }
+      fab!(:category_channel_1) { Fabricate(:chat_channel, chatable: Fabricate(:category)) }
+
+      before do
+        topic_channel_1.chatable.trash!
+      end
+
+      it 'doesn’t list the channel' do
+        ids = ChatChannel.public_channels.pluck(:chatable_id)
+        expect(ids).to_not include(topic_channel_1.chatable_id)
+        expect(ids).to include(topic_channel_2.chatable_id)
+        expect(ids).to include(category_channel_1.chatable_id)
+      end
+    end
+
+    context 'a category used as chatable is destroyed' do
+      fab!(:category_channel_1) { Fabricate(:chat_channel, chatable: Fabricate(:category)) }
+      fab!(:category_channel_2) { Fabricate(:chat_channel, chatable: Fabricate(:category)) }
+      fab!(:topic_channel_1) { Fabricate(:chat_channel, chatable: Fabricate(:topic)) }
+
+      before do
+        category_channel_1.chatable.destroy!
+      end
+
+      it 'doesn’t list the channel' do
+        ids = ChatChannel.public_channels.pluck(:chatable_id)
+        expect(ids).to_not include(category_channel_1.chatable_id)
+        expect(ids).to include(topic_channel_1.chatable_id)
+        expect(ids).to include(category_channel_2.chatable_id)
+      end
+    end
+  end
+
   describe "#archived!" do
     before do
       public_topic_channel.update!(status: :read_only)


### PR DESCRIPTION
Prior to this fix, destroying a chatable would cause a 500 on /admin/plugins/chat page as the chatable would be found and the serializer couldn't display its data.
