### PR TITLE
FIX: Onebox should only show active users

### DIFF
--- a/app/jobs/scheduled/update_user_counts_for_chat_channels.rb
+++ b/app/jobs/scheduled/update_user_counts_for_chat_channels.rb
@@ -15,8 +15,8 @@ module Jobs
       new_count = chat_channel
         .user_chat_channel_memberships
         .joins(:user)
-        .where(user: { active: true, suspended_till: nil, staged: false })
         .where(following: true)
+        .merge(User.activated.not_suspended.not_staged)
         .count
 
       return if current_count == new_count

--- a/app/jobs/scheduled/update_user_counts_for_chat_channels.rb
+++ b/app/jobs/scheduled/update_user_counts_for_chat_channels.rb
@@ -15,7 +15,7 @@ module Jobs
       new_count = chat_channel
         .user_chat_channel_memberships
         .joins(:user)
-        .where(user: {active: true, suspended_till: nil, staged: false})
+        .where(user: { active: true, suspended_till: nil, staged: false })
         .where(following: true)
         .count
 

--- a/app/jobs/scheduled/update_user_counts_for_chat_channels.rb
+++ b/app/jobs/scheduled/update_user_counts_for_chat_channels.rb
@@ -15,8 +15,8 @@ module Jobs
       new_count = chat_channel
         .user_chat_channel_memberships
         .joins(:user)
+        .where(user: {active: true, suspended_till: nil, staged: false})
         .where(following: true)
-        .merge(User.not_suspended)
         .count
 
       return if current_count == new_count

--- a/plugin.rb
+++ b/plugin.rb
@@ -233,7 +233,7 @@ after_initialize do
 
     users = chat_channel
       .user_chat_channel_memberships
-      .includes(:user).where(user: {active: true, suspended_till: nil, staged: false})
+      .includes(:user).where(user: { active: true, suspended_till: nil, staged: false })
       .limit(10)
       .map do |membership|
         {

--- a/plugin.rb
+++ b/plugin.rb
@@ -233,7 +233,7 @@ after_initialize do
 
     users = chat_channel
       .user_chat_channel_memberships
-      .includes(:user).where(user: { active: true, suspended_till: nil, staged: false })
+      .includes(:user).where(user: User.activated.not_suspended.not_staged)
       .limit(10)
       .map do |membership|
         {

--- a/plugin.rb
+++ b/plugin.rb
@@ -233,7 +233,7 @@ after_initialize do
 
     users = chat_channel
       .user_chat_channel_memberships
-      .includes(:user)
+      .includes(:user).where(user: {active: true, suspended_till: nil, staged: false})
       .limit(10)
       .map do |membership|
         {

--- a/spec/jobs/update_user_counts_for_chat_channels_spec.rb
+++ b/spec/jobs/update_user_counts_for_chat_channels_spec.rb
@@ -8,6 +8,7 @@ describe Jobs::UpdateUserCountsForChatChannels do
   fab!(:user_1) { Fabricate(:user) }
   fab!(:user_2) { Fabricate(:user) }
   fab!(:user_3) { Fabricate(:user) }
+  fab!(:user_4) { Fabricate(:user) }
 
   it "sets the user_count correctly for each chat channel" do
     user_1.user_chat_channel_memberships.create!(chat_channel: chat_channel_1, following: true)
@@ -25,10 +26,14 @@ describe Jobs::UpdateUserCountsForChatChannels do
     expect(chat_channel_2.reload.user_count).to eq(3)
   end
 
-  it "doesn't count suspended users" do
+  it "does not count suspended, non-activated, nor staged users" do
     user_1.user_chat_channel_memberships.create!(chat_channel: chat_channel_1, following: true)
     user_2.user_chat_channel_memberships.create!(chat_channel: chat_channel_2, following: true)
+    user_3.user_chat_channel_memberships.create!(chat_channel: chat_channel_2, following: true)
+    user_4.user_chat_channel_memberships.create!(chat_channel: chat_channel_2, following: true)
     user_2.update(suspended_till: 3.weeks.from_now)
+    user_3.update(staged: true)
+    user_4.update(active: false)
 
     Jobs::UpdateUserCountsForChatChannels.new.execute
 

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -153,7 +153,11 @@ describe 'discourse-chat' do
 
   describe "chat oneboxes" do
     fab!(:chat_channel) { Fabricate(:chat_channel, chatable: Fabricate(:topic)) }
-    fab!(:user) { Fabricate(:user) }
+    fab!(:user) { Fabricate(:user, active: true) }
+    fab!(:user_2) { Fabricate(:user, active: false) }
+    fab!(:user_3) { Fabricate(:user, staged: true) }
+    fab!(:user_4) { Fabricate(:user, suspended_till: 3.weeks.from_now) }
+
     let!(:chat_message) do
       DiscourseChat::ChatMessageCreator.create(
         chat_channel: chat_channel,
@@ -184,6 +188,12 @@ describe 'discourse-chat' do
 
     context "regular" do
       it "renders channel" do
+        user.user_chat_channel_memberships.create!(chat_channel: chat_channel, following: true)
+        user_2.user_chat_channel_memberships.create!(chat_channel: chat_channel, following: true)
+        user_3.user_chat_channel_memberships.create!(chat_channel: chat_channel, following: true)
+        user_4.user_chat_channel_memberships.create!(chat_channel: chat_channel, following: true)
+        Jobs::UpdateUserCountsForChatChannels.new.execute({})
+
         expect(Oneboxer.preview(chat_url)).to match_html <<~HTML
           <aside class="onebox chat-onebox">
             <article class="onebox-body chat-onebox-body">
@@ -195,8 +205,12 @@ describe 'discourse-chat' do
                   <span class="clear-badge">#{chat_channel.name}</span>
                 </a>
               </h3>
-              <div class="chat-onebox-members-count">0 members</div>
-              <div class="chat-onebox-members"></div>
+              <div class="chat-onebox-members-count">1 member</div>
+              <div class="chat-onebox-members">
+               <a class="trigger-user-card" data-user-card="#{user.username}" aria-hidden="true" tabindex="-1">
+                 <img loading="lazy" alt="#{user.username}" width="30" height="30" src="#{user.avatar_template_url.gsub('{size}', '30')}" class="avatar">
+               </a>
+              </div>
             </article>
         </aside>
 

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -187,7 +187,7 @@ describe 'discourse-chat' do
     end
 
     context "regular" do
-      it "renders channel" do
+      it "renders channel, excluding inactive, staged, and suspended users" do
         user.user_chat_channel_memberships.create!(chat_channel: chat_channel, following: true)
         user_2.user_chat_channel_memberships.create!(chat_channel: chat_channel, following: true)
         user_3.user_chat_channel_memberships.create!(chat_channel: chat_channel, following: true)


### PR DESCRIPTION
A onebox for a chat channel should only show users that are active, not
staged, and not suspended in the members list.

Maybe as a future feature we should boot users from the channel list that don't
belong to a certain group or that are no longer activated. Not really
sure, it's possible they should re-join the group if they are no longer
suspended.
