### PR TITLE
FIX: sidebar direct messages are limited to 20

### DIFF
--- a/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -338,14 +338,16 @@ export default {
             _refreshPms() {
               const newSectionLinks = [];
               this.chatService.getChannels().then((channels) => {
-                channels.directMessageChannels.forEach((channel) => {
-                  newSectionLinks.push(
-                    new SidebarChatDirectMessagesSectionLink({
-                      channel,
-                      chatService: this.chatService,
-                    })
-                  );
-                });
+                this.chatService
+                  .truncateDirectMessageChannels(channels.directMessageChannels)
+                  .forEach((channel) => {
+                    newSectionLinks.push(
+                      new SidebarChatDirectMessagesSectionLink({
+                        channel,
+                        chatService: this.chatService,
+                      })
+                    );
+                  });
                 this.sectionLinks = newSectionLinks;
               });
             }

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -48,6 +48,7 @@ export default Service.extend({
   fullPageChat: service(),
   _chatOpen: false,
   _fetchingChannels: null,
+  directMessagesLimit: 20,
 
   init() {
     this._super(...arguments);
@@ -145,7 +146,7 @@ export default Service.extend({
   },
 
   truncateDirectMessageChannels(channels) {
-    return channels.slice(0, 20);
+    return channels.slice(0, this.directMessagesLimit);
   },
 
   getActiveChannel() {


### PR DESCRIPTION
PMs section should be limited to 20 links.
Existing `truncateDirectMessageChannels` function is used.