### PR TITLE
DEV: adds last_emailed_for_chat to ignored columns

### DIFF
--- a/lib/extensions/user_option_extension.rb
+++ b/lib/extensions/user_option_extension.rb
@@ -2,6 +2,12 @@
 
 module DiscourseChat::UserOptionExtension
   def self.prepended(base)
+    if base.ignored_columns
+      base.ignored_columns = base.ignored_columns + [:last_emailed_for_chat]
+    else
+      base.ignored_columns = [:last_emailed_for_chat]
+    end
+
     def base.chat_email_frequencies
       @chat_email_frequencies ||= {
         never: 0,


### PR DESCRIPTION
In commit https://github.com/discourse/discourse-chat/commit/9083e37e40010bd7c9ff0c2f279bbe2bbd5a18e7 the column has been dropped but not added to ignored columns, this is the cause of errors like this one after a migration:

```
ActiveRecord::StatementInvalid (PG::UndefinedColumn: ERROR:  column user_options.last_emailed_for_chat does not exist
LINE 1: ..._mention", "user_options"."chat_email_frequency", "user_opti...
                                                             ^
)
(eval):105:in `exec_params'
app/controllers/application_controller.rb:477:in `handle_theme'
lib/middleware/omniauth_bypass_middleware.rb:71:in `call'
lib/content_security_policy/middleware.rb:12:in `call'
lib/middleware/anonymous_cache.rb:368:in `call'
config/initializers/008-rack-cors.rb:25:in `call'
config/initializers/100-silence_logger.rb:29:in `call'
lib/middleware/enforce_hostname.rb:23:in `call'
lib/middleware/request_tracker.rb:202:in `call'
```

Note I didn't got with a simpler pattern of:

```
base.ignored_columns = [:last_emailed_for_chat]
````

as the current UserOption table in core already has ignored columns defined and that would override it I think.