### PR TITLE
FIX: Allow user to direct message themself again and fix DM inconsistencies

### DIFF
--- a/app/controllers/direct_messages_controller.rb
+++ b/app/controllers/direct_messages_controller.rb
@@ -6,7 +6,7 @@ class DiscourseChat::DirectMessagesController < DiscourseChat::ChatBaseControlle
   def create
     guardian.ensure_can_chat!(current_user)
     users = users_from_usernames(current_user, params)
-    chat_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: current_user, target_users: users)
+    chat_channel = DiscourseChat::DirectMessageChannelCreator.create!(target_users: users)
     render_serialized(chat_channel, ChatChannelSerializer, root: "chat_channel")
   end
 

--- a/app/services/chat_publisher.rb
+++ b/app/services/chat_publisher.rb
@@ -104,12 +104,12 @@ module ChatPublisher
 
   def self.publish_new_direct_message_channel(chat_channel, users)
     users.each do |user|
-      content = ChatChannelSerializer.new(
+      serialized_channel = ChatChannelSerializer.new(
         chat_channel,
         scope: Guardian.new(user), # We need a guardian here for direct messages
         root: :chat_channel
-      )
-      MessageBus.publish("/chat/new-direct-message-channel", content.as_json, user_ids: [user.id])
+      ).to_json
+      MessageBus.publish("/chat/new-direct-message-channel", serialized_channel, user_ids: [user.id])
     end
   end
 

--- a/assets/javascripts/discourse/components/chat-channel-selector-modal-inner.js
+++ b/assets/javascripts/discourse/components/chat-channel-selector-modal-inner.js
@@ -97,7 +97,7 @@ export default Component.extend({
   @action
   switchChannel(channel) {
     if (channel.user) {
-      return this.fetchChannelForUser(channel).then((response) => {
+      return this.fetchOrCreateChannelForUser(channel).then((response) => {
         this.chat
           .startTrackingChannel(ChatChannel.create(response.chat_channel))
           .then((newlyTracked) => {
@@ -159,10 +159,10 @@ export default Component.extend({
   },
 
   @action
-  fetchChannelForUser(user) {
+  fetchOrCreateChannelForUser(user) {
     return ajax("/chat/direct_messages/create.json", {
       method: "POST",
-      data: { usernames: user.username },
+      data: { usernames: [user.username] },
     }).catch(popupAjaxError);
   },
 

--- a/assets/javascripts/discourse/components/chat-draft-channel-screen.js
+++ b/assets/javascripts/discourse/components/chat-draft-channel-screen.js
@@ -19,15 +19,11 @@ export default class ChatDraftChannelScreen extends Component {
     this.onSwitchChannel?.(channel);
   }
 
-  _formatUsernames(users = []) {
-    return users.mapBy("username").uniq().join(",");
-  }
-
   _fetchPreviewedChannel(users) {
     this.set("previewedChannel", null);
 
     return this.chat
-      .getDmChannelForUsernames(this._formatUsernames(users))
+      .getDmChannelForUsernames(users.mapBy("username"))
       .then((response) => {
         this.set(
           "previewedChannel",

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1044,10 +1044,9 @@ export default Component.extend({
     let promise;
 
     if (channel.isDirectMessageChannel || channel.isDraft) {
-      promise = ajax("/chat/direct_messages/create.json", {
-        method: "POST",
-        data: { usernames: channel.chatable.users.mapBy("username") },
-      }).then((response) => ChatChannel.create(response.chat_channel));
+      promise = this.chat.upsertDmChannelForUsernames(
+        channel.chatable.users.mapBy("username")
+      );
     } else {
       promise = ajax(`/chat/chat_channels/${channel.id}/follow`, {
         method: "POST",

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -839,10 +839,13 @@ export default Service.extend({
     return this.upsertDmChannelForUsernames(usernames);
   },
 
+  // @param {array} usernames - The usernames to create or fetch the direct message
+  // channel for. The current user will automatically be included in the channel
+  // when it is created.
   upsertDmChannelForUsernames(usernames) {
     return ajax("/chat/direct_messages/create.json", {
       method: "POST",
-      data: { usernames: usernames.uniq().join(",") },
+      data: { usernames: usernames.uniq() },
     })
       .then((response) => {
         const chatChannel = ChatChannel.create(response.chat_channel);
@@ -852,8 +855,13 @@ export default Service.extend({
       .catch(popupAjaxError);
   },
 
+  // @param {array} usernames - The usernames to fetch the direct message
+  // channel for. The current user will automatically be included as a
+  // participant to fetch the channel for.
   getDmChannelForUsernames(usernames) {
-    return ajax("/chat/direct_messages.json", { data: { usernames } });
+    return ajax("/chat/direct_messages.json", {
+      data: { usernames: usernames.uniq().join(",") },
+    });
   },
 
   _saveDraft(channelId, draft) {

--- a/lib/direct_message_channel_creator.rb
+++ b/lib/direct_message_channel_creator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module DiscourseChat::DirectMessageChannelCreator
-  def self.create!(acting_user:, target_users:)
+  def self.create!(target_users:)
     unique_target_users = target_users.uniq
     direct_messages_channel = DirectMessageChannel.for_user_ids(unique_target_users.map(&:id))
     if direct_messages_channel

--- a/lib/direct_message_channel_creator.rb
+++ b/lib/direct_message_channel_creator.rb
@@ -1,26 +1,25 @@
 # frozen_string_literal: true
 
 module DiscourseChat::DirectMessageChannelCreator
-  attr_reader :chat_channel, :users
-
-  def self.create!(users)
-    direct_messages_channel = DirectMessageChannel.for_user_ids(users.map(&:id).uniq)
+  def self.create!(acting_user:, target_users:)
+    unique_target_users = target_users.uniq
+    direct_messages_channel = DirectMessageChannel.for_user_ids(unique_target_users.map(&:id))
     if direct_messages_channel
       chat_channel = ChatChannel.find_by!(chatable: direct_messages_channel)
     else
-      direct_messages_channel = DirectMessageChannel.create!(users: users)
+      direct_messages_channel = DirectMessageChannel.create!(user_ids: unique_target_users.map(&:id))
       chat_channel = ChatChannel.create!(chatable: direct_messages_channel)
     end
 
-    update_memberships(users, chat_channel.id)
-    ChatPublisher.publish_new_direct_message_channel(chat_channel, users)
+    update_memberships(unique_target_users, chat_channel.id)
+    ChatPublisher.publish_new_direct_message_channel(chat_channel, unique_target_users)
     chat_channel
   end
 
   private
 
-  def self.update_memberships(users, chat_channel_id)
-    users.each do |user|
+  def self.update_memberships(unique_target_users, chat_channel_id)
+    unique_target_users.each do |user|
       membership = UserChatChannelMembership.find_or_initialize_by(user_id: user.id, chat_channel_id: chat_channel_id)
 
       if membership.new_record?

--- a/lib/discourse_dev/direct_channel.rb
+++ b/lib/discourse_dev/direct_channel.rb
@@ -22,7 +22,7 @@ module DiscourseDev
     end
 
     def create!
-      DiscourseChat::DirectMessageChannelCreator.create!(acting_user: data.first, target_users: data)
+      DiscourseChat::DirectMessageChannelCreator.create!(target_users: data)
     end
   end
 end

--- a/lib/discourse_dev/direct_channel.rb
+++ b/lib/discourse_dev/direct_channel.rb
@@ -22,7 +22,7 @@ module DiscourseDev
     end
 
     def create!
-      DiscourseChat::DirectMessageChannelCreator.create!(data)
+      DiscourseChat::DirectMessageChannelCreator.create!(acting_user: data.first, target_users: data)
     end
   end
 end

--- a/spec/components/chat_mailer_spec.rb
+++ b/spec/components/chat_mailer_spec.rb
@@ -22,7 +22,7 @@ describe DiscourseChat::ChatMailer do
                                      chat_channel: @chat_channel, last_read_message_id: nil
     )
 
-    @private_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: @sender, target_users: [@sender, @user_1])
+    @private_channel = DiscourseChat::DirectMessageChannelCreator.create!(target_users: [@sender, @user_1])
   end
 
   def asert_summary_skipped

--- a/spec/components/chat_mailer_spec.rb
+++ b/spec/components/chat_mailer_spec.rb
@@ -22,7 +22,7 @@ describe DiscourseChat::ChatMailer do
                                      chat_channel: @chat_channel, last_read_message_id: nil
     )
 
-    @private_channel = DiscourseChat::DirectMessageChannelCreator.create!([@sender, @user_1])
+    @private_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: @sender, target_users: [@sender, @user_1])
   end
 
   def asert_summary_skipped

--- a/spec/components/chat_message_creator_spec.rb
+++ b/spec/components/chat_message_creator_spec.rb
@@ -24,7 +24,7 @@ describe DiscourseChat::ChatMessageCreator do
       Fabricate(:user_chat_channel_membership, chat_channel: public_chat_channel, user: user)
     end
 
-    @direct_message_channel = DiscourseChat::DirectMessageChannelCreator.create!([user1, user2])
+    @direct_message_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user1, target_users: [user1, user2])
   end
 
   describe "Integration tests with jobs running immediately" do

--- a/spec/components/chat_message_creator_spec.rb
+++ b/spec/components/chat_message_creator_spec.rb
@@ -24,7 +24,7 @@ describe DiscourseChat::ChatMessageCreator do
       Fabricate(:user_chat_channel_membership, chat_channel: public_chat_channel, user: user)
     end
 
-    @direct_message_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user1, target_users: [user1, user2])
+    @direct_message_channel = DiscourseChat::DirectMessageChannelCreator.create!(target_users: [user1, user2])
   end
 
   describe "Integration tests with jobs running immediately" do

--- a/spec/components/chat_message_updater_spec.rb
+++ b/spec/components/chat_message_updater_spec.rb
@@ -22,7 +22,7 @@ describe DiscourseChat::ChatMessageUpdater do
     [admin1, admin2, user1, user2, user3, user4].each do |user|
       Fabricate(:user_chat_channel_membership, chat_channel: public_chat_channel, user: user)
     end
-    @direct_message_channel = DiscourseChat::DirectMessageChannelCreator.create!([user1, user2])
+    @direct_message_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user1, target_users: [user1, user2])
   end
 
   def create_chat_message(user, message, channel, upload_ids: nil)

--- a/spec/components/chat_message_updater_spec.rb
+++ b/spec/components/chat_message_updater_spec.rb
@@ -22,7 +22,7 @@ describe DiscourseChat::ChatMessageUpdater do
     [admin1, admin2, user1, user2, user3, user4].each do |user|
       Fabricate(:user_chat_channel_membership, chat_channel: public_chat_channel, user: user)
     end
-    @direct_message_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user1, target_users: [user1, user2])
+    @direct_message_channel = DiscourseChat::DirectMessageChannelCreator.create!(target_users: [user1, user2])
   end
 
   def create_chat_message(user, message, channel, upload_ids: nil)

--- a/spec/jobs/regular/chat_notify_mentioned_spec.rb
+++ b/spec/jobs/regular/chat_notify_mentioned_spec.rb
@@ -7,11 +7,11 @@ describe Jobs::ChatNotifyMentioned do
   fab!(:user_2) { Fabricate(:user) }
   fab!(:public_channel) { Fabricate(:chat_channel) }
 
-  let!(:personal_chat_channel) { DiscourseChat::DirectMessageChannelCreator.create!([user_1, user_2]) }
+  let!(:personal_chat_channel) { DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user_1, target_users: [user_1, user_2]) }
 
   before do
     @chat_group = Fabricate(:group, users: [user_1, user_2])
-    @personal_chat_channel = DiscourseChat::DirectMessageChannelCreator.create!([user_1, user_2])
+    @personal_chat_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user_1, target_users: [user_1, user_2])
 
     [user_1, user_2].each { |u| Fabricate(:user_chat_channel_membership, chat_channel: public_channel, user: u) }
   end

--- a/spec/jobs/regular/chat_notify_mentioned_spec.rb
+++ b/spec/jobs/regular/chat_notify_mentioned_spec.rb
@@ -7,11 +7,11 @@ describe Jobs::ChatNotifyMentioned do
   fab!(:user_2) { Fabricate(:user) }
   fab!(:public_channel) { Fabricate(:chat_channel) }
 
-  let!(:personal_chat_channel) { DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user_1, target_users: [user_1, user_2]) }
+  let!(:personal_chat_channel) { DiscourseChat::DirectMessageChannelCreator.create!(target_users: [user_1, user_2]) }
 
   before do
     @chat_group = Fabricate(:group, users: [user_1, user_2])
-    @personal_chat_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user_1, target_users: [user_1, user_2])
+    @personal_chat_channel = DiscourseChat::DirectMessageChannelCreator.create!(target_users: [user_1, user_2])
 
     [user_1, user_2].each { |u| Fabricate(:user_chat_channel_membership, chat_channel: public_channel, user: u) }
   end

--- a/spec/lib/chat_notifier_spec.rb
+++ b/spec/lib/chat_notifier_spec.rb
@@ -216,7 +216,7 @@ describe DiscourseChat::ChatNotifier do
       end
 
       context 'in a personal message' do
-        let(:personal_chat_channel) { DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user_1, target_users: [user_1, user_2]) }
+        let(:personal_chat_channel) { DiscourseChat::DirectMessageChannelCreator.create!(target_users: [user_1, user_2]) }
 
         before { @chat_group.add(user_3) }
 

--- a/spec/lib/chat_notifier_spec.rb
+++ b/spec/lib/chat_notifier_spec.rb
@@ -216,7 +216,7 @@ describe DiscourseChat::ChatNotifier do
       end
 
       context 'in a personal message' do
-        let(:personal_chat_channel) { DiscourseChat::DirectMessageChannelCreator.create!([user_1, user_2]) }
+        let(:personal_chat_channel) { DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user_1, target_users: [user_1, user_2]) }
 
         before { @chat_group.add(user_3) }
 

--- a/spec/lib/direct_message_channel_creator_spec.rb
+++ b/spec/lib/direct_message_channel_creator_spec.rb
@@ -6,21 +6,97 @@ describe DiscourseChat::DirectMessageChannelCreator do
   fab!(:user_1) { Fabricate(:user) }
   fab!(:user_2) { Fabricate(:user) }
 
-  context 'existing direct message channel' do
+  context "existing direct message channel" do
     fab!(:dm_chat_channel) { Fabricate(:chat_channel, chatable: Fabricate(:direct_message_channel, users: [user_1, user_2])) }
+    fab!(:own_chat_channel) { Fabricate(:chat_channel, chatable: Fabricate(:direct_message_channel, users: [user_1])) }
 
-    it 'doesn’t create a new chat channel' do
+    it "doesn't create a new chat channel" do
+      existing_channel = nil
       expect {
-        subject.create!([user_1, user_2])
+        existing_channel = subject.create!(acting_user: user_1, target_users: [user_1, user_2])
       }.to change { ChatChannel.count }.by(0)
+      expect(existing_channel).to eq(dm_chat_channel)
+    end
+
+    it "creates UserChatChannelMembership records and sets their notification levels" do
+      expect {
+        subject.create!(acting_user: user_1, target_users: [user_1, user_2])
+      }.to change { UserChatChannelMembership.count }.by(2)
+
+      user_1_membership = UserChatChannelMembership.find_by(user_id: user_1.id, chat_channel_id: dm_chat_channel)
+      expect(user_1_membership.last_read_message_id).to eq(nil)
+      expect(user_1_membership.desktop_notification_level).to eq("always")
+      expect(user_1_membership.mobile_notification_level).to eq("always")
+      expect(user_1_membership.muted).to eq(false)
+      expect(user_1_membership.following).to eq(true)
+    end
+
+    it "publishes the new DM channel message bus message for each user" do
+      messages = MessageBus.track_publish do
+        subject.create!(acting_user: user_1, target_users: [user_1, user_2])
+      end.filter { |m| m.channel == "/chat/new-direct-message-channel" }
+      expect(messages.count).to eq(2)
+      expect(messages.map { |m| JSON.parse(m[:data])["chat_channel"]["id"] }).to eq([dm_chat_channel.id, dm_chat_channel.id])
+    end
+
+    it "allows a user to create a direct message to themself, without creating a new channel" do
+      existing_channel = nil
+      expect {
+        existing_channel = subject.create!(acting_user: user_1, target_users: [user_1])
+      }.to change { ChatChannel.count }.by(0).and change { UserChatChannelMembership.count }.by(1)
+      expect(existing_channel).to eq(own_chat_channel)
+    end
+
+    it "deduplicates target_users" do
+      existing_channel = nil
+      expect {
+        existing_channel = subject.create!(acting_user: user_1, target_users: [user_1, user_1])
+      }.to change { ChatChannel.count }.by(0).and change { UserChatChannelMembership.count }.by(1)
+      expect(existing_channel).to eq(own_chat_channel)
     end
   end
 
-  context 'non existing direct message channel' do
-    it 'creates a new chat channel' do
+  context "non existing direct message channel" do
+    it "creates a new chat channel" do
       expect {
-        subject.create!([user_1, user_2])
+        subject.create!(acting_user: user_1, target_users: [user_1, user_2])
       }.to change { ChatChannel.count }.by(1)
+    end
+
+    it "creates UserChatChannelMembership records and sets their notification levels" do
+      expect {
+        subject.create!(acting_user: user_1, target_users: [user_1, user_2])
+      }.to change { UserChatChannelMembership.count }.by(2)
+
+      chat_channel = ChatChannel.last
+      user_1_membership = UserChatChannelMembership.find_by(user_id: user_1.id, chat_channel_id: chat_channel)
+      expect(user_1_membership.last_read_message_id).to eq(nil)
+      expect(user_1_membership.desktop_notification_level).to eq("always")
+      expect(user_1_membership.mobile_notification_level).to eq("always")
+      expect(user_1_membership.muted).to eq(false)
+      expect(user_1_membership.following).to eq(true)
+    end
+
+    it "publishes the new DM channel message bus message for each user" do
+      messages = MessageBus.track_publish do
+        subject.create!(acting_user: user_1, target_users: [user_1, user_2])
+      end.filter { |m| m.channel == "/chat/new-direct-message-channel" }
+
+      chat_channel = ChatChannel.last
+      expect(messages.count).to eq(2)
+      expect(messages.map { |m| JSON.parse(m[:data])["chat_channel"]["id"] }).to eq([chat_channel.id, chat_channel.id])
+    end
+
+    it "allows a user to create a direct message to themself" do
+      expect {
+        subject.create!(acting_user: user_1, target_users: [user_1])
+      }.to change { ChatChannel.count }.by(1).and change { UserChatChannelMembership.count }.by(1)
+    end
+
+    it "deduplicates target_users" do
+      expect {
+        subject.create!(acting_user: user_1, target_users: [user_1, user_1])
+      }.to change { ChatChannel.count }.by(1).and change { UserChatChannelMembership.count }.by(1)
     end
   end
 end

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -28,7 +28,7 @@ describe UserNotifications do
     describe 'email subject' do
       context 'DM messages' do
         before do
-          @dm_channel = DiscourseChat::DirectMessageChannelCreator.create!([@sender, @user])
+          @dm_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: @sender, target_users: [@sender, @user])
           Fabricate(:chat_message, user: @sender, chat_channel: @dm_channel)
         end
 
@@ -66,7 +66,7 @@ describe UserNotifications do
 
         it 'includes both channel titles when there are exactly two with unread messages' do
           another_dm_user = Fabricate(:user, group_ids: [@chatters_group.id])
-          dm_channel_2 = DiscourseChat::DirectMessageChannelCreator.create!([another_dm_user, @user])
+          dm_channel_2 = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: another_dm_user, target_users: [another_dm_user, @user])
           chat_message = Fabricate(:chat_message, user: another_dm_user, chat_channel: dm_channel_2)
 
           email = described_class.chat_summary(@user, {})
@@ -78,7 +78,7 @@ describe UserNotifications do
         it 'displays a count when there are more than two DMs with unread messages' do
           2.times do
             another_dm_user = Fabricate(:user, group_ids: [@chatters_group.id])
-            dm_channel = DiscourseChat::DirectMessageChannelCreator.create!([another_dm_user, @user])
+            dm_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: another_dm_user, target_users: [another_dm_user, @user])
             chat_message = Fabricate(:chat_message, user: another_dm_user, chat_channel: dm_channel)
           end
           expected_count_text = I18n.t('user_notifications.chat_summary.subject.others', count: 2)
@@ -137,7 +137,7 @@ describe UserNotifications do
 
       context 'both unread DM messages and mentions' do
         before do
-          @dm_channel = DiscourseChat::DirectMessageChannelCreator.create!([@sender, @user])
+          @dm_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: @sender, target_users: [@sender, @user])
           Fabricate(:chat_message, user: @sender, chat_channel: @dm_channel)
           Fabricate(:chat_mention, user: @user, chat_message: @chat_message)
         end
@@ -235,7 +235,7 @@ describe UserNotifications do
 
         it 'returns an email when the user has unread private messages' do
           @user_membership.update!(last_read_message_id: @chat_message.id)
-          private_channel = DiscourseChat::DirectMessageChannelCreator.create!([@sender, @user])
+          private_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: @sender, target_users: [@sender, @user])
           Fabricate(:chat_message, user: @sender, chat_channel: private_channel)
 
           email = described_class.chat_summary(@user, {})

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -28,7 +28,7 @@ describe UserNotifications do
     describe 'email subject' do
       context 'DM messages' do
         before do
-          @dm_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: @sender, target_users: [@sender, @user])
+          @dm_channel = DiscourseChat::DirectMessageChannelCreator.create!(target_users: [@sender, @user])
           Fabricate(:chat_message, user: @sender, chat_channel: @dm_channel)
         end
 
@@ -66,7 +66,7 @@ describe UserNotifications do
 
         it 'includes both channel titles when there are exactly two with unread messages' do
           another_dm_user = Fabricate(:user, group_ids: [@chatters_group.id])
-          dm_channel_2 = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: another_dm_user, target_users: [another_dm_user, @user])
+          dm_channel_2 = DiscourseChat::DirectMessageChannelCreator.create!(target_users: [another_dm_user, @user])
           chat_message = Fabricate(:chat_message, user: another_dm_user, chat_channel: dm_channel_2)
 
           email = described_class.chat_summary(@user, {})
@@ -78,7 +78,7 @@ describe UserNotifications do
         it 'displays a count when there are more than two DMs with unread messages' do
           2.times do
             another_dm_user = Fabricate(:user, group_ids: [@chatters_group.id])
-            dm_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: another_dm_user, target_users: [another_dm_user, @user])
+            dm_channel = DiscourseChat::DirectMessageChannelCreator.create!(target_users: [another_dm_user, @user])
             chat_message = Fabricate(:chat_message, user: another_dm_user, chat_channel: dm_channel)
           end
           expected_count_text = I18n.t('user_notifications.chat_summary.subject.others', count: 2)
@@ -137,7 +137,7 @@ describe UserNotifications do
 
       context 'both unread DM messages and mentions' do
         before do
-          @dm_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: @sender, target_users: [@sender, @user])
+          @dm_channel = DiscourseChat::DirectMessageChannelCreator.create!(target_users: [@sender, @user])
           Fabricate(:chat_message, user: @sender, chat_channel: @dm_channel)
           Fabricate(:chat_mention, user: @user, chat_message: @chat_message)
         end
@@ -235,7 +235,7 @@ describe UserNotifications do
 
         it 'returns an email when the user has unread private messages' do
           @user_membership.update!(last_read_message_id: @chat_message.id)
-          private_channel = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: @sender, target_users: [@sender, @user])
+          private_channel = DiscourseChat::DirectMessageChannelCreator.create!(target_users: [@sender, @user])
           Fabricate(:chat_message, user: @sender, chat_channel: private_channel)
 
           email = described_class.chat_summary(@user, {})

--- a/spec/requests/chat_channel_controller_spec.rb
+++ b/spec/requests/chat_channel_controller_spec.rb
@@ -130,10 +130,10 @@ RSpec.describe DiscourseChat::ChatChannelsController do
         fab!(:user3) { Fabricate(:user) }
 
         before do
-          @dm1 = DiscourseChat::DirectMessageChannelCreator.create!([user1, user2])
-          @dm2 = DiscourseChat::DirectMessageChannelCreator.create!([user1, user3])
-          @dm3 = DiscourseChat::DirectMessageChannelCreator.create!([user1, user2, user3])
-          @dm4 = DiscourseChat::DirectMessageChannelCreator.create!([user2, user3])
+          @dm1 = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user1, target_users: [user1, user2])
+          @dm2 = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user1, target_users: [user1, user3])
+          @dm3 = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user1, target_users: [user1, user2, user3])
+          @dm4 = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user1, target_users: [user2, user3])
         end
 
         it "returns correct DMs for user1" do

--- a/spec/requests/chat_channel_controller_spec.rb
+++ b/spec/requests/chat_channel_controller_spec.rb
@@ -130,10 +130,10 @@ RSpec.describe DiscourseChat::ChatChannelsController do
         fab!(:user3) { Fabricate(:user) }
 
         before do
-          @dm1 = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user1, target_users: [user1, user2])
-          @dm2 = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user1, target_users: [user1, user3])
-          @dm3 = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user1, target_users: [user1, user2, user3])
-          @dm4 = DiscourseChat::DirectMessageChannelCreator.create!(acting_user: user1, target_users: [user2, user3])
+          @dm1 = DiscourseChat::DirectMessageChannelCreator.create!(target_users: [user1, user2])
+          @dm2 = DiscourseChat::DirectMessageChannelCreator.create!(target_users: [user1, user3])
+          @dm3 = DiscourseChat::DirectMessageChannelCreator.create!(target_users: [user1, user2, user3])
+          @dm4 = DiscourseChat::DirectMessageChannelCreator.create!(target_users: [user2, user3])
         end
 
         it "returns correct DMs for user1" do


### PR DESCRIPTION
At some time in the past few months (possibly #758)
the ability for users to create a new DM channel with themselves
was broken. There was inconsistency around the
chat direct message controller sometimes accepting
an array of usernames and sometimes accepting
a comma separated string of usernames. They are
both needed - the former for POST and the latter
for GET. The test for POST in ruby did not pass the
usernames as an array so it was not catching the
error which was preventing the creation of the channel,
which was caused by a duplication of the current user
in the users array.

This commit also changes the `create!` method argument
for `DirectMessageChannelCreator` to have a
`target_user` argument, which will make it easier to
add mute/ignore checks involving the user creating
the message and who they are targeting, since an `acting_user`
argument will be needed for that change.

It also addresses some inconsistencies with how the usernames
are passed to the controller from JS, and adds missing specs
for `DirectMessageChannelCreator`