### PR TITLE
FIX: move CSS to sidebar-extensions

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -872,12 +872,3 @@ body.has-full-page-chat {
 .chat-browse {
   overflow-y: auto;
 }
-
-.has-sidebar-page.chat-enabled {
-  .sidebar-container .channels-list {
-    padding-bottom: 0;
-    .chat-channel-divider {
-      padding-right: 0;
-    }
-  }
-}

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -162,10 +162,3 @@
     }
   }
 }
-
-.has-sidebar-page.has-full-page-chat {
-  .full-page-chat {
-    grid-template-columns: 1fr;
-    overflow: inherit;
-  }
-}

--- a/assets/stylesheets/desktop/sidebar-extensions.scss
+++ b/assets/stylesheets/desktop/sidebar-extensions.scss
@@ -1,0 +1,6 @@
+.has-sidebar-page.has-full-page-chat {
+  .full-page-chat {
+    grid-template-columns: 1fr;
+    overflow: inherit;
+  }
+}

--- a/assets/stylesheets/sidebar-extensions.scss
+++ b/assets/stylesheets/sidebar-extensions.scss
@@ -134,3 +134,12 @@
     }
   }
 }
+
+.has-sidebar-page.chat-enabled {
+  .sidebar-container .channels-list {
+    padding-bottom: 0;
+    .chat-channel-divider {
+      padding-right: 0;
+    }
+  }
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -46,6 +46,7 @@ register_asset 'stylesheets/common/chat-channel-selector-modal.scss'
 register_asset 'stylesheets/mobile/mobile.scss', :mobile
 register_asset 'stylesheets/desktop/desktop.scss', :desktop
 register_asset 'stylesheets/sidebar-extensions.scss'
+register_asset 'stylesheets/desktop/sidebar-extensions.scss', :desktop
 register_asset 'stylesheets/common/chat-message-separator.scss'
 register_asset 'stylesheets/common/chat-onebox.scss'
 


### PR DESCRIPTION
Continue of https://github.com/discourse/discourse-chat/pull/998
Extract CSS to sidebar-extensions