### PR TITLE
UX: fix channel msg indicator

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -134,6 +134,7 @@ $float-height: 530px;
   position: relative;
 
   .chat-channel-unread-indicator {
+    min-width: 10px;
     width: 10px;
     height: 10px;
     border-radius: 10px;


### PR DESCRIPTION
Fixing the squashing of the indicator when a channel name is max length
<img width="232" alt="image" src="https://user-images.githubusercontent.com/101828855/178312391-ef211084-bdd3-4526-b5c4-c29d45bc9a7d.png">
