### PR TITLE
FIX: Allow overflow for pop-up visibility

### DIFF
--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -75,7 +75,6 @@
   .full-page-chat {
     border-right: 1px solid var(--primary-low);
     border-left: 1px solid var(--primary-low);
-    overflow: hidden;
 
     .channels-list {
       background: var(--primary-very-low);


### PR DESCRIPTION
### After
<img width="300" alt="image" src="https://user-images.githubusercontent.com/30537603/179024896-0853384f-0aeb-4983-8228-1a1fcb905a10.png">

### Before
<img width="300" alt="image" src="https://user-images.githubusercontent.com/30537603/179024796-a23557db-3180-4bff-b21c-29fbd0311896.png">
