### PR TITLE
UX: Hide boostrap alerts on full page chat

### DIFF
--- a/assets/stylesheets/common/chat-alerts.scss
+++ b/assets/stylesheets/common/chat-alerts.scss
@@ -1,0 +1,3 @@
+body.has-full-page-chat .alert-too-few-topics, body.has-full-page-chat .alert-bootstrap-mode {
+  display: none;
+}

--- a/assets/stylesheets/common/chat-alerts.scss
+++ b/assets/stylesheets/common/chat-alerts.scss
@@ -1,3 +1,4 @@
-body.has-full-page-chat .alert-too-few-topics, body.has-full-page-chat .alert-bootstrap-mode {
+body.has-full-page-chat .alert-too-few-topics,
+body.has-full-page-chat .alert-bootstrap-mode {
   display: none;
 }


### PR DESCRIPTION
Remove the boostrap & too few topics alert when chat is in full screen.

### After
<img width="200" alt="image" src="https://user-images.githubusercontent.com/30537603/178360741-3aa3898b-f2be-47ab-a6d0-56cdd6cdf80c.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/30537603/178360875-f66b8d3d-3688-4aea-9dce-de2cd9924101.png">

### Before
<img width="200" alt="image" src="https://user-images.githubusercontent.com/30537603/178361089-f1f13598-ef42-4817-9946-abd0a65dcd18.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/30537603/178361007-c10daf60-ffea-430e-b979-5954f28bb423.png">

