### PR TITLE
DEV: adds ChatPublisher.publish_refresh!

### DIFF
--- a/app/services/chat_publisher.rb
+++ b/app/services/chat_publisher.rb
@@ -28,6 +28,12 @@ module ChatPublisher
     MessageBus.publish("/chat/#{chat_channel.id}", content.as_json, permissions(chat_channel))
   end
 
+  def self.publish_refresh!(chat_channel, chat_message)
+    content = ChatMessageSerializer.new(chat_message, { scope: anonymous_guardian, root: :chat_message }).as_json
+    content[:type] = :refresh
+    MessageBus.publish("/chat/#{chat_channel.id}", content.as_json, permissions(chat_channel))
+  end
+
   def self.publish_reaction!(chat_channel, chat_message, action, user, emoji)
     content = {
       action: action,

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -670,6 +670,9 @@ export default Component.extend({
       case "edit":
         this.handleEditMessage(data);
         break;
+      case "refresh":
+        this.handleRefreshMessage(data);
+        break;
       case "delete":
         this.handleDeleteMessage(data);
         break;
@@ -745,6 +748,13 @@ export default Component.extend({
     if (message) {
       message.set("cooked", data.chat_message.cooked);
       this.reStickScrollIfNeeded();
+    }
+  },
+
+  handleRefreshMessage(data) {
+    const message = this.messageLookup[data.chat_message.id];
+    if (message) {
+      this.appEvents.trigger("chat:refresh-message", message);
     }
   },
 

--- a/assets/javascripts/discourse/components/chat-message.js
+++ b/assets/javascripts/discourse/components/chat-message.js
@@ -69,6 +69,8 @@ export default Component.extend({
       );
     }
 
+    this.appEvents.off("chat:refresh-message", this, "_refreshedMessage");
+
     this.appEvents.off(
       "chat-message:reaction-picker-opened",
       this,
@@ -95,6 +97,13 @@ export default Component.extend({
   },
 
   @bind
+  _refreshedMessage(message) {
+    if (message.id === this.message.id) {
+      this.decorateMessageCooked();
+    }
+  },
+
+  @bind
   decorateMessageCooked() {
     if (!this.messageContainer) {
       return;
@@ -117,6 +126,8 @@ export default Component.extend({
     if (!this.message.id || this._hasSubscribedToAppEvents) {
       return;
     }
+
+    this.appEvents.on("chat:refresh-message", this, "_refreshedMessage");
 
     this.appEvents.on(
       "chat-message:reaction-picker-opened",

--- a/spec/services/chat_publisher_spec.rb
+++ b/spec/services/chat_publisher_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ChatPublisher do
+  fab!(:channel) { Fabricate(:chat_channel) }
+  fab!(:message) { Fabricate(:chat_message, chat_channel: channel) }
+
+  describe '.publish_refresh!' do
+    it 'publishes the message' do
+      data = MessageBus.track_publish do
+        ChatPublisher.publish_refresh!(channel, message)
+      end[0].data
+
+      expect(data['chat_message']['id']).to eq(message.id)
+      expect(data['type']).to eq('refresh')
+    end
+  end
+end


### PR DESCRIPTION
This method allows to send a "refresh" message which will trigger a re-decorate on the client side.

The js part of this PR is sadly too complicated to test in the current state of coupling.