### PR TITLE
FIX: Add a scheduled job to auto-join users when their state changes.

### DIFF
--- a/app/jobs/regular/auto_join_channel_batch.rb
+++ b/app/jobs/regular/auto_join_channel_batch.rb
@@ -61,7 +61,7 @@ module Jobs
           users.staged IS FALSE AND users.active AND
           NOT EXISTS(SELECT 1 FROM anonymous_users a WHERE a.user_id = users.id) AND
           (suspended_till IS NULL OR suspended_till <= :suspended_until) AND
-          (last_seen_at IS NULL OR last_seen_at > :last_seen_at) AND
+          (last_seen_at > :last_seen_at) AND
           uo.chat_enabled AND
           uccm.id IS NULL
       SQL

--- a/app/jobs/regular/auto_manage_channel_memberships.rb
+++ b/app/jobs/regular/auto_manage_channel_memberships.rb
@@ -12,7 +12,12 @@ module Jobs
 
       return if !channel
 
-      processed = 0
+      processed =
+        UserChatChannelMembership.where(
+          chat_channel: channel,
+          following: true,
+          join_mode: UserChatChannelMembership.join_modes[:automatic],
+        ).count
 
       auto_join_query(channel).find_in_batches do |batch|
         break if processed >= SiteSetting.max_chat_auto_joined_users
@@ -44,7 +49,7 @@ module Jobs
           .not_staged
           .distinct
           .select(:id, "users.id AS query_user_id")
-          .where("last_seen_at IS NULL OR last_seen_at > ?", 3.months.ago)
+          .where("last_seen_at > ?", 3.months.ago)
           .joins(:user_option)
           .where(user_options: { chat_enabled: true })
           .joins(<<~SQL)

--- a/app/jobs/scheduled/auto_join_users.rb
+++ b/app/jobs/scheduled/auto_join_users.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Jobs
+  class AutoJoinUsers < ::Jobs::Scheduled
+    every 1.hour
+
+    def execute(_args)
+      ChatChannel
+        .where(auto_join_users: true)
+        .each { |channel| UserChatChannelMembership.enforce_automatic_channel_memberships(channel) }
+    end
+  end
+end

--- a/spec/jobs/scheduled/auto_join_users_spec.rb
+++ b/spec/jobs/scheduled/auto_join_users_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Jobs::AutoJoinUsers do
+  it "works" do
+    Jobs.run_immediately!
+    channel = Fabricate(:chat_channel, auto_join_users: true)
+    user = Fabricate(:user, last_seen_at: 1.minute.ago, active: true)
+
+    membership = UserChatChannelMembership.find_by(user: user, chat_channel: channel)
+    expect(membership).to be_nil
+
+    subject.execute({})
+
+    membership = UserChatChannelMembership.find_by(user: user, chat_channel: channel)
+    expect(membership.following).to eq(true)
+  end
+end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2,8 +2,6 @@
 
 describe UsersController do
   describe "#perform_account_activation" do
-    let(:user) { Fabricate(:user, active: false) }
-    let(:email_token) { Fabricate(:email_token, user: user) }
     let!(:channel) { Fabricate(:chat_channel, auto_join_users: true) }
 
     before do
@@ -14,6 +12,9 @@ describe UsersController do
     end
 
     it "triggers the auto-join process" do
+      user = Fabricate(:user, last_seen_at: 1.minute.ago, active: false)
+      email_token = Fabricate(:email_token, user: user)
+
       put "/u/activate-account/#{email_token.token}"
 
       expect(response.status).to eq(200)


### PR DESCRIPTION
Additionally, trigger an auto-join for a user the first time we set `last_seen_at` instead of on create to avoid adding users who never visited the site.
