### PR TITLE
UX: Split each summary's message into its row.

### DIFF
--- a/app/views/user_notifications/chat_summary.html.erb
+++ b/app/views/user_notifications/chat_summary.html.erb
@@ -43,6 +43,8 @@
                 <%= I18n.l(@user_tz.to_local(chat_message.created_at), format: :long) -%>
               </span>
             </td>
+          </tr>
+          <tr>
             <td style="width:99%;margin:0;padding:<%= rtl? ? '0 2em 0 0' : '0 0 0 2em' %>;vertical-align:top;">
               <%= email_excerpt(chat_message.cooked_for_excerpt) %>
             </td>


### PR DESCRIPTION
It looks better on mobile this way.

### Mobile
<img width="374" alt="Screen Shot 2022-06-08 at 12 44 10" src="https://user-images.githubusercontent.com/5025816/172660858-23b104f9-5fb8-45d2-a5cd-fb61aead3d2d.png">

### Desktop
<img width="1991" alt="Screen Shot 2022-06-08 at 12 46 58" src="https://user-images.githubusercontent.com/5025816/172660870-97114a53-ef9a-4f06-a9ab-281db5829919.png">
