### PR TITLE
FEATURE: show status next to avatar on chat messages

### DIFF
--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -448,16 +448,21 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
   private
 
   def preloaded_chat_message_query
-    ChatMessage
+    query = ChatMessage
       .includes(in_reply_to: [:user, chat_webhook_event: [:incoming_chat_webhook]])
       .includes(:revisions)
       .includes(:user)
-      .includes(user: :user_status )
       .includes(chat_webhook_event: :incoming_chat_webhook)
       .includes(reactions: :user)
       .includes(:bookmarks)
       .includes(:uploads)
       .includes(chat_channel: :chatable)
+
+    if SiteSetting.enable_user_status
+      query = query.includes(user: :user_status )
+    end
+
+    query
   end
 
   def find_chatable

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -448,19 +448,18 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
   private
 
   def preloaded_chat_message_query
-    query = ChatMessage
-      .includes(in_reply_to: [:user, chat_webhook_event: [:incoming_chat_webhook]])
-      .includes(:revisions)
-      .includes(:user)
-      .includes(chat_webhook_event: :incoming_chat_webhook)
-      .includes(reactions: :user)
-      .includes(:bookmarks)
-      .includes(:uploads)
-      .includes(chat_channel: :chatable)
+    query =
+      ChatMessage
+        .includes(in_reply_to: [:user, chat_webhook_event: [:incoming_chat_webhook]])
+        .includes(:revisions)
+        .includes(:user)
+        .includes(chat_webhook_event: :incoming_chat_webhook)
+        .includes(reactions: :user)
+        .includes(:bookmarks)
+        .includes(:uploads)
+        .includes(chat_channel: :chatable)
 
-    if SiteSetting.enable_user_status
-      query = query.includes(user: :user_status )
-    end
+    query = query.includes(user: :user_status) if SiteSetting.enable_user_status
 
     query
   end

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -452,6 +452,7 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
       .includes(in_reply_to: [:user, chat_webhook_event: [:incoming_chat_webhook]])
       .includes(:revisions)
       .includes(:user)
+      .includes(user: :user_status )
       .includes(chat_webhook_event: :incoming_chat_webhook)
       .includes(reactions: :user)
       .includes(:bookmarks)

--- a/app/serializers/basic_user_with_status_serializer.rb
+++ b/app/serializers/basic_user_with_status_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class BasicUserWithStatusSerializer < BasicUserSerializer
+  attributes :status
+
+  def include_status?
+    SiteSetting.enable_user_status && user.has_status?
+  end
+
+  def status
+    UserStatusSerializer.new(user.user_status, root: false)
+  end
+end

--- a/app/serializers/chat_message_serializer.rb
+++ b/app/serializers/chat_message_serializer.rb
@@ -14,7 +14,7 @@ class ChatMessageSerializer < ApplicationSerializer
              :reactions,
              :bookmark
 
-  has_one :user, serializer: BasicUserSerializer, embed: :objects
+  has_one :user, serializer: BasicUserWithStatusSerializer, embed: :objects
   has_one :chat_webhook_event, serializer: ChatWebhookEventSerializer, embed: :objects
   has_one :in_reply_to, serializer: ChatInReplyToSerializer, embed: :objects
   has_many :uploads, serializer: UploadSerializer, embed: :objects

--- a/assets/javascripts/discourse/components/chat-message-info.js
+++ b/assets/javascripts/discourse/components/chat-message-info.js
@@ -8,6 +8,16 @@ export default class ChatMessageInfo extends Component {
   message = null;
   details = null;
 
+  didInsertElement() {
+    this._super(...arguments);
+    this.message.user?.trackStatus?.();
+  }
+
+  willDestroyElement() {
+    this._super(...arguments);
+    this.message.user?.stopTrackingStatus?.();
+  }
+
   @computed("message.user")
   get name() {
     if (!this.message?.user) {
@@ -30,6 +40,11 @@ export default class ChatMessageInfo extends Component {
       this.siteSettings.display_name_on_posts &&
       prioritizeNameInUx(this.message?.user?.name)
     );
+  }
+
+  @computed("message.user.status")
+  get showStatus() {
+    return !!this.message.user?.status;
   }
 
   @computed("message.user")

--- a/assets/javascripts/discourse/models/chat-message.js
+++ b/assets/javascripts/discourse/models/chat-message.js
@@ -1,2 +1,20 @@
 import RestModel from "discourse/models/rest";
-export default RestModel.extend({});
+import User from "discourse/models/user";
+
+const ChatMessage = RestModel.extend({});
+
+ChatMessage.reopenClass({
+  create(args) {
+    args = args || {};
+    this._initUserModel(args);
+    return this._super(args);
+  },
+
+  _initUserModel(args) {
+    if (args.user) {
+      args.user = User.create(args.user);
+    }
+  },
+});
+
+export default ChatMessage;

--- a/assets/javascripts/discourse/templates/components/chat-message-info.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message-info.hbs
@@ -16,6 +16,13 @@
       data-user-card={{@message.user.username}}
     >
       <span class="chat-message-info__username__name">{{this.name}}</span>
+      {{#if this.showStatus}}
+        <div class="chat-message-info__status">
+          {{emoji
+            @message.user.status.emoji
+            title=@message.user.status.description}}
+        </div>
+      {{/if}}
     </span>
   {{/if}}
 

--- a/assets/stylesheets/common/chat-message-info.scss
+++ b/assets/stylesheets/common/chat-message-info.scss
@@ -61,3 +61,14 @@
     margin-left: 0.5em;
   }
 }
+
+.chat-message-info__status {
+  display: flex;
+  margin-left: 0.2em;
+  margin-right: 0.2em;
+
+  .emoji {
+    width: 16px;
+    height: 16px;
+  }
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -122,6 +122,7 @@ after_initialize do
   load File.expand_path("../app/models/chat_view.rb", __FILE__)
   load File.expand_path("../app/serializers/chat_webhook_event_serializer.rb", __FILE__)
   load File.expand_path("../app/serializers/chat_in_reply_to_serializer.rb", __FILE__)
+  load File.expand_path("../app/serializers/basic_user_with_status_serializer.rb", __FILE__)
   load File.expand_path("../app/serializers/chat_message_serializer.rb", __FILE__)
   load File.expand_path("../app/serializers/chat_channel_serializer.rb", __FILE__)
   load File.expand_path("../app/serializers/chat_channel_settings_serializer.rb", __FILE__)

--- a/test/javascripts/components/chat-message-info-test.js
+++ b/test/javascripts/components/chat-message-info-test.js
@@ -6,6 +6,7 @@ import hbs from "htmlbars-inline-precompile";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
 import I18n from "I18n";
 import { module } from "qunit";
+import User from "discourse/models/user";
 
 module("Discourse Chat | Component | chat-message-info", function (hooks) {
   setupRenderingTest(hooks);
@@ -88,6 +89,21 @@ module("Discourse Chat | Component | chat-message-info", function (hooks) {
 
     async test(assert) {
       assert.ok(exists(".chat-message-info__bookmark .d-icon-bookmark"));
+    },
+  });
+
+  componentTest("user status", {
+    template: hbs`{{chat-message-info message=message}}`,
+
+    beforeEach() {
+      const status = { description: "off to dentist", emoji: "tooth" };
+      this.set("message", { user: User.create({ status }) });
+    },
+
+    async test(assert) {
+      assert.ok(
+        exists(".chat-message-info__status .emoji[title='off to dentist']")
+      );
     },
   });
 


### PR DESCRIPTION
_Note that before merging this, https://github.com/discourse/discourse/pull/17497 and https://github.com/discourse/discourse/pull/17598 should be merged in Core._

This adds "live" status to the user avatar on chat messages. Note that we'll improve design a bit later:

<img width="232" alt="Screenshot 2022-07-26 at 00 03 05" src="https://user-images.githubusercontent.com/1274517/180864924-271352a4-ef55-4367-8ab8-8cb7e99108b4.png">

