### PR TITLE
FIX: Do not fetch messages for draft channel with no ID

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -137,7 +137,8 @@ export default Component.extend({
 
     if (
       this.chatChannel &&
-      this.registeredChatChannelId !== this.chatChannel?.id
+      this.chatChannel.id &&
+      this.registeredChatChannelId !== this.chatChannel.id
     ) {
       this._cleanRegisteredChatChannelId();
       this.messageLookup = {};
@@ -149,7 +150,7 @@ export default Component.extend({
         .then((trackedChannel) => {
           this.fetchMessages(this.chatChannel);
 
-          if (!this.chatChannel?.isDraft) {
+          if (!this.chatChannel.isDraft) {
             this.set("previewing", !Boolean(trackedChannel));
             this._startLastReadRunner();
             this.loadDraftForChannel(this.chatChannel.id);


### PR DESCRIPTION
Follow up to 9c800e0146182ce6a4a3353138d0ba7c8ccbe2a3

When starting a new DM channel with one or more users where
no channel exists we return a 404 from the server. However
we were still trying to fetch messages for that channel in
the chat-live-pane, leading to a GET like this:

http://localhost:4200/chat/undefined/messages.json?page_size=50

This commit fixes the issue by not doing any additional fetching
in chat-live-pane if the chat channel ID is not present.
