### PR TITLE
FIX: For non-open channels do not show Join on preview card

### DIFF
--- a/assets/javascripts/discourse/components/chat-channel-preview-card.js
+++ b/assets/javascripts/discourse/components/chat-channel-preview-card.js
@@ -3,6 +3,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { isEmpty } from "@ember/utils";
 import ChatApi from "discourse/plugins/discourse-chat/discourse/lib/chat-api";
 import { action, computed } from "@ember/object";
+import { alias } from "@ember/object/computed";
 import { inject as service } from "@ember/service";
 
 export default class ChatChannelPreviewCard extends Component {
@@ -11,6 +12,8 @@ export default class ChatChannelPreviewCard extends Component {
   @service chat;
 
   channel = null;
+
+  @alias("channel.isOpen") showJoinButton;
 
   @action
   onJoinChannel() {

--- a/assets/javascripts/discourse/components/chat-channel-preview-card.js
+++ b/assets/javascripts/discourse/components/chat-channel-preview-card.js
@@ -3,7 +3,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { isEmpty } from "@ember/utils";
 import ChatApi from "discourse/plugins/discourse-chat/discourse/lib/chat-api";
 import { action, computed } from "@ember/object";
-import { alias } from "@ember/object/computed";
+import { readOnly } from "@ember/object/computed";
 import { inject as service } from "@ember/service";
 
 export default class ChatChannelPreviewCard extends Component {
@@ -13,7 +13,7 @@ export default class ChatChannelPreviewCard extends Component {
 
   channel = null;
 
-  @alias("channel.isOpen") showJoinButton;
+  @readOnly("channel.isOpen") showJoinButton;
 
   @action
   onJoinChannel() {

--- a/assets/javascripts/discourse/templates/components/chat-channel-preview-card.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-preview-card.hbs
@@ -3,11 +3,13 @@
   {{#if hasDescription}}
     <p class="chat-channel-preview-card__description">{{channel.description}}</p>
   {{/if}}
-  {{d-button
-    action=(action "onJoinChannel")
-    label="chat.channel_settings.join_channel"
-    class="chat-channel-preview-card__join-channel-btn btn-primary"
-  }}
+  {{#if showJoinButton}}
+    {{d-button
+      action=(action "onJoinChannel")
+      label="chat.channel_settings.join_channel"
+      class="chat-channel-preview-card__join-channel-btn btn-primary"
+    }}
+  {{/if}}
   <LinkTo @route="chat.browse" class="chat-channel-preview-card__browse-all">
     {{i18n "chat.browse_all_channels"}}
   </LinkTo>

--- a/test/javascripts/components/chat-channel-preview-card-test.js
+++ b/test/javascripts/components/chat-channel-preview-card-test.js
@@ -86,5 +86,35 @@ discourseModule(
         "it shows a link to browse all channels"
       );
     });
+
+    test("closed channel", async function (assert) {
+      this.channel.set("status", "closed");
+      await render(hbs`{{chat-channel-preview-card channel=channel}}`);
+
+      assert.notOk(
+        exists(".chat-channel-preview-card__join-channel-btn"),
+        "it does not show the join channel button"
+      );
+    });
+
+    test("archived channel", async function (assert) {
+      this.channel.set("status", "archived");
+      await render(hbs`{{chat-channel-preview-card channel=channel}}`);
+
+      assert.notOk(
+        exists(".chat-channel-preview-card__join-channel-btn"),
+        "it does not show the join channel button"
+      );
+    });
+
+    test("read_only channel", async function (assert) {
+      this.channel.set("status", "read_only");
+      await render(hbs`{{chat-channel-preview-card channel=channel}}`);
+
+      assert.notOk(
+        exists(".chat-channel-preview-card__join-channel-btn"),
+        "it does not show the join channel button"
+      );
+    });
   }
 );

--- a/test/javascripts/components/chat-channel-preview-card-test.js
+++ b/test/javascripts/components/chat-channel-preview-card-test.js
@@ -96,25 +96,5 @@ discourseModule(
         "it does not show the join channel button"
       );
     });
-
-    test("archived channel", async function (assert) {
-      this.channel.set("status", "archived");
-      await render(hbs`{{chat-channel-preview-card channel=channel}}`);
-
-      assert.notOk(
-        exists(".chat-channel-preview-card__join-channel-btn"),
-        "it does not show the join channel button"
-      );
-    });
-
-    test("read_only channel", async function (assert) {
-      this.channel.set("status", "read_only");
-      await render(hbs`{{chat-channel-preview-card channel=channel}}`);
-
-      assert.notOk(
-        exists(".chat-channel-preview-card__join-channel-btn"),
-        "it does not show the join channel button"
-      );
-    });
   }
 );


### PR DESCRIPTION
When we show the chat channel preview card if you
are not a member of the channel, we should not be
showing the Join button if the channel is anything
but open (e.g. closed/archived/etc)