### PR TITLE
FIX: Undefined uploads error when attempting to cloneJSON

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -703,7 +703,7 @@ export default Component.extend({
         message: data.chat_message.message,
         cooked: data.chat_message.cooked,
         excerpt: data.chat_message.excerpt,
-        uploads: cloneJSON(data.chat_message.uploads),
+        uploads: cloneJSON(data.chat_message.uploads || []),
         edited: true,
       });
     }
@@ -885,7 +885,7 @@ export default Component.extend({
   },
 
   @action
-  sendMessage(message, uploads) {
+  sendMessage(message, uploads = []) {
     resetIdle();
 
     if (this.sendingloading) {
@@ -927,7 +927,7 @@ export default Component.extend({
       message,
       cooked,
       staged_id: stagedId,
-      upload_ids: (uploads || []).map((upload) => upload.id),
+      upload_ids: uploads.map((upload) => upload.id),
     };
     if (this.replyToMsg) {
       data.in_reply_to_id = this.replyToMsg.id;


### PR DESCRIPTION
Sometimes `uploads` are not present, which means that
the change from 0f4816c43e285d3e5e330742ff2a62e045db596b sometimes
errors (e.g. when inserting gifs via discourse-gifs). This
fixes the issue by providing default values. As in the
referenced commit, current coupling prevents this from being
easily testable.
