### PR TITLE
FIX: do not list bookmarks of trashed messages

### DIFF
--- a/lib/chat_message_bookmarkable.rb
+++ b/lib/chat_message_bookmarkable.rb
@@ -19,6 +19,7 @@ class ChatMessageBookmarkable < BaseBookmarkable
     user.bookmarks_of_type("ChatMessage")
       .joins(
         "INNER JOIN chat_messages ON chat_messages.id = bookmarks.bookmarkable_id
+          AND chat_messages.deleted_at IS NULL
           AND bookmarks.bookmarkable_type = 'ChatMessage'"
       )
       .where("chat_messages.chat_channel_id IN (?)", accessible_channel_ids)

--- a/spec/lib/chat_message_bookmarkable_spec.rb
+++ b/spec/lib/chat_message_bookmarkable_spec.rb
@@ -59,6 +59,12 @@ describe ChatMessageBookmarkable do
       guardian = Guardian.new(user)
       expect(subject.perform_list_query(user, guardian).map(&:id)).to match_array([bookmark1.id, bookmark2.id])
     end
+
+    it "does not return bookmarks for deleted messages" do
+      message1.trash!
+      guardian = Guardian.new(user)
+      expect(subject.perform_list_query(user, guardian).map(&:id)).to match_array([bookmark2.id])
+    end
   end
 
   describe "#perform_search_query" do


### PR DESCRIPTION
Messages are trashed and not destroyed, as a result `dependent: :destroy` has no effect on bookmarks and we have to make sure we don't attempt to list these bookmarks.

Before this fix the following repro would cause a 500 when reaching for `/u/:username/bookmarks.json`:

- Open a DM with any user
- Send a message
- Bookmark the message
- Delete the message

```
NoMethodError at /u/tomtom/bookmarks.json
=========================================

undefined method `chat_channel' for nil:NilClass

plugins/discourse-chat/app/serializers/user_chat_message_bookmark_serializer.rb, line 11
----------------------------------------------------------------------------------------

    6     def title
    7       fancy_title
    8     end
    9
   10     def fancy_title
>  11       @fancy_title ||= chat_message.chat_channel.title(scope.user)
   12     end
   13
   14     def cooked
   15       chat_message.cooked
   16     end
```
