### PR TITLE
FIX: Chat quote interfering with oneboxes

### DIFF
--- a/assets/javascripts/lib/discourse-markdown/discourse-chat-transcript.js
+++ b/assets/javascripts/lib/discourse-markdown/discourse-chat-transcript.js
@@ -152,7 +152,7 @@ const chatTranscriptRule = {
     messagesToken.attrs = [["class", "chat-transcript-messages"]];
 
     // rendering chat message content with limited markdown rule subset
-    const token = state.push("html_raw", "", 0);
+    const token = state.push("html_raw", "", 1);
     token.content = customMarkdownCookFn(content);
     state.push("html_raw", "", -1);
 

--- a/spec/integration/post_chat_quote_spec.rb
+++ b/spec/integration/post_chat_quote_spec.rb
@@ -139,4 +139,65 @@ describe "chat bbcode quoting in posts" do
       </div>
     COOKED
   end
+
+  it "correctly renders inline and non-inline oneboxes combined with chat quotes" do
+    full_onebox_html = <<~HTML.chomp
+      <aside class="onebox wikipedia" data-onebox-src="https://en.wikipedia.org/wiki/Hyperlink" dir="ltr">
+        <header class="source">
+          <svg class="fa d-icon d-icon-fab-wikipedia-w svg-icon svg-string" xmlns="http://www.w3.org/2000/svg">
+            <use href="#fab-wikipedia-w"></use>
+          </svg>
+          <a href="https://en.wikipedia.org/wiki/Hyperlink" target="_blank" rel="nofollow ugc noopener" tabindex="-1">en.wikipedia.org</a>
+        </header>
+        <article class="onebox-body">
+          <img src="//upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Hyperlink-Wikipedia.svg/250px-Hyperlink-Wikipedia.svg.png" class="thumbnail">
+          <h3>
+            <a href="https://en.wikipedia.org/wiki/Hyperlink" target="_blank" rel="nofollow ugc noopener" tabindex="-1">Hyperlink | History</a>
+          </h3>
+          <p>The term "link" was coined in 1965 (or possibly 1964) by Ted Nelson at the start of Project Xanadu. Nelson had been inspired by "As We May Think", a popular 1945 essay by Vannevar Bush. In the essay, Bush described a microfilm-based machine (the Memex) in which one could link any two pages of information into a "trail" of related information, and then scroll back and forth among pages in a trail as if they were on a single microfilm reel. In a series of books and articles published from 1964 thr...</p>
+        </article>
+        <div class="onebox-metadata"></div>
+        <div style="clear: both"></div>
+      </aside>
+    HTML
+    SiteSetting.enable_inline_onebox_on_all_domains = true
+    Oneboxer.stubs(:cached_onebox).with("https://en.wikipedia.org/wiki/Hyperlink").returns(full_onebox_html)
+    stub_request(:get, "https://en.wikipedia.org/wiki/Hyperlink").to_return(
+      status: 200,
+      body: "<html><head><title>Hyperlink - Wikipedia</title></head></html>"
+    )
+    stub_request(:get, "http://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Hyperlink-Wikipedia.svg/250px-Hyperlink-Wikipedia.svg.png").to_return(status: 200, body: "", headers: {})
+    post.update!(raw: <<~MD)
+https://en.wikipedia.org/wiki/Hyperlink
+
+[chat quote=\"martin;2321;2022-01-25T05:40:39Z\"]
+This is a chat message.
+[/chat]
+
+https://en.wikipedia.org/wiki/Hyperlink
+
+This is an inline onebox https://en.wikipedia.org/wiki/Hyperlink.
+    MD
+
+    expect(post.cooked.chomp).to eq(<<~COOKED.chomp)
+#{full_onebox_html}
+<div class="discourse-chat-transcript" data-message-id="2321" data-username="martin" data-datetime="2022-01-25T05:40:39Z">
+<div class="chat-transcript-user">
+<div class="chat-transcript-user-avatar"></div>
+<div class="chat-transcript-username">
+martin</div>
+<div class="chat-transcript-datetime">
+<a href="/chat/message/2321" title="2022-01-25T05:40:39Z"></a>
+</div>
+</div>
+<div class="chat-transcript-messages">
+<p>This is a chat message.</p>
+</div>
+</div>
+#{full_onebox_html}
+<p>This is an inline onebox <a href="https://en.wikipedia.org/wiki/Hyperlink" class="inline-onebox-loading" rel="noopener nofollow ugc">https://en.wikipedia.org/wiki/Hyperlink</a>.</p>
+    COOKED
+  ensure
+    InlineOneboxer.invalidate("https://en.wikipedia.org/wiki/Hyperlink")
+  end
 end

--- a/spec/integration/post_chat_quote_spec.rb
+++ b/spec/integration/post_chat_quote_spec.rb
@@ -143,18 +143,11 @@ describe "chat bbcode quoting in posts" do
   it "correctly renders inline and non-inline oneboxes combined with chat quotes" do
     full_onebox_html = <<~HTML.chomp
       <aside class="onebox wikipedia" data-onebox-src="https://en.wikipedia.org/wiki/Hyperlink" dir="ltr">
-        <header class="source">
-          <svg class="fa d-icon d-icon-fab-wikipedia-w svg-icon svg-string" xmlns="http://www.w3.org/2000/svg">
-            <use href="#fab-wikipedia-w"></use>
-          </svg>
-          <a href="https://en.wikipedia.org/wiki/Hyperlink" target="_blank" rel="nofollow ugc noopener" tabindex="-1">en.wikipedia.org</a>
-        </header>
         <article class="onebox-body">
-          <img src="//upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Hyperlink-Wikipedia.svg/250px-Hyperlink-Wikipedia.svg.png" class="thumbnail">
           <h3>
-            <a href="https://en.wikipedia.org/wiki/Hyperlink" target="_blank" rel="nofollow ugc noopener" tabindex="-1">Hyperlink | History</a>
+            <a href="https://en.wikipedia.org/wiki/Hyperlink" target="_blank" rel="nofollow ugc noopener" tabindex="-1">Hyperlink</a>
           </h3>
-          <p>The term "link" was coined in 1965 (or possibly 1964) by Ted Nelson at the start of Project Xanadu. Nelson had been inspired by "As We May Think", a popular 1945 essay by Vannevar Bush. In the essay, Bush described a microfilm-based machine (the Memex) in which one could link any two pages of information into a "trail" of related information, and then scroll back and forth among pages in a trail as if they were on a single microfilm reel. In a series of books and articles published from 1964 thr...</p>
+          <p>This is a test</p>
         </article>
         <div class="onebox-metadata"></div>
         <div style="clear: both"></div>
@@ -166,7 +159,7 @@ describe "chat bbcode quoting in posts" do
       status: 200,
       body: "<html><head><title>Hyperlink - Wikipedia</title></head></html>"
     )
-    stub_request(:get, "http://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Hyperlink-Wikipedia.svg/250px-Hyperlink-Wikipedia.svg.png").to_return(status: 200, body: "", headers: {})
+
     post.update!(raw: <<~MD)
 https://en.wikipedia.org/wiki/Hyperlink
 


### PR DESCRIPTION
A oneline change. Chat quotes render their inner content with the
chat markdown engine with a limited subset of rules, using a
html_raw markdown-it token. However when I first added this I
pushed the token to the state with the wrong level. I had this:

```javascript
// rendering chat message content with limited markdown rule subset
const token = state.push("html_raw", "", 0);
token.content = customMarkdownCookFn(content);
state.push("html_raw", "", -1);
```

But needed this:

```javascript
// rendering chat message content with limited markdown rule subset
const token = state.push("html_raw", "", 1);
token.content = customMarkdownCookFn(content);
state.push("html_raw", "", -1);
```

Spot the difference? (I simply changed the 0 to 1 on the first line).
This was causing the token "level" to go into negatives, which then
broke our onebox.js logic in core. If the previous token level is 0,
then we do a big onebox, otherwise we do an inline onebox because
we assume the link is lower in the HTML heirarchy:

https://github.com/discourse/discourse/blob/0ae7b43018238a883326da950f1e3bbf7e1f87a6/app/assets/javascripts/pretty-text/engines/discourse-markdown/onebox.js#L21-L22

So the level was -1 after a chat quote since the html_raw token
was pushed incorrectly, which meant that any oneboxes after the quote
would render inline.
