### PR TITLE
FIX: Use as_json instead of to_json for chat DM message bus

### DIFF
--- a/app/services/chat_publisher.rb
+++ b/app/services/chat_publisher.rb
@@ -108,7 +108,7 @@ module ChatPublisher
         chat_channel,
         scope: Guardian.new(user), # We need a guardian here for direct messages
         root: :chat_channel
-      ).to_json
+      ).as_json
       MessageBus.publish("/chat/new-direct-message-channel", serialized_channel, user_ids: [user.id])
     end
   end

--- a/spec/lib/direct_message_channel_creator_spec.rb
+++ b/spec/lib/direct_message_channel_creator_spec.rb
@@ -36,7 +36,8 @@ describe DiscourseChat::DirectMessageChannelCreator do
         subject.create!(target_users: [user_1, user_2])
       end.filter { |m| m.channel == "/chat/new-direct-message-channel" }
       expect(messages.count).to eq(2)
-      expect(messages.map { |m| JSON.parse(m[:data])["chat_channel"]["id"] }).to eq([dm_chat_channel.id, dm_chat_channel.id])
+      expect(messages.first[:data]).to be_kind_of(Hash)
+      expect(messages.map { |m| m[:data][:chat_channel][:id] }).to eq([dm_chat_channel.id, dm_chat_channel.id])
     end
 
     it "allows a user to create a direct message to themself, without creating a new channel" do
@@ -84,7 +85,8 @@ describe DiscourseChat::DirectMessageChannelCreator do
 
       chat_channel = ChatChannel.last
       expect(messages.count).to eq(2)
-      expect(messages.map { |m| JSON.parse(m[:data])["chat_channel"]["id"] }).to eq([chat_channel.id, chat_channel.id])
+      expect(messages.first[:data]).to be_kind_of(Hash)
+      expect(messages.map { |m| m[:data][:chat_channel][:id] }).to eq([chat_channel.id, chat_channel.id])
     end
 
     it "allows a user to create a direct message to themself" do


### PR DESCRIPTION
Follow up to f1fb1d0b4843b6265a6f46d8b24c31930a69c015,
in this commit I accidentally changed as_json (which produces
a Hash) to to_json (which produces a JSON string) in the
ChatPublisher for the new DM channel. This makes the MessageBus
data unparseable, so in JS in the chat service it ends up creating
a public channel in the channel list with undefined data, leaving
a blank channel in the list with a blue unread indicator.

Before fix MessageBus data:

![2022-07-06_13-01](https://user-images.githubusercontent.com/920448/177459161-f847c320-d37a-4aa7-85dc-8b8d8bbe82d0.png)

After fix MessageBus data:

![2022-07-06_13-00](https://user-images.githubusercontent.com/920448/177459166-cd48e665-4eea-4051-a592-3110c52ac40a.png)

UI error:

![2022-07-06_12-59](https://user-images.githubusercontent.com/920448/177459168-61723a75-cb84-46e2-8c39-44912eadf64d.png)
