### PR TITLE
FIX: Don’t add users when chatable isn’t present

### DIFF
--- a/app/jobs/regular/auto_manage_channel_memberships.rb
+++ b/app/jobs/regular/auto_manage_channel_memberships.rb
@@ -10,7 +10,7 @@ module Jobs
           chatable_type: "Category",
         )
 
-      return if !channel
+      return if !channel&.chatable
 
       processed =
         UserChatChannelMembership.where(

--- a/spec/jobs/regular/auto_manage_channel_memberships_spec.rb
+++ b/spec/jobs/regular/auto_manage_channel_memberships_spec.rb
@@ -103,6 +103,17 @@ describe Jobs::AutoManageChannelMemberships do
         end
       end
     end
+
+    context "when chatable doesn’t exist anymore" do
+      before do
+        channel.chatable.destroy!
+        channel.reload
+      end
+
+      it "does nothing" do
+        assert_batches_enqueued(channel, 0)
+      end
+    end
   end
 
   def assert_batches_enqueued(channel, expected)


### PR DESCRIPTION
Currently the `AutoManageChannelMemberships` job will add users to a channel following a set of rules. It won’t do anything if the channel doesn’t exist or if the chatable isn’t a category.
But if the chatable doesn’t exist anymore then the job will raise an exception.

This PR addresses this issue by simply checking if the chatable exists before trying to do anything.