### PR TITLE
FIX: Dev populate breaks with missing admin user

### DIFF
--- a/lib/discourse_dev/public_channel.rb
+++ b/lib/discourse_dev/public_channel.rb
@@ -30,8 +30,8 @@ module DiscourseDev
       super do |channel|
         Faker::Number.between(from: 5, to: 10).times do
           if Faker::Boolean.boolean(true_ratio: 0.5)
-            admin_username = DiscourseDev::Config.new.config[:admin][:username]
-            admin_user = ::User.find_by(username: admin_username)
+            admin_username = DiscourseDev::Config.new.config[:admin][:username] rescue nil
+            admin_user = ::User.find_by(username: admin_username) if admin_username
           end
 
           ::UserChatChannelMembership.find_or_create_by!(


### PR DESCRIPTION
When running dev:populate you might not have the admin user specified in
your config yaml file so we should ignore that instead of throwing an
error.
