### PR TITLE
UX: Remove gap on sidebar with full page chat

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -566,6 +566,10 @@ $float-height: 530px;
   }
 }
 
+body.has-sidebar-page.has-full-page-chat #main-outlet-wrapper {
+  gap: 0;
+}
+
 body.has-full-page-chat {
   .alert-error,
   .alert-info,


### PR DESCRIPTION
### After
<img width="70" alt="image" src="https://user-images.githubusercontent.com/30537603/178583844-21489412-ac52-4fb1-8c60-5e5f1ba88c8d.png">


### Before
<img width="150" alt="image" src="https://user-images.githubusercontent.com/30537603/178585263-61eb536b-68fb-42a9-a192-794002f897e6.png">
