### PR TITLE
UI: reduces spacing between avatars in channel onebox

### DIFF
--- a/assets/stylesheets/common/chat-onebox.scss
+++ b/assets/stylesheets/common/chat-onebox.scss
@@ -21,6 +21,7 @@
 
       .avatar {
         aspect-ratio: 30 / 30;
+        margin-right: 0.25rem;
       }
     }
   }


### PR DESCRIPTION
Before:
<img width="220" alt="Screenshot 2022-06-08 at 23 19 49" src="https://user-images.githubusercontent.com/339945/172719439-cc9cd59b-6ee8-4bca-9bc6-979dea143718.png">

After:
<img width="246" alt="Screenshot 2022-06-08 at 23 19 42" src="https://user-images.githubusercontent.com/339945/172719429-dcf37b44-2288-4730-9351-f0927e19b487.png">


