### PR TITLE
FIX: makes drawer not expanded on full page

### DIFF
--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -259,8 +259,6 @@ export default Component.extend({
       return false;
     }
 
-    // Set activeChannel to null to avoid a moment where the chat composer is rendered twice.
-    // Since the mobile-file-upload button has an ID, a JS error will break things otherwise.
     this.chat.openChannel(channel);
   },
 

--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -242,6 +242,11 @@ export default Component.extend({
   openInFullPage(e) {
     const channel = this.chat.activeChannel;
 
+    this.set("expanded", false);
+    this.set("hidden", true);
+    this.chat.setActiveChannel(null);
+    this.chatWindowStore.set("fullPage", true);
+
     if (!channel) {
       return this.router.transitionTo("chat");
     }
@@ -256,10 +261,6 @@ export default Component.extend({
 
     // Set activeChannel to null to avoid a moment where the chat composer is rendered twice.
     // Since the mobile-file-upload button has an ID, a JS error will break things otherwise.
-    this.set("expanded", false);
-    this.set("hidden", true);
-    this.chat.setActiveChannel(null);
-    this.chatWindowStore.set("fullPage", true);
     this.chat.openChannel(channel);
   },
 
@@ -273,7 +274,7 @@ export default Component.extend({
   close() {
     this.setProperties({
       hidden: true,
-      expanded: true,
+      expanded: false,
     });
     this.chat.setActiveChannel(null);
     this.appEvents.trigger("chat:float-toggled", this.hidden);


### PR DESCRIPTION
Before this fix, the drawer would still be expanded when switching to full page, albeit hidden, making the live pane inside the drawer still existing and new messages would be appended to this instead of the live pane of the full page.