### PR TITLE
FIX: N1 in chat channels controller index querying chat_channel_archives

### DIFF
--- a/app/serializers/chat_channel_serializer.rb
+++ b/app/serializers/chat_channel_serializer.rb
@@ -54,7 +54,7 @@ class ChatChannelSerializer < ApplicationSerializer
   end
 
   def include_archive_status?
-    scope.is_staff? && archive.present?
+    scope.is_staff? && object.archived? && archive.present?
   end
 
   def archive_completed

--- a/lib/chat_channel_fetcher.rb
+++ b/lib/chat_channel_fetcher.rb
@@ -59,7 +59,7 @@ module DiscourseChat::ChatChannelFetcher
   end
 
   def self.secured_public_channels(guardian, memberships, scope_with_membership: true, filter: nil)
-    channels = ChatChannel.includes(:chatable)
+    channels = ChatChannel.includes(:chatable, :chat_channel_archive)
       .joins("LEFT JOIN categories ON categories.id = chat_channels.chatable_id AND chat_channels.chatable_type = 'Category'")
       .joins("LEFT JOIN topics ON topics.id = chat_channels.chatable_id AND chat_channels.chatable_type = 'Topic'")
       .where(

--- a/spec/serializer/chat_channel_serializer_spec.rb
+++ b/spec/serializer/chat_channel_serializer_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ChatChannelSerializer do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:admin) { Fabricate(:admin) }
+  fab!(:chat_channel) { Fabricate(:chat_channel) }
+  let(:guardian_user) { user }
+  let(:guardian) { Guardian.new(guardian_user) }
+  subject do
+    described_class.new(chat_channel, scope: guardian, root: nil)
+  end
+
+  describe "archive status" do
+    context "when user is not staff" do
+      let(:guardian_user) { user }
+
+      it "does not return any sort of archive status" do
+        expect(subject.as_json.key?(:archive_completed)).to eq(false)
+      end
+    end
+
+    context "when user is staff" do
+      let(:guardian_user) { admin }
+
+      it "includes the archive status if the channel is archived and the archive record exists" do
+        expect(subject.as_json.key?(:archive_completed)).to eq(false)
+
+        chat_channel.update!(status: ChatChannel.statuses[:archived])
+        expect(subject.as_json.key?(:archive_completed)).to eq(false)
+
+        ChatChannelArchive.create!(
+          chat_channel: chat_channel,
+          archived_by: admin,
+          destination_topic_title: "This will be the archive topic",
+          total_messages: 10
+        )
+        chat_channel.reload
+        expect(subject.as_json.key?(:archive_completed)).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We were getting N1 queries with the archive record for
a channel when listing all public channels. This is mitigated
by:

  a) only trying to query for the archive record if the channel
     status is archived and
  b) including the channel archive record when querying all public
     chat channels