### PR TITLE
FIX: ensures a new channel always starts with unread 1

### DIFF
--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -560,11 +560,12 @@ export default Service.extend({
 
     const newChannel = this.processChannel(channel);
     existingChannels.pushObject(newChannel);
-    this.currentUser.chat_channel_tracking_state[channel.id] = {
-      unread_count: 0,
-      unread_mentions: 0,
-      chatable_type: channel.chatable_type,
-    };
+    this.currentUser.chat_channel_tracking_state[channel.id] =
+      EmberObject.create({
+        unread_count: 1,
+        unread_mentions: 0,
+        chatable_type: channel.chatable_type,
+      });
     this.userChatChannelTrackingStateChanged();
     if (!channel.isDirectMessageChannel) {
       this.set("publicChannels", this.sortPublicChannels(this.publicChannels));


### PR DESCRIPTION
Also fixes a bug where the state was not an ember object. Note this is currently way too complicated to test this behavior given the very high complexity and coupling of this codepath.
