### PR TITLE
FIX: Don't corrupt users' last read IDs.

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -63,6 +63,7 @@ export default Component.extend({
   _nextStagedMessageId: 0, // Iterate on every new message
   _lastSelectedMessage: null,
   targetMessageId: null,
+  hasNewMessages: null,
 
   chat: service(),
   router: service(),
@@ -123,7 +124,7 @@ export default Component.extend({
       this,
       "highlightOrFetchMessage"
     );
-    this._stopLastReadRunner();
+    this._cancelPendingReadUpdate();
 
     // don't need to removeEventListener from scroller as the DOM element goes away
     cancel(this.stickyScrollTimer);
@@ -167,8 +168,11 @@ export default Component.extend({
 
           if (!this.chatChannel.isDraft) {
             this.set("previewing", !Boolean(trackedChannel));
-            this._startLastReadRunner();
             this.loadDraftForChannel(this.chatChannel.id);
+
+            if (!isTesting()) {
+              this._updateLastReadMessage(0);
+            }
           }
         });
     }
@@ -645,8 +649,12 @@ export default Component.extend({
     if (atTop) {
       this._fetchMoreMessages(PAST);
       return;
-    } else if (Math.abs(this._scrollerEl.scrollTop) <= STICKY_SCROLL_LENIENCE) {
-      this._fetchMoreMessages(FUTURE);
+    } else {
+      this._updateLastReadMessage();
+
+      if (Math.abs(this._scrollerEl.scrollTop) <= STICKY_SCROLL_LENIENCE) {
+        this._fetchMoreMessages(FUTURE);
+      }
     }
 
     this._calculateStickScroll();
@@ -662,6 +670,10 @@ export default Component.extend({
         ? false
         : absoluteScrollTop / this._scrollerEl.offsetHeight > 0.67
     );
+
+    if (!this.showScrollToBottomBtn) {
+      this.set("hasNewMessages", false);
+    }
 
     if (shouldStick !== this.stickyScroll) {
       if (shouldStick) {
@@ -910,7 +922,7 @@ export default Component.extend({
 
   @bind
   _updateLastReadMessage(wait = READ_INTERVAL) {
-    cancel(this._updateReadTimer);
+    this._cancelPendingReadUpdate();
 
     if (this._selfDeleted) {
       return;
@@ -923,15 +935,23 @@ export default Component.extend({
           return;
         }
 
-        let messageId;
-        if (this.messages?.length) {
-          messageId = this.messages[this.messages.length - 1]?.id;
+        let latestUnreadMsgId = this.lastSendReadMessageId;
+        if (
+          this.messages?.length &&
+          this.messages[this.messages.length - 1].id > latestUnreadMsgId
+        ) {
+          latestUnreadMsgId = this._findNextUnreadMessage(
+            0,
+            this.messages.length - 1,
+            this.lastSendReadMessageId
+          );
         }
-        const hasUnreadMessage =
-          messageId && messageId > this.lastSendReadMessageId;
+
+        const hasUnreadMessages =
+          latestUnreadMsgId && latestUnreadMsgId > this.lastSendReadMessageId;
 
         if (
-          !hasUnreadMessage &&
+          !hasUnreadMessages &&
           this.currentUser.chat_channel_tracking_state[this.chatChannel.id]
             ?.unread_count > 0
         ) {
@@ -941,34 +961,69 @@ export default Component.extend({
 
         // Make sure new messages have come in. Do not keep pinging server with read updates
         // if no new messages came in since last read update was sent.
-        if (this._floatOpenAndFocused() && hasUnreadMessage) {
-          this.set("lastSendReadMessageId", messageId);
-          ajax(`/chat/${this.chatChannel.id}/read/${messageId}.json`, {
+        if (this._floatOpenAndFocused() && hasUnreadMessages) {
+          this.set("lastSendReadMessageId", latestUnreadMsgId);
+          ajax(`/chat/${this.chatChannel.id}/read/${latestUnreadMsgId}.json`, {
             method: "PUT",
-          }).catch(() => {
-            this._stopLastReadRunner();
           });
         }
-
-        this._updateLastReadMessage();
       },
       wait
     );
+  },
+
+  // Recursive binary search to find an unread message in the viewport.
+  _findNextUnreadMessage(start, end, lastReadMessageId) {
+    if (end < start) {
+      return this.messages[end]?.id;
+    }
+
+    const candidateIdx = Math.round((start + end) / 2);
+    const unreadCandidateId = this.messages[candidateIdx]?.id;
+
+    if (!unreadCandidateId) {
+      return this.messages[end]?.id;
+    }
+
+    if (unreadCandidateId > lastReadMessageId) {
+      const messageElem = document.querySelector(
+        `.chat-message-container[data-id="${unreadCandidateId}"]`
+      );
+
+      if (this._messageVisible(messageElem)) {
+        return unreadCandidateId;
+      } else {
+        // Right half but not visible yet. Keep searching.
+        return this._findNextUnreadMessage(
+          start,
+          candidateIdx - 1,
+          lastReadMessageId
+        );
+      }
+    } else {
+      // Wrong half. Look in the rest of the array
+      return this._findNextUnreadMessage(
+        candidateIdx + 1,
+        end,
+        lastReadMessageId
+      );
+    }
+  },
+
+  _messageVisible(message) {
+    const { bottom, height, top } = message.getBoundingClientRect();
+    const containerRect = this._scrollerEl.getBoundingClientRect();
+
+    return top <= containerRect.top
+      ? containerRect.top - top <= height
+      : bottom - containerRect.bottom <= height;
   },
 
   _floatOpenAndFocused() {
     return userPresent() && this.expanded && !this.floatHidden;
   },
 
-  _startLastReadRunner() {
-    if (!isTesting()) {
-      next(this, () => {
-        this._updateLastReadMessage(0);
-      });
-    }
-  },
-
-  _stopLastReadRunner() {
+  _cancelPendingReadUpdate() {
     cancel(this._updateReadTimer);
   },
 
@@ -1375,7 +1430,11 @@ export default Component.extend({
   _subscribeToUpdates(channelId) {
     this._unsubscribeToUpdates(channelId);
     this.messageBus.subscribe(`/chat/${channelId}`, (busData) => {
-      this.handleMessage(busData);
+      if (!this.details.can_load_more_future || busData.type !== "sent") {
+        this.handleMessage(busData);
+      } else {
+        this.set("hasNewMessages", true);
+      }
     });
   },
 

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -76,7 +76,7 @@
     <a
       href
       title={{i18n "chat.scroll_to_bottom"}}
-      class="btn btn-flat chat-scroll-to-bottom {{if hasNewMessages "unread-messages"}}"
+      class={{concat-class "btn" "btn-flat" "chat-scroll-to-bottom" (if hasNewMessages "unread-messages")}}
       {{on "click" (action "restickScrolling")}}
     >
       {{#if hasNewMessages}}

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -76,9 +76,12 @@
     <a
       href
       title={{i18n "chat.scroll_to_bottom"}}
-      class="btn btn-flat chat-scroll-to-bottom"
+      class="btn btn-flat chat-scroll-to-bottom {{if hasNewMessages "unread-messages"}}"
       {{on "click" (action "restickScrolling")}}
     >
+      {{#if hasNewMessages}}
+        {{i18n "chat.scroll_to_new_messages"}}
+      {{/if}}
       {{d-icon "arrow-down"}}
     </a>
   </div>

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -371,7 +371,7 @@ $float-height: 530px;
     bottom: 1em;
     border-radius: 100%;
     left: 50%;
-    opacity: 75%;
+    opacity: 50%;
     padding: 0.5em;
     position: absolute;
     transform: translateX(-50%);

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -371,19 +371,34 @@ $float-height: 530px;
     bottom: 1em;
     border-radius: 100%;
     left: 50%;
-    opacity: 20%;
+    opacity: 75%;
     padding: 0.5em;
     position: absolute;
     transform: translateX(-50%);
     z-index: 2;
 
     &:hover {
-      opacity: 75%;
+      background: var(--primary-medium);
+      opacity: 100%;
     }
 
     .d-icon {
       color: var(--primary);
       margin: 0;
+    }
+
+    &.unread-messages {
+      opacity: 85%;
+      border-radius: 0;
+      transition: border-radius 0.1s linear;
+
+      &:hover {
+        opacity: 100%;
+      }
+
+      .d-icon {
+        margin: 0 0 0 0.5em;
+      }
     }
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -143,6 +143,7 @@ en:
       silence: "Silence user"
       return_to_list: "Return to channels list"
       scroll_to_bottom: "Scroll to bottom"
+      scroll_to_new_messages: "See new messages"
       sound:
         title: "Desktop chat notification sound"
       sounds:

--- a/test/javascripts/acceptance/chat-live-pane-test.js
+++ b/test/javascripts/acceptance/chat-live-pane-test.js
@@ -1,0 +1,95 @@
+import { settled, visit } from "@ember/test-helpers";
+import {
+  acceptance,
+  exists,
+  publishToMessageBus,
+} from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+
+function buildMessage(messageId) {
+  return {
+    id: messageId,
+    message: "hi",
+    cooked: "<p>hi</p>",
+    excerpt: "hi",
+    created_at: "2021-07-20T08:14:16.950Z",
+    flag_count: 0,
+    user: {
+      avatar_template: "/letter_avatar_proxy/v4/letter/t/a9a28c/{size}.png",
+      id: 1,
+      name: "Tomtom",
+      username: "tomtom",
+    },
+  };
+}
+
+acceptance(
+  "Discourse Chat - Chat live pane - viewing old messages",
+  function (needs) {
+    needs.user({
+      username: "eviltrout",
+      id: 1,
+      can_chat: true,
+      has_chat_enabled: true,
+    });
+    needs.settings({
+      chat_enabled: true,
+    });
+    needs.pretender((server, helper) => {
+      server.get("/chat/:chatChannelId/messages.json", () =>
+        helper.response({
+          meta: {
+            can_flag: true,
+            user_silenced: true,
+            can_load_more_future: true,
+          },
+          chat_messages: [buildMessage(1), buildMessage(2)],
+        })
+      );
+
+      server.get("/chat/chat_channels.json", () =>
+        helper.response({
+          public_channels: [],
+          direct_message_channels: [],
+        })
+      );
+
+      server.get("/chat/chat_channels/:chatChannelId", () =>
+        helper.response({ chat_channel: { id: 1, title: "something" } })
+      );
+    });
+
+    test("doesn't create a gap in history by adding new messages", async function (assert) {
+      await visit("/chat/channel/1/cat");
+
+      publishToMessageBus("/chat/1", {
+        type: "sent",
+        chat_message: {
+          id: 3,
+          cooked: "<p>hello!</p>",
+          user: {
+            id: 2,
+          },
+        },
+      });
+      await settled();
+
+      assert.notOk(exists(`.chat-message-container[data-id='${3}']`));
+    });
+
+    test("It continues to handle other message types", async function (assert) {
+      await visit("/chat/channel/1/cat");
+
+      publishToMessageBus("/chat/1", {
+        action: "add",
+        user: { id: 77, username: "notTomtom" },
+        emoji: "cat",
+        type: "reaction",
+        chat_message_id: 1,
+      });
+      await settled();
+
+      assert.ok(exists(".chat-message-reaction.cat"));
+    });
+  }
+);


### PR DESCRIPTION
When we set up a chat channel, we subscribe to a message bus channel that notifies us about updates, one of them being new messages from other users. To show them in real-time, we add them immediately, but since we don't check if
all the latest ones are already loaded, we may create a gap where some messages will be missing until you refresh the tab.

We are changing how we handle new message updates and checking if it's possible to scroll into the future, and if it is, it means we haven't loaded all the latest messages yet, so we'll display a "jump to latest" button.


https://user-images.githubusercontent.com/5025816/179126445-ed56b275-0260-42db-9b8a-458a1d1ed07f.mov

Thanks to this bug, we also noticed that our last read update logic is problematic because it aggressively updates to the latest unread and **loaded** message every two seconds without checking if the message is visible. Because of
this, the new message update that introduces the gap also updates your last read message to the latest channel's message.

Another scenario where this is problematic is when you visit a channel for one second, then switch to a different one. Here, the runner could mark up to 50 messages (max items loaded per page) as read. It also means the next time
you visit, we will start fetching from the unread message number 51, so you'll have to scroll up to find where you really left.

This PR implements a binary search to find an unread message available in the viewport and schedules a last read message update only when scrolling into the future, reducing the number of attempts to update. The downside is that we
end up with a few more requests per user, but the read progression feels more natural.

<!-- Checklist for UI / stylesheet changes, delete if not applicable -->

- [X] chat-scoped -- core unaffected

### View mode

- [X] docked (windowed/drawer)

### Browsers

- [X] safari
- [X] chrome
- [X] firefox

### Device

- [X] desktop – wide screen
- [X] mobile – `?mobile_view=1`
