### PR TITLE
DEV: Fix "Create channel modal" test

### DIFF
--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -40,6 +40,7 @@ import sinon from "sinon";
 import * as ajaxModule from "discourse/lib/ajax";
 import I18n from "I18n";
 import { CHANNEL_STATUSES } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
+import fabricators from "../helpers/fabricators";
 
 const baseChatPretenders = (server, helper) => {
   server.get("/chat/:chatChannelId/messages.json", () =>
@@ -1377,15 +1378,19 @@ acceptance(
       can_chat: true,
       has_chat_enabled: true,
     });
+
     needs.settings({
       chat_enabled: true,
     });
+
     needs.pretender((server, helper) => {
       baseChatPretenders(server, helper);
       chatChannelPretender(server, helper);
-      server.get("/chat/chat_channels/:chatChannelId", () => {
-        return helper.response(siteChannel);
+
+      server.get("/chat/api/chat_channels.json", () => {
+        return helper.response([fabricators.chatChannel()]);
       });
+
       server.put("/chat/chat_channels", () => {
         return helper.response({
           chat_channel: {
@@ -1411,26 +1416,25 @@ acceptance(
       const dropdown = selectKit(".edit-channels-dropdown");
       await dropdown.expand();
       await dropdown.selectRowByValue("browseChannels");
+      assert.strictEqual(currentURL(), "/chat/browse/open");
 
-      assert.equal(currentURL(), "/chat/browse/open");
       await visit("/chat/channel/11/another-category");
       await dropdown.expand();
       await dropdown.selectRowByValue("openCreateChannelModal");
       assert.ok(exists(".create-channel-modal"));
-
       assert.ok(query(".create-channel-modal .btn.create").disabled);
+
       let categories = selectKit(".create-channel-modal .category-chooser");
       await categories.expand();
       await categories.selectRowByValue("6"); // Category 6 is "support"
-      assert.equal(
+      assert.strictEqual(
         query(".create-channel-modal .create-channel-name-input").value.trim(),
         "support"
       );
       assert.notOk(query(".create-channel-modal .btn.create").disabled);
 
-      assert.notOk(query(".create-channel-modal .btn.create").disabled);
       await click(".create-channel-modal .btn.create");
-      assert.equal(currentURL(), "/chat/channel/88/something");
+      assert.strictEqual(currentURL(), "/chat/channel/88/something");
     });
   }
 );


### PR DESCRIPTION
It previously worked (occasionally) just because of pretender handler leak. That issue will be fixed in core.