### PR TITLE
FIX: Codeblock sizing (message and transcript)

### DIFF
--- a/assets/stylesheets/common/chat-message.scss
+++ b/assets/stylesheets/common/chat-message.scss
@@ -128,6 +128,7 @@
     width: 100%;
 
     code {
+      box-sizing: border-box;
       font-size: var(--font-down-1);
       width: 100%;
     }

--- a/assets/stylesheets/common/chat-transcript.scss
+++ b/assets/stylesheets/common/chat-transcript.scss
@@ -1,11 +1,14 @@
 .discourse-chat-transcript {
   @extend .chat-message-container;
-  display: block;
   min-height: 50px;
   padding: 12px;
   margin: 1rem 0;
 
   @include post-aside;
+
+  .chat-messages-container & {
+    display: block;
+  }
 
   &.chat-transcript-chained {
     margin: 0;


### PR DESCRIPTION
A followup to #932

Checked:

- [x] docked (windowed/drawer)
- [x] isolated (full-screen)
