### PR TITLE
FIX: Correctly place the retention reminder

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -41,11 +41,11 @@
   onSwitchChannel=onSwitchChannel
 }}
 
+{{chat-retention-reminder chatChannel=chatChannel}}
+
 <div class="chat-messages-scroll chat-messages-container">
   {{#conditional-loading-spinner condition=this.loading}}
     {{conditional-loading-spinner condition=this.loadingMoreFuture}}
-
-    {{chat-retention-reminder chatChannel=chatChannel}}
 
     {{#each this.messages as |message|}}
       {{chat-message

--- a/assets/stylesheets/common/chat-retention-reminder.scss
+++ b/assets/stylesheets/common/chat-retention-reminder.scss
@@ -31,5 +31,5 @@
 }
 
 .full-page-chat .chat-retention-reminder {
-  top: 3.5rem;
+  top: 4rem;
 }


### PR DESCRIPTION
Before / After

<img width="380" alt="image" src="https://user-images.githubusercontent.com/66961/173679708-69b08e27-22b8-4e6e-80ba-c8d4e618cac2.png"> <img width="380" alt="image" src="https://user-images.githubusercontent.com/66961/173679606-d32d6d63-dfe2-472a-960a-08127f055424.png">


Checked:

- [x] docked (windowed/drawer)
- [x] isolated (full-screen)
