### PR TITLE
Show hovering when sidebar is on as well

### DIFF
--- a/assets/stylesheets/common/chat-message.scss
+++ b/assets/stylesheets/common/chat-message.scss
@@ -473,15 +473,13 @@
   font-style: italic;
 }
 
-.full-page-chat {
-  .not-mobile-device & .chat-message:hover,
-  .chat-message.chat-message-selected {
-    background: var(--primary-very-low);
-  }
+.chat-message-container:hover,
+.chat-message.chat-message-selected {
+  background: var(--primary-very-low);
+}
 
-  .chat-message.chat-message-bookmarked {
-    background: var(--highlight-low);
-  }
+.chat-message.chat-message-bookmarked {
+  background: var(--highlight-low);
 }
 
 .has-full-page-chat .chat-message .onebox:not(img),


### PR DESCRIPTION
- [x] chat-scoped -- core unaffected

### View mode

- [x] docked (windowed/drawer)
- [x] isolated (full-screen)

### Browsers

- [ ] safari
- [x] chrome
- [ ] firefox

### Device

- [x] desktop – wide screen
- [x] ~~mobile – `?mobile_view=1`~~

### Ember

- [x] ember-cli
- [x] ~~legacy~~

drawer:

https://user-images.githubusercontent.com/1555215/176351384-9051342d-a652-48cd-bc95-45e5fa8fade8.mov



full screen


https://user-images.githubusercontent.com/1555215/176351395-7f68dd33-3920-4f77-a9e9-7b199b46d922.mov




