### PR TITLE
FIX: Add extra chat shortcut help text

### DIFF
--- a/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
+++ b/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
@@ -86,17 +86,47 @@ export default {
       api.addKeyboardShortcut(
         `${mod}+b`,
         (event) => modifyComposerSelection(event, "bold"),
-        { global: true }
+        {
+          global: true,
+          help: {
+            category: "chat",
+            name: "chat.keyboard_shortcuts.composer_bold",
+            definition: {
+              keys1: ["meta", "b"],
+              keysDelimiter: "plus",
+            },
+          },
+        }
       );
       api.addKeyboardShortcut(
         `${mod}+i`,
         (event) => modifyComposerSelection(event, "italic"),
-        { global: true }
+        {
+          global: true,
+          help: {
+            category: "chat",
+            name: "chat.keyboard_shortcuts.composer_italic",
+            definition: {
+              keys1: ["meta", "i"],
+              keysDelimiter: "plus",
+            },
+          },
+        }
       );
       api.addKeyboardShortcut(
         `${mod}+e`,
         (event) => modifyComposerSelection(event, "code"),
-        { global: true }
+        {
+          global: true,
+          help: {
+            category: "chat",
+            name: "chat.keyboard_shortcuts.composer_code",
+            definition: {
+              keys1: ["meta", "e"],
+              keysDelimiter: "plus",
+            },
+          },
+        }
       );
       api.addKeyboardShortcut(
         `${mod}+l`,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -347,7 +347,10 @@ en:
         keyboard_shortcuts:
           switch_channel_arrows: "%{shortcut} Switch channel"
           open_quick_channel_selector: "%{shortcut} Open quick channel selector"
-          open_insert_link_modal: "%{shortcut} Insert hyperlink"
+          open_insert_link_modal: "%{shortcut} Insert hyperlink (composer only)"
+          composer_bold: "%{shortcut} Bold (composer only)"
+          composer_italic: "%{shortcut} Italic (composer only)"
+          composer_code: "%{shortcut} Code (composer only)"
     topic_statuses:
       chat:
         help: "Chat is enabled for this topic"


### PR DESCRIPTION
We may be changing these at some point, but still
best to have the help discoverable for these additional
shortcuts.

![image](https://user-images.githubusercontent.com/920448/172092066-9ab918f7-8a9b-4c99-8b5e-e8967af21858.png)
