### PR TITLE
FIX: various issues in selector modal

### DIFF
--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -93,7 +93,7 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
     )
 
     users = User.joins(:user_option).where.not(id: current_user.id)
-    unless DiscourseChat.allowed_group_ids.include?(Group::AUTO_GROUPS[:everyone])
+    if !DiscourseChat.allowed_group_ids.include?(Group::AUTO_GROUPS[:everyone])
       users = users.joins(:groups).where(groups: { id: DiscourseChat.allowed_group_ids })
     end
 

--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -92,22 +92,20 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
       status: :open
     )
 
-    users = User.joins(:user_option)
+    users = User.joins(:user_option).where.not(id: current_user.id)
     unless DiscourseChat.allowed_group_ids.include?(Group::AUTO_GROUPS[:everyone])
       users = users.joins(:groups).where(groups: { id: DiscourseChat.allowed_group_ids })
     end
 
     users = users.where(user_option: { chat_enabled: true })
-    like_filter = "#{filter}%"
-    if SiteSetting.enable_names
-      users = users.where("LOWER(users.name) LIKE ? OR LOWER(users.username) LIKE ?", like_filter, like_filter)
+    like_filter = "%#{filter}%"
+    if SiteSetting.prioritize_username_in_ux || !SiteSetting.enable_names
+      users = users.where("users.username_lower ILIKE ?", like_filter)
     else
-      users = users.where("LOWER(users.username) LIKE ?", like_filter)
+      users = users.where("LOWER(users.name) ILIKE ? OR users.username_lower ILIKE ?", like_filter, like_filter)
     end
 
     users = users.limit(25).uniq
-    # Need to filter out current user for chat channel query
-    users.reject! { |user| user.id === current_user.id }
 
     direct_message_channels = users.count > 0 ?
       ChatChannel

--- a/assets/javascripts/discourse/components/chat-channel-selector-modal-inner.js
+++ b/assets/javascripts/discourse/components/chat-channel-selector-modal-inner.js
@@ -8,6 +8,7 @@ import { inject as service } from "@ember/service";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import discourseDebounce from "discourse-common/lib/debounce";
 import { INPUT_DELAY } from "discourse-common/config/environment";
+import { isPresent } from "@ember/utils";
 
 export default Component.extend({
   chat: service(),
@@ -115,21 +116,26 @@ export default Component.extend({
 
   @action
   search() {
-    if (this.filter.trim()) {
-      discourseDebounce(this.fetchChannelsFromServer, INPUT_DELAY, this);
+    if (isPresent(this.filter?.trim())) {
+      discourseDebounce(
+        this,
+        this.fetchChannelsFromServer,
+        this.filter.trim(),
+        INPUT_DELAY
+      );
     } else {
-      discourseDebounce(this.getInitialChannels, INPUT_DELAY, this);
+      discourseDebounce(this, this.getInitialChannels, INPUT_DELAY);
     }
   },
 
   @action
-  fetchChannelsFromServer() {
+  fetchChannelsFromServer(filter) {
     this.setProperties({
       loading: true,
       searchIndex: this.searchIndex + 1,
     });
     const thisSearchIndex = this.searchIndex;
-    ajax("/chat/chat_channels/search", { data: { filter: this.filter } })
+    ajax("/chat/chat_channels/search", { data: { filter } })
       .then((searchModel) => {
         if (this.searchIndex === thisSearchIndex) {
           this.set("searchModel", searchModel);


### PR DESCRIPTION
- race condition with this filter and debounce
- not correctly filtering usernames
- directly exclude current user in query
- user username_lower instead of LOWER()
- correctly checks for prioritize_username_in_ux and enable_names
