### PR TITLE
UX: stop displaying member count, clean up minimized chat view

### DIFF
--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -124,6 +124,12 @@ export default Component.extend({
     this.switchChannel(channel);
   },
 
+  @discourseComputed("expanded")
+  topLineClass(expanded) {
+    const baseClass = "topic-chat-drawer-header__top-line";
+    return expanded ? baseClass + "--expanded" : baseClass + "--collapsed";
+  },
+
   @discourseComputed("expanded", "chat.activeChannel")
   displayMembers(expanded, channel) {
     return expanded && !channel?.isDirectMessageChannel;

--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -127,7 +127,7 @@ export default Component.extend({
   @discourseComputed("expanded")
   topLineClass(expanded) {
     const baseClass = "topic-chat-drawer-header__top-line";
-    return expanded ? baseClass + "--expanded" : baseClass + "--collapsed";
+    return expanded ? `${baseClass}--expanded` : `${baseClass}--collapsed`;
   },
 
   @discourseComputed("expanded", "chat.activeChannel")

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -14,15 +14,6 @@
         class="chat-full-page-header__title"
       }}
         {{chat-channel-title channel=chatChannel}}
-
-        {{#if displayMembers}}
-          <span class="chat-channel-member-count">
-            {{i18n
-              "chat.channel.memberships_count"
-              count=chatChannel.memberships_count
-            }}
-          </span>
-        {{/if}}
       {{/link-to}}
 
       {{#if showCloseFullScreenBtn}}

--- a/assets/javascripts/discourse/templates/components/topic-chat-float.hbs
+++ b/assets/javascripts/discourse/templates/components/topic-chat-float.hbs
@@ -46,8 +46,7 @@
               class="topic-chat-drawer-header__title"
             }}
               <div class="topic-chat-drawer-header__top-line">
-                {{#chat-channel-title channel=chat.activeChannel}}
-                {{/chat-channel-title}}
+                {{chat-channel-title channel=chat.activeChannel}}
               </div>
             {{/link-to}}
           {{else}}

--- a/assets/javascripts/discourse/templates/components/topic-chat-float.hbs
+++ b/assets/javascripts/discourse/templates/components/topic-chat-float.hbs
@@ -38,31 +38,29 @@
         {{/if}}
 
         {{#if chat.activeChannel}}
-          {{#link-to
-            infoTabRoute
-            chat.activeChannel.id
-            chat.activeChannel.title
-            class="topic-chat-drawer-header__title"
-          }}
-            <div class="topic-chat-drawer-header__top-line">
-              {{#chat-channel-title channel=chat.activeChannel}}
-                {{#if (and (not expanded) unreadCount)}}
-                  <span class="chat-unread-count">{{unreadCount}}</span>
-                {{/if}}
-              {{/chat-channel-title}}
-            </div>
-
-            {{#if displayMembers}}
-              <div class="topic-chat-drawer-header__bottom-line">
-                <span class="chat-channel-member-count">
-                  {{i18n
-                    "chat.channel.memberships_count"
-                    count=chat.activeChannel.memberships_count
-                  }}
-                </span>
+          {{#if expanded}}
+            {{#link-to
+              infoTabRoute
+              chat.activeChannel.id
+              chat.activeChannel.title
+              class="topic-chat-drawer-header__title"
+            }}
+              <div class="topic-chat-drawer-header__top-line">
+                {{#chat-channel-title channel=chat.activeChannel}}
+                {{/chat-channel-title}}
               </div>
-            {{/if}}
-          {{/link-to}}
+            {{/link-to}}
+          {{else}}
+            <div role="button" {{action "toggleExpand"}} class="topic-chat-drawer-header__title">
+              <div class="topic-chat-drawer-header__top-line">
+                {{#chat-channel-title channel=chat.activeChannel}}
+                  {{#if unreadCount}}
+                    <span class="chat-unread-count">{{unreadCount}}</span>
+                  {{/if}}
+                {{/chat-channel-title}}
+              </div>
+            </div>
+          {{/if}}
         {{/if}}
       {{else}}
         <span class="topic-chat-drawer-header__title">
@@ -74,15 +72,17 @@
 
       <div class="topic-chat-drawer-header__right-actions">
         <div class="topic-chat-drawer-header__top-line">
-          <button
-            class="btn-flat chat-full-screen-btn"
-            onmouseup={{action "openInFullPage"}}
-            icon="discourse-expand"
-            title={{i18n "chat.open_full_page"}}
-            type="button"
-          >
-            {{d-icon "discourse-expand"}}
-          </button>
+          {{#if expanded}}
+            <button
+              class="btn-flat chat-full-screen-btn"
+              onmouseup={{action "openInFullPage"}}
+              icon="discourse-expand"
+              title={{i18n "chat.open_full_page"}}
+              type="button"
+            >
+              {{d-icon "discourse-expand"}}
+            </button>
+          {{/if}}
 
           {{flat-button
             icon=this.expandIcon

--- a/assets/javascripts/discourse/templates/components/topic-chat-float.hbs
+++ b/assets/javascripts/discourse/templates/components/topic-chat-float.hbs
@@ -12,7 +12,7 @@
         <div class="topic-chat-drawer-header__left-actions">
           <div class="topic-chat-drawer-header__top-line">
             {{flat-button
-              class="return-to-channels"
+              class="topic-chat-drawer-header__return-to-channels-btn"
               icon="chevron-left"
               action=(action "fetchChannels")
               title="chat.return_to_list"
@@ -29,7 +29,7 @@
         {{#if this.expanded}}
           <div class="topic-chat-drawer-header__left-actions">
             {{flat-button
-              class="return-to-channels"
+              class="topic-chat-drawer-header__return-to-channels-btn"
               icon="chevron-left"
               action=(action "fetchChannels")
               title="chat.return_to_list"
@@ -70,10 +70,10 @@
       {{/if}}
 
       <div class="topic-chat-drawer-header__right-actions">
-        <div class="topic-chat-drawer-header__top-line">
+        <div class="topic-chat-drawer-header__top-line {{topLineClass}}">
           {{#if expanded}}
             <button
-              class="btn-flat chat-full-screen-btn"
+              class="btn-flat topic-chat-drawer-header__full-screen-btn"
               onmouseup={{action "openInFullPage"}}
               icon="discourse-expand"
               title={{i18n "chat.open_full_page"}}
@@ -85,7 +85,7 @@
 
           {{flat-button
             icon=this.expandIcon
-            class="chat-expand"
+            class="topic-chat-drawer-header__expand-btn"
             action=(action "toggleExpand")
             title="chat.collapse"
           }}
@@ -95,7 +95,7 @@
               icon="times"
               action=(action "close")
               title="chat.close"
-              class="chat-close-btn"
+              class="topic-chat-drawer-header__close-btn"
             }}
           {{/if}}
         </div>

--- a/assets/stylesheets/common/chat-drawer.scss
+++ b/assets/stylesheets/common/chat-drawer.scss
@@ -111,14 +111,10 @@ body.composer-open .topic-chat-float-container {
   width: 100%;
   font-weight: 700;
   padding: 0 0.5rem;
+  cursor: pointer;
 
   .chat-channel-title {
     padding: 0;
-  }
-
-  .chat-channel-member-count {
-    margin-top: -0.25rem;
-    margin-left: 1.55rem;
   }
 }
 

--- a/assets/stylesheets/common/chat-drawer.scss
+++ b/assets/stylesheets/common/chat-drawer.scss
@@ -171,10 +171,10 @@ body.composer-open .topic-chat-float-container {
     }
   }
 
-  .return-to-channels,
-  .chat-close-btn,
-  .chat-full-screen-btn,
-  .chat-expand {
+  &__return-to-channels-btn,
+  &__close-btn,
+  &__full-screen-btn,
+  &__expand-btn {
     height: 100%;
     max-height: 2.5rem;
     width: 2.5rem;

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -868,12 +868,6 @@ body.has-full-page-chat {
   font-weight: 500;
 }
 
-.chat-channel-member-count {
-  font-weight: 500;
-  font-size: var(--font-down-1);
-  margin-left: 2rem;
-}
-
 .chat-browse {
   overflow-y: auto;
 }

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -550,13 +550,13 @@ acceptance("Discourse Chat - without unread", function (needs) {
     this.appEvents.trigger("chat:toggle-open");
     await settled();
 
-    await click(".return-to-channels");
+    await click(".topic-chat-drawer-header__return-to-channels-btn");
     await click(".chat-channel-row.chat-channel-9");
     await triggerEvent(".chat-message-container[data-id='174']", "mouseenter");
     await click(".chat-message-container[data-id='174'] .reply-btn");
     // Reply-to line is present
     assert.ok(exists(".chat-composer-message-details .chat-reply"));
-    await click(".return-to-channels");
+    await click(".topic-chat-drawer-header__return-to-channels-btn");
     await click(".chat-channel-row.chat-channel-11");
     // Reply-to line is gone since switching channels
     assert.notOk(exists(".chat-composer-message-details .chat-reply"));
@@ -567,13 +567,13 @@ acceptance("Discourse Chat - without unread", function (needs) {
     await click(".cancel-message-action");
 
     // Go back to channel 9 and check that reply-to is present
-    await click(".return-to-channels");
+    await click(".topic-chat-drawer-header__return-to-channels-btn");
     await click(".chat-channel-row.chat-channel-9");
     // Now reply-to should be back and loaded from draft
     assert.ok(exists(".chat-composer-message-details .chat-reply"));
 
     // Go back one for time to channel 7 and make sure reply-to is gone
-    await click(".return-to-channels");
+    await click(".topic-chat-drawer-header__return-to-channels-btn");
     await click(".chat-channel-row.chat-channel-11");
     assert.notOk(exists(".chat-composer-message-details .chat-reply"));
   });
@@ -1150,7 +1150,7 @@ acceptance(
       await visit("/t/internationalization-localization/280");
       this.chatService.set("sidebarActive", false);
       await visit(".header-dropdown-toggle.open-chat");
-      await click(".chat-full-screen-btn");
+      await click(".topic-chat-drawer-header__full-screen-btn");
 
       assert.equal(currentURL(), `/chat/channel/11/another-category`);
     });
@@ -1219,6 +1219,87 @@ acceptance(
     test("Close fullscreen chat button present", async function (assert) {
       await visit("/chat/channel/11/another-category");
       assert.ok(exists(".chat-full-screen-button"));
+    });
+  }
+);
+
+acceptance(
+  "Discourse Chat - Expand and collapse chat drawer (topic-chat-float)",
+  function (needs) {
+    needs.user({
+      admin: false,
+      moderator: false,
+      username: "eviltrout",
+      id: 1,
+      can_chat: true,
+      has_chat_enabled: true,
+    });
+    needs.settings({
+      chat_enabled: true,
+    });
+    needs.pretender((server, helper) => {
+      baseChatPretenders(server, helper);
+      siteChannelPretender(server, helper, { unread_count: 2, muted: false });
+      chatChannelPretender(server, helper, [
+        { id: 9, unread_count: 2, muted: false },
+      ]);
+    });
+    needs.hooks.beforeEach(function () {
+      Object.defineProperty(this, "chatService", {
+        get: () => this.container.lookup("service:chat"),
+      });
+    });
+
+    test("chat drawer can be collapsed and expanded", async function (assert) {
+      await visit("/t/internationalization-localization/280");
+      this.chatService.set("sidebarActive", false);
+      await click(".header-dropdown-toggle.open-chat");
+      assert.ok(
+        visible(".topic-chat-drawer-header__top-line--expanded"),
+        "chat float is expanded"
+      );
+      await click(".topic-chat-drawer-header__expand-btn");
+      assert.ok(
+        visible(".topic-chat-drawer-header__top-line--collapsed"),
+        "chat float is collapsed"
+      );
+      await click(".topic-chat-drawer-header__expand-btn");
+      assert.ok(
+        visible(".topic-chat-drawer-header__top-line--expanded"),
+        "chat float is expanded"
+      );
+    });
+
+    test("chat drawer title links to channel info when expanded", async function (assert) {
+      await visit("/t/internationalization-localization/280");
+      this.chatService.set("sidebarActive", false);
+      await click(".header-dropdown-toggle.open-chat");
+      assert.ok(
+        visible(".topic-chat-drawer-header__top-line--expanded"),
+        "chat float is expanded"
+      );
+      await click(".topic-chat-drawer-header__title");
+      assert.equal(currentURL(), `/chat/channel/9/Site/info/settings`);
+    });
+
+    test("chat drawer title expands the chat drawer when collapsed", async function (assert) {
+      await visit("/t/internationalization-localization/280");
+      this.chatService.set("sidebarActive", false);
+      await click(".header-dropdown-toggle.open-chat");
+      assert.ok(
+        visible(".topic-chat-drawer-header__top-line--expanded"),
+        "chat float is expanded"
+      );
+      await click(".topic-chat-drawer-header__expand-btn");
+      assert.ok(
+        visible(".topic-chat-drawer-header__top-line--collapsed"),
+        "chat float is collapsed"
+      );
+      await click(".topic-chat-drawer-header__title");
+      assert.ok(
+        visible(".topic-chat-drawer-header__top-line--expanded"),
+        "chat float is expanded"
+      );
     });
   }
 );

--- a/test/javascripts/acceptance/user-card-chat-test.js
+++ b/test/javascripts/acceptance/user-card-chat-test.js
@@ -85,7 +85,7 @@ acceptance("Discourse Chat - User card test", function (needs) {
     await visit("/latest");
     this.appEvents.trigger("chat:toggle-open");
     await settled();
-    await click(".return-to-channels");
+    await click(".topic-chat-drawer-header__return-to-channels-btn");
     await click(".chat-channel-row.chat-channel-9");
     await click("[data-user-card='hawk']");
     assert.ok(exists(".user-card-chat-btn"));


### PR DESCRIPTION
- Removes member count from header in chat, it is not adding value
- Remove "full screen" button from minimized chat
- When minimized any click will simply restore height drawer
- BEM-izes some more of the chat drawer CSS classes