### PR TITLE
FIX: slugify channel name when opening from float

### DIFF
--- a/assets/javascripts/discourse/templates/components/topic-chat-float.hbs
+++ b/assets/javascripts/discourse/templates/components/topic-chat-float.hbs
@@ -42,7 +42,7 @@
             {{#link-to
               infoTabRoute
               chat.activeChannel.id
-              chat.activeChannel.title
+              (slugify-channel chat.activeChannel.title)
               class="topic-chat-drawer-header__title"
             }}
               <div class="topic-chat-drawer-header__top-line">


### PR DESCRIPTION
<!-- Checklist for UI / stylesheet changes, delete if not applicable -->

- [ ] chat-scoped -- core unaffected

### View mode

- [ ] docked (windowed/drawer)

### Browsers

- [ ] safari
- [ ] chrome
- [ ] firefox

### Device

- [ ] desktop – wide screen
- [ ] mobile – `?mobile_view=1`

### Ember

- [ ] ember-cli
- [ ] legacy
