### PR TITLE
hide collapse button on mobile and isolate

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -48,7 +48,7 @@ export default Component.extend({
   stickyScroll: true,
   stickyScrollTimer: null,
   showChatQuoteSuccess: false,
-  showCompressBtn: false,
+  showCloseFullScreenBtn: false,
 
   editingMessage: null, // ?Message
   replyToMsg: null, // ?Message
@@ -100,7 +100,7 @@ export default Component.extend({
     this.appEvents.on("chat:cancel-message-selection", this, "cancelSelecting");
 
     this.set(
-      "showCompressBtn",
+      "showCloseFullScreenBtn",
       !this.currentUser.chat_isolated && !this.site.mobileView
     );
   },

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -48,6 +48,7 @@ export default Component.extend({
   stickyScroll: true,
   stickyScrollTimer: null,
   showChatQuoteSuccess: false,
+  showCompressBtn: false,
 
   editingMessage: null, // ?Message
   replyToMsg: null, // ?Message
@@ -97,6 +98,8 @@ export default Component.extend({
     );
 
     this.appEvents.on("chat:cancel-message-selection", this, "cancelSelecting");
+
+    this.set("showCompressBtn", !this.currentUser.chat_isolated && !this.site.mobileView);
   },
 
   willDestroyElement() {

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -99,7 +99,10 @@ export default Component.extend({
 
     this.appEvents.on("chat:cancel-message-selection", this, "cancelSelecting");
 
-    this.set("showCompressBtn", !this.currentUser.chat_isolated && !this.site.mobileView);
+    this.set(
+      "showCompressBtn",
+      !this.currentUser.chat_isolated && !this.site.mobileView
+    );
   },
 
   willDestroyElement() {

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -20,7 +20,7 @@
         {{chat-channel-status channel=chatChannel}}
       </div>
 
-      {{#if showCompressBtn}}
+      {{#if showCloseFullScreenBtn}}
         {{flat-button
           class="chat-full-screen-button"
           icon="discourse-compress"

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -20,12 +20,14 @@
         {{chat-channel-status channel=chatChannel}}
       </div>
 
-      {{flat-button
-        class="chat-full-screen-button"
-        icon="discourse-compress"
-        action=(action "onCloseFullScreen" chatChannel)
-        title="chat.close_full_page"
-      }}
+      {{#if showCompressBtn}}
+        {{flat-button
+          class="chat-full-screen-button"
+          icon="discourse-compress"
+          action=(action "onCloseFullScreen" chatChannel)
+          title="chat.close_full_page"
+        }}
+      {{/if}}
 
       {{chat-channel-archive-status channel=chatChannel}}
     </div>

--- a/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
+++ b/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
@@ -162,6 +162,7 @@ if (!isLegacyEmber()) {
     test("switching channel with alt+arrow keys in float", async function (assert) {
       await visit("/latest");
       this.chatService.set("sidebarActive", false);
+      this.chatService.set("chatWindowFullPage", false);
       await click(".header-dropdown-toggle.open-chat");
       await settled();
       assert.ok(visible(".topic-chat-float-container"), "chat float is open");

--- a/test/javascripts/acceptance/chat-quoting-test.js
+++ b/test/javascripts/acceptance/chat-quoting-test.js
@@ -115,8 +115,6 @@ acceptance("Discourse Chat | quoting when topic open", async function (needs) {
   });
 
   test("it opens the composer for the topic and pastes in the quote", async function (assert) {
-    this.chatService.set("sidebarActive", false);
-    this.chatService.set("chatWindowFullPage", false);
     await visit("/t/internationalization-localization/280");
     await click(".header-dropdown-toggle.open-chat");
     assert.ok(visible(".topic-chat-float-container"), "chat float is open");

--- a/test/javascripts/acceptance/chat-quoting-test.js
+++ b/test/javascripts/acceptance/chat-quoting-test.js
@@ -118,6 +118,8 @@ acceptance("Discourse Chat | quoting when topic open", async function (needs) {
   // TODO Something about these is weirdly flaky, causing an indexOf error in
   // addImage for upload-protocol.js, no idea why.
   skip("it opens the composer for the topic and pastes in the quote", async function (assert) {
+    this.chatService.set("sidebarActive", false);
+    this.chatService.set("chatWindowFullPage", false);
     await visit("/t/internationalization-localization/280");
     await click(".header-dropdown-toggle.open-chat");
     assert.ok(visible(".topic-chat-float-container"), "chat float is open");

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -1211,6 +1211,47 @@ acceptance(
 );
 
 acceptance(
+  "Discourse Chat - Acceptance Test show/hide close fullscreen chat button",
+  function (needs) {
+    needs.user({
+      admin: false,
+      moderator: false,
+      username: "eviltrout",
+      id: 1,
+      can_chat: true,
+      has_chat_enabled: true,
+    });
+    needs.settings({
+      chat_enabled: true,
+    });
+    needs.pretender((server, helper) => {
+      baseChatPretenders(server, helper);
+      siteChannelPretender(server, helper, { unread_count: 2, muted: false });
+      chatChannelPretender(server, helper, [
+        { id: 9, unread_count: 2, muted: false },
+      ]);
+    });
+    needs.hooks.beforeEach(function () {
+      Object.defineProperty(this, "chatService", {
+        get: () => this.container.lookup("service:chat"),
+      });
+    });
+
+    test("Close fullscreen chat button not present on chat_isolated", async function (assert) {
+      updateCurrentUser({ chat_isolated: true });
+      await visit("/chat/channel/9/Site");
+      assert.notOk(exists(".chat-full-screen-button"));
+    });
+
+    test("Close fullscreen chat button present", async function (assert) {
+      updateCurrentUser({ chat_isolated: false });
+      await visit("/chat/channel/9/Site");
+      assert.ok(exists(".chat-full-screen-button"));
+    });
+  }
+);
+
+acceptance(
   "Discourse Chat - Acceptance Test with unread DMs and public channel messages",
   function (needs) {
     needs.user({

--- a/test/javascripts/acceptance/mobile-chat-test.js
+++ b/test/javascripts/acceptance/mobile-chat-test.js
@@ -25,5 +25,7 @@ acceptance("Discourse Chat - Mobile test", function (needs) {
     await click(".header-dropdown-toggle.open-chat");
     assert.equal(currentURL(), "/chat");
     assert.ok(exists(".channels-list"));
+    await click(".chat-channel-row.chat-channel-7");
+    assert.notOk(exists(".chat-full-screen-button"));
   });
 });

--- a/test/javascripts/acceptance/user-card-chat-test.js
+++ b/test/javascripts/acceptance/user-card-chat-test.js
@@ -85,6 +85,7 @@ if (!isLegacyEmber()) {
 
     test("user card has chat button that opens the correct channel", async function (assert) {
       this.chatService.set("sidebarActive", false);
+      this.chatService.set("chatWindowFullPage", false);
       await visit("/latest");
       this.appEvents.trigger("chat:toggle-open");
       await settled();


### PR DESCRIPTION
<!-- Checklist for UI / stylesheet changes, delete if not applicable -->

- [x] chat-scoped -- core unaffected

### View mode

- [x] docked (windowed/drawer)
- [x] isolated (full-screen)

### Browsers

- [x] safari
- [x] chrome
- [x] firefox

### Device

- [x] desktop – wide screen
- [x] mobile – `?mobile_view=1`

### Ember

- [x] ember-cli
- [x] legacy
