### PR TITLE
DEV: Suppress stree lint warnings with RUBYOPT="-W0"

### DIFF
--- a/.github/workflows/plugin-linting.yml
+++ b/.github/workflows/plugin-linting.yml
@@ -58,4 +58,4 @@ jobs:
 
       - name: Syntax Tree
         if: ${{ always() }}
-        run: bundle exec stree check --print-width=100 --plugins=plugin/trailing_comma **/*.rb Gemfile **/*.rake
+        run: RUBYOPT="-W0" bundle exec stree check --print-width=100 --plugins=plugin/trailing_comma **/*.rb Gemfile **/*.rake


### PR DESCRIPTION
The linter currently spams this warning in CI (and locally):

> warning: Pattern matching is experimental, and the behavior may change in future versions of Ruby!

No need to see that every time, so suppressing warnings.
