### PR TITLE
FIX: ensures chat has correct height on composer resizing

### DIFF
--- a/assets/javascripts/discourse/components/full-page-chat.js
+++ b/assets/javascripts/discourse/components/full-page-chat.js
@@ -1,3 +1,4 @@
+import afterTransition from "discourse/lib/after-transition";
 import Component from "@ember/component";
 import discourseComputed, { bind } from "discourse-common/utils/decorators";
 import { action } from "@ember/object";
@@ -41,6 +42,7 @@ export default Component.extend({
     document.body.classList.add("has-full-page-chat");
     this.chat.set("fullScreenChatOpen", true);
     schedule("afterRender", this._calculateHeight);
+    this.appEvents.on("composer:resized", this._calculateHeight);
   },
 
   willDestroyElement() {
@@ -52,6 +54,7 @@ export default Component.extend({
     document.removeEventListener("keydown", this._autoFocusChatComposer);
     document.body.classList.remove("has-full-page-chat");
     this.chat.set("fullScreenChatOpen", false);
+    this.appEvents.off("composer:resized", this._calculateHeight);
   },
 
   @bind

--- a/assets/javascripts/discourse/components/full-page-chat.js
+++ b/assets/javascripts/discourse/components/full-page-chat.js
@@ -1,4 +1,3 @@
-import afterTransition from "discourse/lib/after-transition";
 import Component from "@ember/component";
 import discourseComputed, { bind } from "discourse-common/utils/decorators";
 import { action } from "@ember/object";

--- a/assets/javascripts/discourse/components/full-page-chat.js
+++ b/assets/javascripts/discourse/components/full-page-chat.js
@@ -42,7 +42,7 @@ export default Component.extend({
     document.body.classList.add("has-full-page-chat");
     this.chat.set("fullScreenChatOpen", true);
     schedule("afterRender", this._calculateHeight);
-    this.appEvents.on("composer:resized", this._calculateHeight);
+    this.appEvents.on("composer:resized", this, "_calculateHeight");
   },
 
   willDestroyElement() {
@@ -54,7 +54,7 @@ export default Component.extend({
     document.removeEventListener("keydown", this._autoFocusChatComposer);
     document.body.classList.remove("has-full-page-chat");
     this.chat.set("fullScreenChatOpen", false);
-    this.appEvents.off("composer:resized", this._calculateHeight);
+    this.appEvents.off("composer:resized", this, "_calculateHeight");
   },
 
   @bind


### PR DESCRIPTION
Ideally in the future I want to get rid of this calculateHeight logic, this is temporary fix for this case.