### PR TITLE
FIX: Create channel modal error with type param required

### DIFF
--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -62,15 +62,12 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
   end
 
   def create
-    params.require([:type, :id, :name])
+    params.require([:id, :name])
     guardian.ensure_can_create_chat_channel!
-    raise Discourse::InvalidParameters unless params[:type].downcase == 'category'
     raise Discourse::InvalidParameters.new(:name) if params[:name].length > SiteSetting.max_topic_title_length
 
-    chatable_type = 'Category'
-
     exists = ChatChannel.exists?(
-      chatable_type: chatable_type,
+      chatable_type: 'Category',
       chatable_id: params[:id],
       name: params[:name]
     )
@@ -78,7 +75,7 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
       raise Discourse::InvalidParameters.new(I18n.t("chat.errors.channel_exists_for_category"))
     end
 
-    chatable = chatable_type.constantize.find_by(id: params[:id])
+    chatable = Category.find_by(id: params[:id])
     raise Discourse::NotFound unless chatable
 
     chat_channel = ChatChannel.create!(chatable: chatable, name: params[:name], description: params[:description], user_count: 1)

--- a/spec/requests/chat_channel_controller_spec.rb
+++ b/spec/requests/chat_channel_controller_spec.rb
@@ -216,26 +216,20 @@ RSpec.describe DiscourseChat::ChatChannelsController do
 
     it "errors for non-staff" do
       sign_in(user)
-      put "/chat/chat_channels.json", params: { type: "category", id: category2.id, name: "hi" }
+      put "/chat/chat_channels.json", params: { id: category2.id, name: "hi" }
       expect(response.status).to eq(403)
-    end
-
-    it "errors when type is not category/topic" do
-      sign_in(admin)
-      put "/chat/chat_channels.json", params: { type: "beeep", id: category2.id, name: "hi" }
-      expect(response.status).to eq(400)
     end
 
     it "errors when chatable doesn't exist" do
       sign_in(admin)
-      put "/chat/chat_channels.json", params: { type: "category", id: Category.last.id + 1, name: "hi" }
+      put "/chat/chat_channels.json", params: { id: Category.last.id + 1, name: "hi" }
       expect(response.status).to eq(404)
     end
 
     it "errors when the name is over SiteSetting.max_topic_title_length" do
       sign_in(admin)
       SiteSetting.max_topic_title_length = 10
-      put "/chat/chat_channels.json", params: { type: "category", id: category2.id, name: "Hi, this is over 10 characters" }
+      put "/chat/chat_channels.json", params: { id: category2.id, name: "Hi, this is over 10 characters" }
       expect(response.status).to eq(400)
     end
 
@@ -244,7 +238,7 @@ RSpec.describe DiscourseChat::ChatChannelsController do
       name = "beep boop hi"
       ChatChannel.create!(chatable: category2, name: name)
 
-      put "/chat/chat_channels.json", params: { type: "category", id: category2.id, name: name }
+      put "/chat/chat_channels.json", params: { id: category2.id, name: name }
       expect(response.status).to eq(400)
     end
 
@@ -253,7 +247,7 @@ RSpec.describe DiscourseChat::ChatChannelsController do
       ChatChannel.create!(chatable: category2, name: "this is a name")
 
       expect {
-        put "/chat/chat_channels.json", params: { type: "category", id: category2.id, name: "Different name!" }
+        put "/chat/chat_channels.json", params: { id: category2.id, name: "Different name!" }
       }.to change { ChatChannel.where(chatable: category2).count }.by(1)
       expect(response.status).to eq(200)
     end
@@ -261,7 +255,7 @@ RSpec.describe DiscourseChat::ChatChannelsController do
     it "creates a user_chat_channel_membership when the channel is created" do
       sign_in(admin)
       expect {
-        put "/chat/chat_channels.json", params: { type: "category", id: category2.id, name: "hi hi" }
+        put "/chat/chat_channels.json", params: { id: category2.id, name: "hi hi" }
       }.to change { UserChatChannelMembership.where(user: admin).count }.by(1)
       expect(response.status).to eq(200)
     end


### PR DESCRIPTION
Follow up to ca528966dfc4be9a920a8477813892e19a38d0a2, channel
creation was prevented because we still required the `type`
parameter in the controller but it was removed from create-channel.js . That
param is redundant anyway since the only type of channel we can
make now is a Category channel.

This commit fixes the issue and removes the type requirement.