### PR TITLE
DEV: allows to refresh only notifications and not full page

### DIFF
--- a/assets/javascripts/discourse/components/chat-channel-unread-indicator.js
+++ b/assets/javascripts/discourse/components/chat-channel-unread-indicator.js
@@ -1,6 +1,6 @@
 import discourseComputed from "discourse-common/utils/decorators";
 import Component from "@ember/component";
-import { equal, gt, reads } from "@ember/object/computed";
+import { equal, gt } from "@ember/object/computed";
 import { CHATABLE_TYPES } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 
 export default Component.extend({

--- a/assets/javascripts/discourse/components/chat-channel-unread-indicator.js
+++ b/assets/javascripts/discourse/components/chat-channel-unread-indicator.js
@@ -15,10 +15,11 @@ export default Component.extend({
   hasUnread: gt("unreadCount", 0),
 
   @discourseComputed(
-    "currentUser.chat_channel_tracking_state.@each.{unread_count,unread_mentions}"
+    "currentUser.chat_channel_tracking_state.@each.{unread_count,unread_mentions}",
+    "channel.id"
   )
-  channelTrackingState(state) {
-    return state[this.channel.id];
+  channelTrackingState(state, channelId) {
+    return state?.[channelId];
   },
 
   @discourseComputed(

--- a/assets/javascripts/discourse/components/chat-channel-unread-indicator.js
+++ b/assets/javascripts/discourse/components/chat-channel-unread-indicator.js
@@ -14,23 +14,32 @@ export default Component.extend({
 
   hasUnread: gt("unreadCount", 0),
 
-  currentUserTrackingState: reads("currentUser.chat_channel_tracking_state"),
-
-  @discourseComputed("currentUserTrackingState", "channel", "isDirectMessage")
-  isUrgent(trackingState, channel, isDirectMessage) {
-    if (!channel) {
-      return;
-    }
-
-    return isDirectMessage || trackingState?.[channel.id]?.unread_mentions > 0;
+  @discourseComputed(
+    "currentUser.chat_channel_tracking_state.@each.{unread_count,unread_mentions}"
+  )
+  channelTrackingState(state) {
+    return state[this.channel.id];
   },
 
-  @discourseComputed("currentUserTrackingState", "channel")
-  unreadCount(trackingState, channel) {
+  @discourseComputed(
+    "channelTrackingState.unread_mentions",
+    "channel",
+    "isDirectMessage"
+  )
+  isUrgent(unreadMentions, channel, isDirectMessage) {
     if (!channel) {
       return;
     }
 
-    return trackingState?.[channel.id]?.unread_count || 0;
+    return isDirectMessage || unreadMentions > 0;
+  },
+
+  @discourseComputed("channelTrackingState.unread_count", "channel")
+  unreadCount(unreadCount, channel) {
+    if (!channel) {
+      return;
+    }
+
+    return unreadCount || 0;
   },
 });

--- a/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/assets/javascripts/discourse/initializers/chat-setup.js
@@ -146,6 +146,7 @@ export default {
   @bind
   _handleFocusChanged(hasFocus) {
     if (!hasFocus) {
+      _lastForcedRefreshAt = Date.now();
       return;
     }
 
@@ -157,6 +158,6 @@ export default {
     }
 
     _lastForcedRefreshAt = Date.now();
-    this.chatService.forceRefreshChannels();
+    this.chatService.refreshTrackingState();
   },
 };

--- a/test/javascripts/unit/services/chat-test.js
+++ b/test/javascripts/unit/services/chat-test.js
@@ -1,0 +1,41 @@
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import {
+  chatComposerButtons,
+  chatComposerButtonsDependentKeys,
+  clearChatComposerButtons,
+  registerChatComposerButton,
+} from "discourse/plugins/discourse-chat/discourse/lib/chat-composer-buttons";
+
+acceptance("Discourse Chat | Unit | Service | chat", function (needs) {
+  needs.hooks.beforeEach(function () {
+    Object.defineProperty(this, "chatService", {
+      get: () => this.container.lookup("service:chat"),
+    });
+    Object.defineProperty(this, "currentUser", {
+      get: () => this.container.lookup("current-user:main"),
+    });
+  });
+
+  needs.user();
+
+  needs.pretender((server, helper) => {
+    server.get("/chat/chat_channels.json", () => {
+      return helper.response({
+        public_channels: [{ id: 1, unread_count: 2 }],
+        direct_message_channels: [],
+      });
+    });
+  });
+
+  test("#refreshTrackingState", async function (assert) {
+    this.currentUser.set("chat_channel_tracking_state", {});
+
+    await this.chatService.refreshTrackingState();
+
+    assert.equal(
+      this.currentUser.chat_channel_tracking_state[1].unread_count,
+      2
+    );
+  });
+});

--- a/test/javascripts/unit/services/chat-test.js
+++ b/test/javascripts/unit/services/chat-test.js
@@ -1,11 +1,5 @@
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
-import {
-  chatComposerButtons,
-  chatComposerButtonsDependentKeys,
-  clearChatComposerButtons,
-  registerChatComposerButton,
-} from "discourse/plugins/discourse-chat/discourse/lib/chat-composer-buttons";
 
 acceptance("Discourse Chat | Unit | Service | chat", function (needs) {
   needs.hooks.beforeEach(function () {


### PR DESCRIPTION
- introduces chat#refreshTrackingState
- makes each tracking state an EmberObject to make computation easier
- reset lastForcedRefreshAt when leaving tab
