### PR TITLE
FIX: ensures msg actions stay in live-pane

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-message-actions-desktop.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message-actions-desktop.hbs
@@ -38,7 +38,7 @@
     {{#if secondaryButtons.length}}
       {{dropdown-select-box
         class="more-buttons"
-        options=(hash icon="ellipsis-v")
+        options=(hash icon="ellipsis-v" placement="bottom-end")
         content=secondaryButtons
         onChange=(action "handlesecondaryButtons")
       }}

--- a/assets/stylesheets/common/chat-message.scss
+++ b/assets/stylesheets/common/chat-message.scss
@@ -252,10 +252,10 @@
 
   position: absolute;
   opacity: 0;
-  padding-left: 4em;
-  padding-top: 0.25em;
+  padding-right: 1rem;
+  padding-top: 0.25rem;
   pointer-events: none;
-  right: 0.25em;
+  right: 0;
   top: -1.5em;
   z-index: 2;
 }


### PR DESCRIPTION
This would also fix a bug in firefox window on large screen (or specific circumstances) where the dropdown would appear under the scrollbar and making it barely usable.
