### PR TITLE
FIX: marks drawer as not expanded when full screen

### DIFF
--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -256,6 +256,7 @@ export default Component.extend({
 
     // Set activeChannel to null to avoid a moment where the chat composer is rendered twice.
     // Since the mobile-file-upload button has an ID, a JS error will break things otherwise.
+    this.set("expanded", false);
     this.set("hidden", true);
     this.chat.setActiveChannel(null);
     this.chatWindowStore.set("fullPage", true);


### PR DESCRIPTION
This small difference ensures that the chat-live-pane component of the drawer is going to be destroyed and call `willDestroyElement`
