### PR TITLE
FIX: ensures we unsubscribe from /chat-reply in draft mode

### DIFF
--- a/assets/javascripts/discourse/components/chat-replying-indicator.js
+++ b/assets/javascripts/discourse/components/chat-replying-indicator.js
@@ -4,7 +4,6 @@ import { inject as service } from "@ember/service";
 import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "I18n";
 import { fmt } from "discourse/lib/computed";
-import { next } from "@ember/runloop";
 
 export default Component.extend({
   tagName: "",
@@ -59,11 +58,6 @@ export default Component.extend({
 
     if (!this.chatChannel || this.chatChannel.isDraft) {
       this.presenceChannel?.unsubscribe();
-
-      next(() => {
-        this.set("presenceChannel", null);
-      });
-
       return;
     }
 

--- a/assets/javascripts/discourse/components/chat-replying-indicator.js
+++ b/assets/javascripts/discourse/components/chat-replying-indicator.js
@@ -4,6 +4,7 @@ import { inject as service } from "@ember/service";
 import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "I18n";
 import { fmt } from "discourse/lib/computed";
+import { next } from "@ember/runloop";
 
 export default Component.extend({
   tagName: "",
@@ -58,14 +59,22 @@ export default Component.extend({
 
     if (!this.chatChannel || this.chatChannel.isDraft) {
       this.presenceChannel?.unsubscribe();
-      this.set("presenceChannel", null);
+
+      next(() => {
+        this.set("presenceChannel", null);
+      });
+
       return;
     }
 
     if (this.presenceChannel?.name !== this.channelName) {
       this.presenceChannel?.unsubscribe();
-      this.set("presenceChannel", this.presence.getChannel(this.channelName));
-      this.presenceChannel.subscribe();
+
+      next(() => {
+        const presenceChannel = this.presence.getChannel(this.channelName);
+        this.set("presenceChannel", presenceChannel);
+        presenceChannel.subscribe();
+      });
     }
   },
 

--- a/assets/javascripts/discourse/components/chat-replying-indicator.js
+++ b/assets/javascripts/discourse/components/chat-replying-indicator.js
@@ -70,11 +70,9 @@ export default Component.extend({
     if (this.presenceChannel?.name !== this.channelName) {
       this.presenceChannel?.unsubscribe();
 
-      next(() => {
-        const presenceChannel = this.presence.getChannel(this.channelName);
-        this.set("presenceChannel", presenceChannel);
-        presenceChannel.subscribe();
-      });
+      const presenceChannel = this.presence.getChannel(this.channelName);
+      this.set("presenceChannel", presenceChannel);
+      presenceChannel.subscribe();
     }
   },
 

--- a/assets/javascripts/discourse/components/chat-replying-indicator.js
+++ b/assets/javascripts/discourse/components/chat-replying-indicator.js
@@ -57,6 +57,8 @@ export default Component.extend({
     this._super(...arguments);
 
     if (!this.chatChannel || this.chatChannel.isDraft) {
+      this.presenceChannel?.unsubscribe();
+      this.set("presenceChannel", null);
       return;
     }
 

--- a/test/javascripts/components/chat-replying-indicator-test.js
+++ b/test/javascripts/components/chat-replying-indicator-test.js
@@ -158,5 +158,27 @@ discourseModule(
         );
       },
     });
+
+    componentTest("resets presence when channel is draft", {
+      template: hbs`{{chat-replying-indicator presenceChannel=presenceChannel chatChannel=chatChannel}}`,
+
+      async beforeEach() {
+        this.set("chatChannel", fabricate("chat-channel"));
+        this.set(
+          "presenceChannel",
+          MockPresenceChannel.create({
+            name: `/chat-reply/${this.chatChannel.id}`,
+          })
+        );
+      },
+
+      async test(assert) {
+        assert.ok(this.presenceChannel);
+
+        this.set("chatChannel", fabricate("chat-channel", { isDraft: true }));
+
+        assert.notOk(this.presenceChannel);
+      },
+    });
   }
 );

--- a/test/javascripts/components/chat-replying-indicator-test.js
+++ b/test/javascripts/components/chat-replying-indicator-test.js
@@ -169,18 +169,17 @@ discourseModule(
           "presenceChannel",
           MockPresenceChannel.create({
             name: `/chat-reply/${this.chatChannel.id}`,
+            subscribed: true,
           })
         );
       },
 
       async test(assert) {
-        assert.ok(this.presenceChannel);
+        assert.ok(this.presenceChannel.subscribed);
 
         this.set("chatChannel", fabricate("chat-channel", { isDraft: true }));
 
-        await settled();
-
-        assert.notOk(this.presenceChannel);
+        assert.notOk(this.presenceChannel.subscribed);
       },
     });
   }

--- a/test/javascripts/components/chat-replying-indicator-test.js
+++ b/test/javascripts/components/chat-replying-indicator-test.js
@@ -1,4 +1,3 @@
-import { settled } from "@ember/test-helpers";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";

--- a/test/javascripts/components/chat-replying-indicator-test.js
+++ b/test/javascripts/components/chat-replying-indicator-test.js
@@ -1,3 +1,4 @@
+import { settled } from "@ember/test-helpers";
 import componentTest, {
   setupRenderingTest,
 } from "discourse/tests/helpers/component-test";
@@ -176,6 +177,8 @@ discourseModule(
         assert.ok(this.presenceChannel);
 
         this.set("chatChannel", fabricate("chat-channel", { isDraft: true }));
+
+        await settled();
 
         assert.notOk(this.presenceChannel);
       },

--- a/test/javascripts/helpers/mock-presence-channel.js
+++ b/test/javascripts/helpers/mock-presence-channel.js
@@ -8,10 +8,14 @@ export default EmberObject.extend({
   },
 
   users: null,
-
-  async unsubscribe() {},
-
-  async subscribe() {},
-
   name: null,
+  subscribed: false,
+
+  async unsubscribe() {
+    this.set("subscribed", false);
+  },
+
+  async subscribe() {
+    this.set("subscribed", true);
+  },
 });


### PR DESCRIPTION
Before this fix, being in another channel and switching to dm creator would not reset replying-indicator state and you would see incorrect data.
