### PR TITLE
UX: inline composer on full-page chat layout

### DIFF
--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -64,6 +64,7 @@
 }
 
 // Full Page Styling in Core
+
 .has-full-page-chat:not(.discourse-sidebar) {
   --max-chat-width: 1200px;
 
@@ -159,5 +160,61 @@
     .btn-container {
       opacity: 1;
     }
+  }
+}
+
+.composer-open .has-full-page-chat {
+  // move composer inline, so it doesn't overlay chat
+  #reply-control {
+    position: static;
+  }
+
+  .discourse-root {
+    height: 100vh;
+    display: grid;
+    grid-template-areas: "header" "main" "footer" "composer";
+    grid-template-rows: auto 1fr auto auto;
+    overflow: hidden;
+
+    .d-header-wrap {
+      grid-area: header;
+    }
+
+    #main-outlet-wrapper {
+      grid-area: main;
+    }
+
+    .below-footer-outlet {
+      grid-area: footer;
+    }
+
+    #reply-control {
+      grid-area: composer;
+    }
+  }
+
+  #main-outlet-wrapper {
+    min-height: 0;
+    .sidebar-wrapper {
+      height: 100%;
+    }
+  }
+
+  #main-outlet {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    height: 100%;
+  }
+
+  #main-chat-outlet {
+    height: 100%;
+    min-height: 0;
+  }
+
+  .full-page-chat {
+    display: block;
+    height: 100%;
+    min-height: 0;
   }
 }

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -163,8 +163,9 @@
   }
 }
 
+// move composer inline, so it doesn't overlay chat
+
 .has-full-page-chat {
-  // move composer inline, so it doesn't overlay chat
   #reply-control {
     position: static;
   }

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -64,7 +64,6 @@
 }
 
 // Full Page Styling in Core
-
 .has-full-page-chat:not(.discourse-sidebar) {
   --max-chat-width: 1200px;
 
@@ -164,7 +163,6 @@
 }
 
 // move composer inline, so it doesn't overlay chat
-
 .has-full-page-chat {
   #reply-control {
     position: static;

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -217,4 +217,8 @@
     height: 100%;
     min-height: 0;
   }
+
+  .composer-popup {
+    top: unset;
+  }
 }

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -163,7 +163,7 @@
   }
 }
 
-.composer-open .has-full-page-chat {
+.has-full-page-chat {
   // move composer inline, so it doesn't overlay chat
   #reply-control {
     position: static;


### PR DESCRIPTION
Scoped to `desktop` > `has-full-page-chat`

Tested on `Firefox`, `Safari`, & `Chrome`

This inlines the topic composer when you open it on a full-screen chat, and makes chat (and the sidebar if shown) adjust their height to fit. This grants users full access to chat features while using the composer (previously chat input and controls were hidden _behind_ the fix-positioned composer). 

![Screen Shot 2022-07-26 at 11 00 35 PM](https://user-images.githubusercontent.com/1681963/181151886-effbd7af-3174-4661-afb3-42e57f2aab94.png)


![Screen Shot 2022-07-26 at 11 12 33 PM](https://user-images.githubusercontent.com/1681963/181152684-0508f524-3fb3-4f5f-8c41-6d8b25ba5f50.png)

