### PR TITLE
FIX: prevents the jump when loading more

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -268,12 +268,6 @@ export default Component.extend({
               ? newMessages.concat(this.messages)
               : this.messages.concat(newMessages)
           );
-
-          const scrollToMessageArgs = {
-            highlight: false,
-            position: loadingPast ? "top" : "bottom",
-          };
-          this.scrollToMessage(messageId, scrollToMessageArgs);
         }
         this.setCanLoadMoreDetails(messages.resultSetMeta);
         return messages;


### PR DESCRIPTION
So far it feels more annoying than helpful, before this fix the top message would be scrolled to about half of the pane, creating a big jump, now it won't move and you can just continue your scrolling.