### PR TITLE
SECURITY: Ensure chat message lookup checks for channel access

### DIFF
--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -865,7 +865,7 @@ export default Service.extend({
   },
 
   _saveDraft(channelId, draft) {
-    const data = { channel_id: channelId };
+    const data = { chat_channel_id: channelId };
     if (draft) {
       data.data = JSON.stringify(draft);
     }

--- a/plugin.rb
+++ b/plugin.rb
@@ -2,7 +2,7 @@
 
 # name: discourse-chat
 # about: Chat inside Discourse
-# version: 0.3
+# version: 0.4
 # authors: Kane York, Mark VanLandingham, Martin Brennan, Joffrey Jaffeux
 # url: https://github.com/discourse/discourse-chat
 # transpile_js: true

--- a/spec/lib/guardian_extensions_spec.rb
+++ b/spec/lib/guardian_extensions_spec.rb
@@ -79,15 +79,15 @@ describe DiscourseChat::GuardianExtensions do
       end
 
       context "for direct message channels" do
-        fab!(:dm_channel) { DirectMessageChannel.create! }
+        fab!(:chatable) { Fabricate(:direct_message_channel) }
+        fab!(:channel) { Fabricate(:chat_channel, chatable: chatable) }
 
-        before do
-          channel.update(chatable_type: "DirectMessageType", chatable: dm_channel)
+        it "returns false if the user is not part of the direct message" do
+          expect(guardian.can_see_chat_channel?(channel)).to eq(false)
         end
 
         it "returns true if the user is part of the direct message" do
-          expect(guardian.can_see_chat_channel?(channel)).to eq(false)
-          DirectMessageUser.create(user: user, direct_message_channel_id: dm_channel.id)
+          DirectMessageUser.create!(user: user, direct_message_channel_id: chatable.id)
           expect(guardian.can_see_chat_channel?(channel)).to eq(true)
         end
       end


### PR DESCRIPTION
This commit primarily fixes a security issue where permissions were not
checked during message lookup.

In addition, a review of the ChatChannelsController and ChatController was
conducted to make sure there was not more holes. They have been
patched, along with the following changes made:

* Refactors ChatBaseController.set_channel_and_chatable_with_access_check to
  use DiscourseChat::ChatChannelFetcher.find_with_access_check directly, and
folds in the different code from the base controller into the fetcher for
consistency.
* Changes the POST /chat/drafts endpoint to use a chat_channel_id parameter
  instead of channel_id for consistency, and ensures channel access is correct
before creating the draft.
* Makes sure many endpoints missing the
  set_channel_and_chatable_with_access_check now have that check, both in the
ChatController and the ChatChannelsController.
* Also deletes some dead code and adds notes.