### PR TITLE
FIX: Staff can participate in private categories' chat presence channels.

### DIFF
--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -105,11 +105,21 @@ class ChatChannel < ActiveRecord::Base
   end
 
   def allowed_group_ids
-    category_channel? ? chatable.secure_group_ids : nil
+    return if !category_channel?
+
+    staff_groups = Group::AUTO_GROUPS.slice(:staff, :moderators, :admins).values
+    chatable.secure_group_ids.to_a.concat(staff_groups)
   end
 
   def public_channel_title
     chatable.name
+  end
+
+  def read_restricted?
+    return true if direct_message_channel?
+    return chatable.read_restricted? if category_channel?
+
+    true
   end
 
   def title(user)

--- a/app/queries/chat_channel_memberships_query.rb
+++ b/app/queries/chat_channel_memberships_query.rb
@@ -9,7 +9,7 @@ class ChatChannelMembershipsQuery
         .where(user: User.activated.not_suspended.not_staged)
         .where(chat_channel: channel, following: true)
 
-    if channel.category_channel? && channel.allowed_group_ids
+    if channel.category_channel? && channel.read_restricted? && channel.allowed_group_ids
       query =
         query.where(
           "user_id IN (SELECT user_id FROM group_users WHERE group_id IN (?))",

--- a/plugin.rb
+++ b/plugin.rb
@@ -466,11 +466,12 @@ after_initialize do
   register_presence_channel_prefix("chat-reply") do |channel_name|
     if chat_channel_id = channel_name[%r{/chat-reply/(\d+)}, 1]
       chat_channel = ChatChannel.find(chat_channel_id)
-      config = PresenceChannel::Config.new
-      config.allowed_group_ids = chat_channel.allowed_group_ids
-      config.allowed_user_ids = chat_channel.allowed_user_ids
-      config.public = true if config.allowed_group_ids.nil? && config.allowed_user_ids.nil?
-      config
+
+      PresenceChannel::Config.new.tap do |config|
+        config.allowed_group_ids = chat_channel.allowed_group_ids
+        config.allowed_user_ids = chat_channel.allowed_user_ids
+        config.public = !chat_channel.read_restricted?
+      end
     end
   rescue ActiveRecord::RecordNotFound
     nil

--- a/spec/queries/chat_channel_memberships_query_spec.rb
+++ b/spec/queries/chat_channel_memberships_query_spec.rb
@@ -64,6 +64,15 @@ describe ChatChannelMembershipsQuery do
 
             expect(described_class.call(channel_1).pluck(:user_id)).to contain_exactly(user_1.id)
           end
+
+          it "returns the membership if the user still has access through a staff group" do
+            chatters_group.remove(user_1)
+            Group.find_by(id: Group::AUTO_GROUPS[:staff]).add(user_1)
+
+            memberships = described_class.call(channel_1)
+
+            expect(memberships.pluck(:user_id)).to include(user_1.id)
+          end
         end
 
         context "membership doesn’t exist" do


### PR DESCRIPTION
When a staff member joins a channel, and it's not a member of one of the groups with access to it, it should still be able to join the presence
channel.
