### PR TITLE
FIX: Make sure chat uploads have correct URL in template

### DIFF
--- a/assets/javascripts/discourse/initializers/chat-decorators.js
+++ b/assets/javascripts/discourse/initializers/chat-decorators.js
@@ -1,4 +1,6 @@
 import { decorateGithubOneboxBody } from "discourse/initializers/onebox-decorators";
+import { resolveAllShortUrls } from "pretty-text/upload-short-url";
+import { ajax } from "discourse/lib/ajax";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import highlightSyntax from "discourse/lib/highlight-syntax";
 import I18n from "I18n";
@@ -44,11 +46,12 @@ export default {
       }
     );
 
+    const siteSettings = container.lookup("site-settings:main");
     api.decorateChatMessage(
       (element) =>
         highlightSyntax(
           element,
-          container.lookup("site-settings:main"),
+          siteSettings,
           container.lookup("session:main")
         ),
       { id: "highlightSyntax" }
@@ -61,6 +64,13 @@ export default {
     api.decorateChatMessage(this.forceLinksToOpenNewTab, {
       id: "linksNewTab",
     });
+
+    api.decorateChatMessage(
+      (element) => resolveAllShortUrls(ajax, siteSettings, element),
+      {
+        id: "resolveShortUrls",
+      }
+    );
 
     api.decorateChatMessage(
       (element) =>

--- a/assets/javascripts/discourse/initializers/chat-decorators.js
+++ b/assets/javascripts/discourse/initializers/chat-decorators.js
@@ -1,6 +1,4 @@
 import { decorateGithubOneboxBody } from "discourse/initializers/onebox-decorators";
-import { resolveAllShortUrls } from "pretty-text/upload-short-url";
-import { ajax } from "discourse/lib/ajax";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import highlightSyntax from "discourse/lib/highlight-syntax";
 import I18n from "I18n";
@@ -64,13 +62,6 @@ export default {
     api.decorateChatMessage(this.forceLinksToOpenNewTab, {
       id: "linksNewTab",
     });
-
-    api.decorateChatMessage(
-      (element) => resolveAllShortUrls(ajax, siteSettings, element),
-      {
-        id: "resolveShortUrls",
-      }
-    );
 
     api.decorateChatMessage(
       (element) =>

--- a/assets/javascripts/discourse/templates/components/chat-upload.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-upload.hbs
@@ -1,5 +1,5 @@
 {{#if (eq type IMAGE_TYPE)}}
-  <img class="chat-img-upload" data-orig-src={{upload.short_url}} height={{size.height}} width={{size.width}}>
+  <img class="chat-img-upload" data-orig-src={{upload.short_url}} height={{size.height}} width={{size.width}} src={{upload.url}}>
 {{else}}
-  <a class="chat-other-upload" data-orig-href={{upload.short_url}}>{{upload.original_filename}}</a>
+  <a class="chat-other-upload" data-orig-href={{upload.short_url}} href={{upload.url}}>{{upload.original_filename}}</a>
 {{/if}}

--- a/assets/javascripts/discourse/templates/components/chat-upload.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-upload.hbs
@@ -1,6 +1,5 @@
 {{#if (eq type IMAGE_TYPE)}}
-  <img class="chat-img-upload" data-orig-src={{upload.short_url}} height={{size.height}} width={{size.width}}
-       src={{upload.url}}>
+  <img class="chat-img-upload" data-orig-src={{upload.short_url}} height={{size.height}} width={{size.width}}>
 {{else}}
   <a class="chat-other-upload" data-orig-href={{upload.short_url}}>{{upload.original_filename}}</a>
 {{/if}}

--- a/spec/models/direct_message_channel_spec.rb
+++ b/spec/models/direct_message_channel_spec.rb
@@ -3,27 +3,27 @@
 require 'rails_helper'
 
 describe DirectMessageChannel do
-  fab!(:user1) { Fabricate(:user) }
-  fab!(:user2) { Fabricate(:user) }
+  fab!(:user1) { Fabricate(:user, username: "chatdmfellow1") }
+  fab!(:user2) { Fabricate(:user, username: "chatdmuser") }
   fab!(:chat_channel) { Fabricate(:chat_channel, chatable: Fabricate(:topic)) }
 
   describe "#chat_channel_title_for_user" do
     it "returns a nicely formatted name if it's more than one user" do
-      user3 = Fabricate.build(:user)
+      user3 = Fabricate.build(:user, username: "chatdmregent")
       direct_message_channel = Fabricate(:direct_message_channel, users: [user1, user2, user3])
 
       expect(direct_message_channel.chat_channel_title_for_user(chat_channel, user1)).to eq(
         I18n.t(
           "chat.channel.dm_title.multi_user",
-          users: [user2, user3].map { |u| "@#{u.username}" }.join(", ")
+          users: [user3, user2].map { |u| "@#{u.username}" }.join(", ")
         )
       )
     end
 
     it "returns a nicely formatted truncated name if it's more than 5 users" do
-      user3 = Fabricate.build(:user)
+      user3 = Fabricate.build(:user, username: "chatdmregent")
 
-      users = [user1, user2, user3].concat(5.times.map { Fabricate(:user) })
+      users = [user1, user2, user3].concat(5.times.map.with_index { |i| Fabricate(:user, username: "chatdmuser#{i}") })
       direct_message_channel = Fabricate(:direct_message_channel, users: users)
 
       expect(direct_message_channel.chat_channel_title_for_user(chat_channel, user1)).to eq(


### PR DESCRIPTION
This commit fixes non-image chat uploads not working since
e9cb7a172dfd1f413626a4590e7f373447370086 when we removed
the `resolveAllShortUrls` calls in the chat message decorator. We can
just use the `upload.url` directly on the `href`.

`data-orig-X` attributes must remain, as they are used for quoting.