### PR TITLE
DEV: Fix flakey chat window tests

### DIFF
--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -270,6 +270,7 @@ acceptance("Discourse Chat - without unread", function (needs) {
   });
 
   test("Clicking mention notification from outside chat opens the float", async function (assert) {
+    this.chatService.set("chatWindowFullPage", false);
     await visit("/t/internationalization-localization/280");
     await click(".header-dropdown-toggle.current-user");
     await click("#quick-access-notifications .chat-mention");

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -1319,6 +1319,7 @@ acceptance(
     test("Chat float open to DM channel with unread messages with sidebar off", async function (assert) {
       await visit("/t/internationalization-localization/280");
       this.chatService.set("sidebarActive", false);
+      this.chatService.set("chatWindowFullPage", false);
       await click(".header-dropdown-toggle.open-chat");
       const chatContainer = query(".topic-chat-container");
       assert.ok(chatContainer.classList.contains("channel-75"));

--- a/test/javascripts/unit/lib/chat-window-store-test.js
+++ b/test/javascripts/unit/lib/chat-window-store-test.js
@@ -4,6 +4,7 @@ import { test } from "qunit";
 discourseModule("Discourse Chat | Unit | chat-window-store", function (hooks) {
   hooks.beforeEach(function () {
     this.chatWindowStore = this.container.lookup("service:chat-window-store");
+    this.chatWindowStore.set("fullPage", false);
   });
 
   test("defaults", function (assert) {

--- a/test/javascripts/unit/lib/chat-window-store-test.js
+++ b/test/javascripts/unit/lib/chat-window-store-test.js
@@ -4,6 +4,9 @@ import { test } from "qunit";
 discourseModule("Discourse Chat | Unit | chat-window-store", function (hooks) {
   hooks.beforeEach(function () {
     this.chatWindowStore = this.container.lookup("service:chat-window-store");
+  });
+
+  hooks.afterEach(function () {
     this.chatWindowStore.set("fullPage", false);
   });
 


### PR DESCRIPTION
Reset chat window state seems to help in these tests. They are passing
locally now at least.
