### PR TITLE
DEV: Trigger an event on chat message processed

### DIFF
--- a/lib/chat_message_processor.rb
+++ b/lib/chat_message_processor.rb
@@ -16,6 +16,7 @@ class DiscourseChat::ChatMessageProcessor
 
   def run!
     post_process_oneboxes
+    DiscourseEvent.trigger(:chat_message_processed, @doc, @model)
   end
 
   def large_images


### PR DESCRIPTION
This will allow core or other plugins to listen for the
`chat_message_processed` event.

This will be needed for this PR for the discourse-video plugin:

https://github.com/discourse/discourse-video/pull/34
