### PR TITLE
FIX: reorder private messages in sidebar

### DIFF
--- a/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -211,27 +211,6 @@ export default {
               super(...arguments);
               this.channel = channel;
               this.chatService = chatService;
-
-              this.chatService.appEvents.on(
-                "chat:user-tracking-state-changed",
-                this._refreshTrackingState
-              );
-            }
-
-            @bind
-            willDestroy() {
-              this.chatService.appEvents.off(
-                "chat:user-tracking-state-changed",
-                this._refreshTrackingState
-              );
-            }
-
-            @bind
-            _refreshTrackingState() {
-              this.chatChannelTrackingState =
-                this.chatService.currentUser.chat_channel_tracking_state[
-                  this.channel.id
-                ];
             }
 
             get name() {
@@ -337,8 +316,8 @@ export default {
                 return;
               }
               this.chatService = container.lookup("service:chat");
-              this.sidebar.appEvents.on(
-                "chat:refresh-channels",
+              this.chatService.appEvents.on(
+                "chat:user-tracking-state-changed",
                 this._refreshPms
               );
               this._refreshPms();
@@ -349,8 +328,8 @@ export default {
               if (container.isDestroyed) {
                 return;
               }
-              this.sidebar.appEvents.off(
-                "chat:refresh-channels",
+              this.chatService.appEvents.off(
+                "chat:user-tracking-state-changed",
                 this._refreshPms
               );
             }

--- a/assets/stylesheets/sidebar-extensions.scss
+++ b/assets/stylesheets/sidebar-extensions.scss
@@ -171,7 +171,7 @@
       width: 1em;
     }
     a.sidebar-section-link {
-      width: calc(var(--d-sidebar-width) - 50px);
+      width: calc(var(--d-sidebar-width) - 3em);
     }
   }
 }

--- a/test/javascripts/acceptance/core-sidebar-test.js
+++ b/test/javascripts/acceptance/core-sidebar-test.js
@@ -5,12 +5,13 @@ import {
   queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
-import { visit } from "@ember/test-helpers";
+import { settled, visit } from "@ember/test-helpers";
 import { directMessageChannels } from "discourse/plugins/discourse-chat/chat-fixtures";
 import { cloneJSON } from "discourse-common/lib/object";
 import I18n from "I18n";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { emojiUnescape } from "discourse/lib/text";
+import User from "discourse/models/user";
 
 acceptance("Discourse Chat - Core Sidebar", function (needs) {
   needs.user({ experimental_sidebar_enabled: true, has_chat_enabled: true });
@@ -187,7 +188,7 @@ acceptance("Discourse Chat - Core Sidebar", function (needs) {
       "displays correct direct messages section title"
     );
 
-    const directLinks = queryAll(
+    let directLinks = queryAll(
       ".sidebar-section-chat-dms a.sidebar-section-link"
     );
 
@@ -245,6 +246,21 @@ acceptance("Discourse Chat - Core Sidebar", function (needs) {
     assert.ok(
       !exists(directLinks.eq(1).find(".sidebar-section-link-suffix")[0]),
       "does not display new messages indicator"
+    );
+
+    const chatService = this.container.lookup("service:chat");
+    User.current().chat_channel_tracking_state[76].set("unread_count", 99);
+    chatService.reSortDirectMessageChannels();
+    chatService.appEvents.trigger("chat:user-tracking-state-changed");
+    await settled();
+    directLinks = queryAll(".sidebar-section-chat-dms a.sidebar-section-link");
+    assert.strictEqual(
+      directLinks
+        .eq(0)
+        .find(".sidebar-section-link-content-text")[0]
+        .textContent.trim(),
+      "eviltrout, markvanlan",
+      "reorders private messages"
     );
   });
 });


### PR DESCRIPTION
Private messages section has to be reloaded more often than channels section because they are reordered based on activity (amount of unread messages or last message date when amount of unread messages is same).


https://user-images.githubusercontent.com/72780/181156596-1ff5bea4-322c-4d15-9a10-d8c062b4cd88.mov

