### PR TITLE
FIX: Adjust reply indicator spacing on iOS

### DIFF
--- a/assets/stylesheets/common/chat-replying-indicator.scss
+++ b/assets/stylesheets/common/chat-replying-indicator.scss
@@ -4,9 +4,7 @@
 
 .chat-replying-indicator {
   color: var(--primary-medium);
-  padding-bottom: unquote(
-    "max(calc(env(safe-area-inset-bottom) - 0.75em), 0.25em)"
-  );
+  padding-bottom: 0.5em;
   font-size: var(--font-down-2);
   display: inline-flex;
 


### PR DESCRIPTION
Fixes extra space showing below the reply indicator on iOS. The culprit is `safe-area-inset-bottom`, iOS mistakenly still adds a value there even when the keyboard is visible. Thankfully it doesn't look like we need to account for safe areas here, the input is still clear of the device's bottom on iOS. 

- [x] chat-scoped -- core unaffected

### View mode

- [x] docked (windowed/drawer)

### Browsers

- [x] safari
- [x] chrome
- [ ] firefox

### Device

- [x] desktop – wide screen
- [x] mobile – DiscourseHub
