### PR TITLE
DEV: creates membership when reacting

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -138,9 +138,9 @@ export default Component.extend({
     this._super(...arguments);
 
     this.set("targetMessageId", this.chat.messageId);
+
     if (this.registeredChatChannelId !== this.chatChannel.id) {
       this._cleanRegisteredChatChannelId();
-
       this.messageLookup = {};
       this.set("allPastMessagesLoaded", false);
       this.cancelEditing();
@@ -1049,9 +1049,7 @@ export default Component.extend({
           },
         }).then(() => {
           this.chat.forceRefreshChannels();
-          this.onSwitchChannel(ChatChannel.create(c), {
-            replace: true,
-          });
+          this.onSwitchChannel(ChatChannel.create(c));
         })
       )
       .finally(() => {

--- a/assets/javascripts/discourse/components/chat-message.js
+++ b/assets/javascripts/discourse/components/chat-message.js
@@ -16,7 +16,6 @@ import { cancel, later, once, schedule } from "@ember/runloop";
 import { clipboardCopy } from "discourse/lib/utilities";
 import { inject as service } from "@ember/service";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import { Promise } from "rsvp";
 
 let _chatMessageDecorators = [];
 

--- a/assets/javascripts/discourse/components/chat-message.js
+++ b/assets/javascripts/discourse/components/chat-message.js
@@ -617,26 +617,29 @@ export default Component.extend({
       this.set("isHovered", false);
     }
 
-    // TODO: ideally all react logic wouldn't be on message but chat channel
-    // or at least chat-live-pane, this would avoid extra complexity
-    let promise;
-    if (this.previewing) {
-      promise = this.chat.upsertDmChannelForUser(
-        this.chatChannel,
-        this.currentUser
-      );
-    } else {
-      promise = Promise.resolve();
-    }
+    this._loadingReactions.push(emoji);
+    this._updateReactionsList(emoji, reactAction, this.currentUser);
 
-    promise.then(() => {
-      this._loadingReactions.push(emoji);
-      this._updateReactionsList(emoji, reactAction, this.currentUser);
-      this._publishReaction(emoji, reactAction);
+    return this._publishReaction(emoji, reactAction).then(() => {
       this.notifyPropertyChange("emojiReactions");
 
-      if (this.previewing) {
-        this.onSwitchChannel(this.chatChannel, { replace: true });
+      // creating reaction will create a membership if not present
+      // so we will fully refresh if we were previewing
+      if (this.previewing || this.chatChannel.isDraft) {
+        this.chat.forceRefreshChannels().then(() => {
+          return this.chat
+            .getChannelBy("id", this.chatChannel.id)
+            .then((reactedChannel) => {
+              this.onSwitchChannel(reactedChannel);
+            })
+            .finally(() => {
+              if (this.isDestroyed || this.isDestroying) {
+                return;
+              }
+
+              this.set("previewing", false);
+            });
+        });
       }
     });
   },

--- a/assets/javascripts/discourse/components/direct-message-creator.js
+++ b/assets/javascripts/discourse/components/direct-message-creator.js
@@ -318,10 +318,7 @@ export default Component.extend({
   _fetchPreviewedChannel() {
     if (isEmpty(this.channel.chatable.users)) {
       this.channel.set("id", "draft");
-      this.onSwitchChannel?.(this.channel, {
-        replace: true,
-        transition: false,
-      });
+      this.onSwitchChannel?.(this.channel);
       return;
     }
 
@@ -332,10 +329,7 @@ export default Component.extend({
       .catch((error) => {
         if (error?.jqXHR?.status === 404) {
           this.channel.set("id", "draft");
-          this.onSwitchChannel?.(this.channel, {
-            replace: true,
-            transition: false,
-          });
+          this.onSwitchChannel?.(this.channel);
         } else {
           popupAjaxError(error);
         }
@@ -347,10 +341,7 @@ export default Component.extend({
         }
 
         this.channel.set("id", response.chat_channel.id);
-        this.onSwitchChannel?.(this.channel, {
-          replace: true,
-          transition: false,
-        });
+        this.onSwitchChannel?.(this.channel);
       })
       .catch(popupAjaxError)
       .finally(() => {

--- a/assets/javascripts/discourse/components/full-page-chat.js
+++ b/assets/javascripts/discourse/components/full-page-chat.js
@@ -4,7 +4,6 @@ import { action } from "@ember/object";
 import { reads } from "@ember/object/computed";
 import { schedule } from "@ember/runloop";
 import { inject as service } from "@ember/service";
-import { Promise } from "rsvp";
 
 export default Component.extend({
   tagName: "",

--- a/assets/javascripts/discourse/components/full-page-chat.js
+++ b/assets/javascripts/discourse/components/full-page-chat.js
@@ -4,6 +4,7 @@ import { action } from "@ember/object";
 import { reads } from "@ember/object/computed";
 import { schedule } from "@ember/runloop";
 import { inject as service } from "@ember/service";
+import { Promise } from "rsvp";
 
 export default Component.extend({
   tagName: "",
@@ -86,7 +87,7 @@ export default Component.extend({
     event.stopPropagation();
 
     const composer = document.querySelector(".chat-composer-input");
-    if (composer && !this.chatChannel.isDraft) {
+    if (composer && !this.chat.activeChannel.isDraft) {
       this.appEvents.trigger("chat:insert-text", event.key);
       composer.focus();
     }
@@ -124,7 +125,7 @@ export default Component.extend({
   },
 
   _refreshChannel(channelId) {
-    if (this.chatChannel.id === channelId) {
+    if (this.chat.activeChannel?.id === channelId) {
       this.refreshModel(true);
     }
   },
@@ -135,20 +136,9 @@ export default Component.extend({
   },
 
   @action
-  switchChannel(channel, options = {}) {
-    options = Object.assign({}, { replace: false, transition: true }, options);
-
-    if (options.replace) {
-      this.set("chatChannel", null);
-      this.set("chatChannel", channel);
-    }
-
-    if (
-      options.transition &&
-      (options.replace || channel.id !== this.chatChannel?.id)
-    ) {
-      return this.chat.openChannel(channel);
-    }
+  switchChannel(channel) {
+    this.chat.setActiveChannel(channel);
+    return this.chat.openChannel(channel);
   },
 
   _handleFocusChanged(hasFocus) {

--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -22,7 +22,6 @@ export default Component.extend({
   loading: false,
   expanded: true, // TODO - false when not first-load topic
   showClose: true, // TODO - false when on same topic
-  expectPageChange: false,
   sizeTimer: null,
   rafTimer: null,
   view: null,
@@ -365,7 +364,6 @@ export default Component.extend({
       this.set("view", CHAT_VIEW);
       this.set("loading", false);
       this.set("hidden", false);
-      this.set("expectPageChange", false);
 
       next(() => {
         resolve();

--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -202,7 +202,7 @@ export default Component.extend({
     this.element.style.setProperty("--composer-height", "40px");
   },
 
-  @discourseComputed("hidden", "expanded", "activeChannel")
+  @discourseComputed("hidden", "expanded", "chat.activeChannel")
   containerClassNames(hidden, expanded, activeChannel) {
     const classNames = ["topic-chat-container"];
     if (expanded) {

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -481,12 +481,13 @@ export default Service.extend({
     return this._openFoundChannelAtMessage(channel);
   },
 
-  _openFoundChannelAtMessage(channel, messageId = null) {
+  async _openFoundChannelAtMessage(channel, messageId = null) {
     if (
       this.router.currentRouteName === "chat.channel" &&
       this.router.currentRoute.params.channelTitle === channel.title
     ) {
       this._fireOpenMessageAppEvent(messageId);
+      return Promise.resolve();
     } else if (
       Site.currentProp("mobileView") ||
       this.router.currentRouteName === "chat" ||
@@ -504,6 +505,7 @@ export default Service.extend({
       ).promise;
     } else {
       this._fireOpenFloatAppEvent(channel, messageId);
+      return Promise.resolve();
     }
   },
 

--- a/assets/javascripts/discourse/templates/components/full-page-chat.hbs
+++ b/assets/javascripts/discourse/templates/components/full-page-chat.hbs
@@ -4,7 +4,7 @@
   {{/if}}
 
   {{chat-live-pane
-    chatChannel=chatChannel
+    chatChannel=chat.activeChannel
     expanded=true
     floatHidden=false
     fullPage=true

--- a/assets/javascripts/discourse/templates/components/topic-chat-float.hbs
+++ b/assets/javascripts/discourse/templates/components/topic-chat-float.hbs
@@ -1,5 +1,8 @@
 <div class="chat-drawer">
-  <div class={{containerClassNames}} data-chat-channel-id={{activeChannel.id}}>
+  <div
+    class={{containerClassNames}}
+    data-chat-channel-id={{chat.activeChannel.id}}
+  >
     <div
       role="region"
       aria-label={{i18n "chat.aria_roles.header"}}
@@ -15,9 +18,9 @@
           }}
         {{/if}}
 
-        {{#if activeChannel}}
+        {{#if chat.activeChannel}}
           {{chat-channel-title
-            channel=activeChannel
+            channel=chat.activeChannel
             onClick=(action "onChannelTitleClick")
             onSelectChannel=(action "switchChannel")
           }}
@@ -54,9 +57,9 @@
 
     <div class="topic-chat-drawer-content">
       {{#if chatView}}
-        {{#if this.activeChannel}}
+        {{#if chat.activeChannel}}
           {{chat-live-pane
-            chatChannel=activeChannel
+            chatChannel=chat.activeChannel
             expanded=this.expanded
             floatHidden=this.hidden
             fullPage=false

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -45,7 +45,6 @@ en:
       max_reactions_limit_reached: "New reactions are not allowed on this message."
       message_move_invalid_channel: "The source and destination channel must be public channels."
       message_move_no_messages_found: "No messages were found with the provided message IDs."
-      cannot_react_without_joining: "You must join the channel first to react to messages. Send a message or join the channel manually from the channel list."
     reviewables:
       actions:
         agree:

--- a/lib/chat_message_reactor.rb
+++ b/lib/chat_message_reactor.rb
@@ -14,29 +14,34 @@ class DiscourseChat::ChatMessageReactor
   def react!(message_id:, react_action:, emoji:)
     @guardian.ensure_can_see_chat_channel!(@chat_channel)
     @guardian.ensure_can_react!
-
     validate_channel_status!
-
-    if ![ADD_REACTION, REMOVE_REACTION].include?(react_action) || !Emoji.exists?(emoji)
-      raise Discourse::InvalidParameters
-    end
-
-    @chat_message = ChatMessage.find_by(id: message_id, chat_channel: @chat_channel)
-    raise Discourse::NotFound unless @chat_message
-
-    validate_max_reactions!(react_action, emoji)
+    validate_reaction!(react_action, emoji)
+    message = ensure_chat_message!(message_id)
+    validate_max_reactions!(message, react_action, emoji)
 
     ActiveRecord::Base.transaction do
       enforce_channel_membership!
-      execute_action(react_action, emoji)
+      create_reaction(message, react_action, emoji)
     end
 
-    publish_reaction(react_action, emoji)
+    publish_reaction(message, react_action, emoji)
 
-    @chat_message
+    message
   end
 
   private
+
+  def ensure_chat_message!(message_id)
+    message = ChatMessage.find_by(id: message_id, chat_channel: @chat_channel)
+    raise Discourse::NotFound unless message
+    message
+  end
+
+  def validate_reaction!(react_action, emoji)
+    if ![ADD_REACTION, REMOVE_REACTION].include?(react_action) || !Emoji.exists?(emoji)
+      raise Discourse::InvalidParameters
+    end
+  end
 
   def enforce_channel_membership!
     existing_membership = UserChatChannelMembership.find_or_initialize_by(
@@ -60,10 +65,10 @@ class DiscourseChat::ChatMessageReactor
     )
   end
 
-  def validate_max_reactions!(react_action, emoji)
+  def validate_max_reactions!(message, react_action, emoji)
     if react_action == ADD_REACTION &&
-      @chat_message.reactions.count('DISTINCT emoji') >= MAX_REACTIONS_LIMIT &&
-      !@chat_message.reactions.exists?(emoji: emoji)
+      message.reactions.count('DISTINCT emoji') >= MAX_REACTIONS_LIMIT &&
+      !message.reactions.exists?(emoji: emoji)
 
       raise Discourse::InvalidAccess.new(
         nil,
@@ -73,18 +78,18 @@ class DiscourseChat::ChatMessageReactor
     end
   end
 
-  def execute_action(react_action, emoji)
+  def create_reaction(message, react_action, emoji)
     if react_action == ADD_REACTION
-      @chat_message.reactions.find_or_create_by!(user: @user, emoji: emoji)
+      message.reactions.find_or_create_by!(user: @user, emoji: emoji)
     else
-      @chat_message.reactions.where(user: @user, emoji: emoji).destroy_all
+      message.reactions.where(user: @user, emoji: emoji).destroy_all
     end
   end
 
-  def publish_reaction(react_action, emoji)
+  def publish_reaction(message, react_action, emoji)
     ChatPublisher.publish_reaction!(
       @chat_channel,
-      @chat_message,
+      message,
       react_action,
       @user,
       emoji

--- a/spec/lib/chat_message_reactor_spec.rb
+++ b/spec/lib/chat_message_reactor_spec.rb
@@ -1,0 +1,230 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DiscourseChat::ChatMessageReactor do
+  fab!(:reacting_user) { Fabricate(:user) }
+  fab!(:chat_channel) { Fabricate(:chat_channel) }
+  fab!(:reactor) { described_class.new(reacting_user, chat_channel) }
+  fab!(:message_1) { Fabricate(:chat_message, chat_channel: chat_channel, user: reacting_user) }
+
+  describe '#react!' do
+    context 'user can’t see this channel' do
+      fab!(:chatable) { Fabricate(:direct_message_channel) }
+      fab!(:chat_channel) { Fabricate(:chat_channel, chatable: chatable) }
+      fab!(:message_1) { Fabricate(:chat_message, chat_channel: chat_channel) }
+      fab!(:reactor) { described_class.new(reacting_user, chat_channel) }
+
+      it 'raises an error' do
+        expect {
+          reactor.react!(message_id: message_1.id, react_action: :something, emoji: ':+1:')
+        }.to raise_error(Discourse::InvalidAccess)
+      end
+    end
+
+    context 'user can see this channel' do
+      context 'removing a reaction' do
+        context 'the reaction exists' do
+          before do
+            Fabricate(:chat_message_reaction, chat_message: message_1, user: reacting_user, emoji: ':+1:')
+          end
+
+          it 'removes the reaction' do
+            ChatPublisher.expects(:publish_reaction!).once
+            
+            expect {
+              reactor.react!(message_id: message_1.id, react_action: :remove, emoji: ':+1:')
+            }.to change(ChatMessageReaction, :count).by(-1)
+            
+          end
+
+          context 'the user is not member of channel' do
+            it 'creates a membership' do
+              expect {
+                reactor.react!(message_id: message_1.id, react_action: :remove, emoji: ':+1:')
+              }.to change(UserChatChannelMembership, :count).by(1)
+            end
+          end
+
+          context 'the user is member of channel' do
+            before do
+              Fabricate(:user_chat_channel_membership, chat_channel: chat_channel, user: reacting_user)
+            end
+
+            it 'doesn’t create a membership' do
+              expect {
+                reactor.react!(message_id: message_1.id, react_action: :remove, emoji: ':+1:')
+              }.to change(UserChatChannelMembership, :count).by(0)
+            end
+          end
+        end
+
+        context 'the reaction doesn’t exist' do
+          it 'doesn’t remove any reaction' do
+            ChatPublisher.expects(:publish_reaction!).once
+
+            expect {
+              reactor.react!(message_id: message_1.id, react_action: :remove, emoji: ':+1:')
+            }.to change(ChatMessageReaction, :count).by(0)
+          end
+        end
+      end
+
+      context 'adding a reaction' do
+        context 'a reaction with this emoji exists' do
+          before do
+            reactor.react!(message_id: message_1.id, react_action: :add, emoji: ':+1:')
+          end
+
+          it 'doesn’t create a new reaction' do
+            ChatPublisher.expects(:publish_reaction!).once
+
+            expect {
+              reactor.react!(message_id: message_1.id, react_action: :add, emoji: ':+1:')
+            }.to change(ChatMessageReaction, :count).by(0)
+          end
+        end
+
+        context 'a reaction with this emoji doesn’t exist' do
+          it 'doesn’t create a new reaction' do
+            ChatPublisher.expects(:publish_reaction!).once
+            
+            expect {
+              reactor.react!(message_id: message_1.id, react_action: :add, emoji: ':+1:')
+            }.to change(ChatMessageReaction, :count).by(1)
+          end
+        end
+      end
+
+      context 'react_action is invalid' do
+        it 'raises an error' do
+          expect {
+            reactor.react!(message_id: message_1.id, react_action: :something, emoji: ':+1:')
+          }.to raise_error(Discourse::InvalidParameters)
+        end
+      end
+
+      context 'emoji is invalid' do
+        it 'raises an error' do
+          expect {
+            reactor.react!(message_id: message_1.id, react_action: :add, emoji: ':foo-bar-baz:')
+          }.to raise_error(Discourse::InvalidParameters)
+        end
+      end
+
+      context 'max reactions reached' do
+        before do
+          emojis = Emoji.all.slice(0, DiscourseChat::ChatMessageReactor::MAX_REACTIONS_LIMIT)
+          emojis.each do |emoji|
+            Fabricate(:chat_message_reaction, chat_message: message_1, emoji: emoji)
+          end
+        end
+
+        context 'adding a new reaction' do
+          it 'raises an error' do
+            expect {
+              reactor.react!(message_id: message_1.id, react_action: :add, emoji: ':heart:')
+            }.to raise_error(Discourse::InvalidAccess)
+          end
+        end
+
+        context 'removing reaction' do
+          it 'doesn’t raise an error' do
+            expect {
+              reactor.react!(message_id: message_1.id, react_action: :remove, emoji: Emoji.all.first)
+            }.to_not raise_error(Discourse::InvalidAccess)
+          end
+        end
+      end
+
+      context 'user is staff' do
+        fab!(:reacting_user) { Fabricate(:admin) }
+        fab!(:reactor) { described_class.new(reacting_user, chat_channel) }
+
+        context 'channel is opened' do
+          it 'doesn’t raise an error' do
+            expect {
+              reactor.react!(message_id: message_1.id, react_action: :add, emoji: ':+1:')
+            }.to_not raise_error(Discourse::InvalidAccess)
+          end
+        end
+
+        context 'channel is archived' do
+          fab!(:chat_channel) { Fabricate(:chat_channel, status: :archived) }
+          fab!(:reactor) { described_class.new(reacting_user, chat_channel) }
+
+          it 'raises an error' do
+            expect {
+              reactor.react!(message_id: message_1.id, react_action: :add, emoji: ':+1:')
+            }.to raise_error(Discourse::InvalidAccess)
+          end
+        end
+        
+        context 'channel is closed' do
+          fab!(:chat_channel) { Fabricate(:chat_channel, status: :closed) }
+          fab!(:reactor) { described_class.new(reacting_user, chat_channel) }
+
+          it 'doesn’t raise an error' do
+            expect {
+              reactor.react!(message_id: message_1.id, react_action: :add, emoji: ':+1:')
+            }.to_not raise_error(Discourse::InvalidAccess)
+          end
+        end
+        
+        context 'channel is read only' do
+          fab!(:chat_channel) { Fabricate(:chat_channel, status: :read_only) }
+          fab!(:reactor) { described_class.new(reacting_user, chat_channel) }
+
+          it 'raises an error' do
+            expect {
+              reactor.react!(message_id: message_1.id, react_action: :add, emoji: ':+1:')
+            }.to raise_error(Discourse::InvalidAccess)
+          end
+        end
+      end
+
+      context 'user is not staff' do
+        context 'channel is opened' do
+          it 'doesn’t raise an error' do
+            expect {
+              reactor.react!(message_id: message_1.id, react_action: :add, emoji: ':+1:')
+            }.to_not raise_error(Discourse::InvalidAccess)
+          end
+        end
+
+        context 'channel is archived' do
+          fab!(:chat_channel) { Fabricate(:chat_channel, status: :archived) }
+          fab!(:reactor) { described_class.new(reacting_user, chat_channel) }
+
+          it 'raises an error' do
+            expect {
+              reactor.react!(message_id: message_1.id, react_action: :add, emoji: ':+1:')
+            }.to raise_error(Discourse::InvalidAccess)
+          end
+        end
+        
+        context 'channel is closed' do
+          fab!(:chat_channel) { Fabricate(:chat_channel, status: :closed) }
+          fab!(:reactor) { described_class.new(reacting_user, chat_channel) }
+
+          it 'raises an error' do
+            expect {
+              reactor.react!(message_id: message_1.id, react_action: :add, emoji: ':+1:')
+            }.to raise_error(Discourse::InvalidAccess)
+          end
+        end
+        
+        context 'channel is read only' do
+          fab!(:chat_channel) { Fabricate(:chat_channel, status: :read_only) }
+          fab!(:reactor) { described_class.new(reacting_user, chat_channel) }
+
+          it 'raises an error' do
+            expect {
+              reactor.react!(message_id: message_1.id, react_action: :add, emoji: ':+1:')
+            }.to raise_error(Discourse::InvalidAccess)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/chat_message_reactor_spec.rb
+++ b/spec/lib/chat_message_reactor_spec.rb
@@ -35,7 +35,7 @@ describe DiscourseChat::ChatMessageReactor do
             expect {
               reactor.react!(message_id: message_1.id, react_action: :remove, emoji: ':+1:')
             }.to change(ChatMessageReaction, :count).by(-1)
-            
+
           end
 
           context 'the user is not member of channel' do
@@ -88,7 +88,7 @@ describe DiscourseChat::ChatMessageReactor do
         context 'a reaction with this emoji doesn’t exist' do
           it 'doesn’t create a new reaction' do
             ChatPublisher.expects(:publish_reaction!).once
-            
+
             expect {
               reactor.react!(message_id: message_1.id, react_action: :add, emoji: ':+1:')
             }.to change(ChatMessageReaction, :count).by(1)
@@ -170,7 +170,7 @@ describe DiscourseChat::ChatMessageReactor do
             }.to_not raise_error(Discourse::InvalidAccess)
           end
         end
-        
+
         context 'channel is read only' do
           fab!(:chat_channel) { Fabricate(:chat_channel, status: :read_only) }
           fab!(:reactor) { described_class.new(reacting_user, chat_channel) }

--- a/spec/lib/chat_message_reactor_spec.rb
+++ b/spec/lib/chat_message_reactor_spec.rb
@@ -31,7 +31,7 @@ describe DiscourseChat::ChatMessageReactor do
 
           it 'removes the reaction' do
             ChatPublisher.expects(:publish_reaction!).once
-            
+
             expect {
               reactor.react!(message_id: message_1.id, react_action: :remove, emoji: ':+1:')
             }.to change(ChatMessageReaction, :count).by(-1)
@@ -159,7 +159,7 @@ describe DiscourseChat::ChatMessageReactor do
             }.to raise_error(Discourse::InvalidAccess)
           end
         end
-        
+
         context 'channel is closed' do
           fab!(:chat_channel) { Fabricate(:chat_channel, status: :closed) }
           fab!(:reactor) { described_class.new(reacting_user, chat_channel) }
@@ -202,7 +202,7 @@ describe DiscourseChat::ChatMessageReactor do
             }.to raise_error(Discourse::InvalidAccess)
           end
         end
-        
+
         context 'channel is closed' do
           fab!(:chat_channel) { Fabricate(:chat_channel, status: :closed) }
           fab!(:reactor) { described_class.new(reacting_user, chat_channel) }
@@ -213,7 +213,7 @@ describe DiscourseChat::ChatMessageReactor do
             }.to raise_error(Discourse::InvalidAccess)
           end
         end
-        
+
         context 'channel is read only' do
           fab!(:chat_channel) { Fabricate(:chat_channel, status: :read_only) }
           fab!(:reactor) { described_class.new(reacting_user, chat_channel) }

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -804,9 +804,12 @@ RSpec.describe DiscourseChat::ChatController do
       expect(response.status).to eq(400)
     end
 
-    it "doesn’t error when user tries to react to channel without a membership record" do
+    it "creates a membership when reacting to channel without a membership record" do
       sign_in(user)
-      put "/chat/#{chat_channel_no_memberships.id}/react/#{chat_message_no_memberships.id}.json", params: { emoji: ":heart:", react_action: "add" }
+      
+      expect {
+        put "/chat/#{chat_channel_no_memberships.id}/react/#{chat_message_no_memberships.id}.json", params: { emoji: ":heart:", react_action: "add" }
+      }.to change { UserChatChannelMembership.count }.by(1)
       expect(response.status).to eq(200)
     end
 

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -804,11 +804,10 @@ RSpec.describe DiscourseChat::ChatController do
       expect(response.status).to eq(400)
     end
 
-    it "errors when user tries to react to channel without a membership record" do
+    it "doesn’t error when user tries to react to channel without a membership record" do
       sign_in(user)
       put "/chat/#{chat_channel_no_memberships.id}/react/#{chat_message_no_memberships.id}.json", params: { emoji: ":heart:", react_action: "add" }
-      expect(response.status).to eq(403)
-      expect(response.parsed_body["errors"]).to include(I18n.t("chat.errors.cannot_react_without_joining"))
+      expect(response.status).to eq(200)
     end
 
     it "errors when user tries to react to private channel they can't access" do

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -806,7 +806,7 @@ RSpec.describe DiscourseChat::ChatController do
 
     it "creates a membership when reacting to channel without a membership record" do
       sign_in(user)
-      
+
       expect {
         put "/chat/#{chat_channel_no_memberships.id}/react/#{chat_message_no_memberships.id}.json", params: { emoji: ":heart:", react_action: "add" }
       }.to change { UserChatChannelMembership.count }.by(1)


### PR DESCRIPTION
With this change reacting to a preview channel or a draft channel, will create a membership, the reaction and then navigate to the actual channel.

To make this change easier/cleaner I also made two other changes:
- rely on `chat.activeChannel` instead of recreating  an intermediate variable in full-page-chat and topic-chat-float
- simplify the `switchChannel` code, I suspect it might cause few regressions, but those are not tested ATM and I will fix/tests them as they come up

It also creates extensive specs for ChatMessageReactor which had none.