### PR TITLE
FIX: prevents mutation of dm creator selected users

### DIFF
--- a/assets/javascripts/discourse/components/chat-draft-channel-screen.js
+++ b/assets/javascripts/discourse/components/chat-draft-channel-screen.js
@@ -2,6 +2,7 @@ import ChatChannel from "discourse/plugins/discourse-chat/discourse/models/chat-
 import { inject as service } from "@ember/service";
 import Component from "@ember/component";
 import { action } from "@ember/object";
+import { cloneJSON } from "discourse-common/lib/object";
 
 export default class ChatDraftChannelScreen extends Component {
   tagName = "";
@@ -37,7 +38,7 @@ export default class ChatDraftChannelScreen extends Component {
           this.set(
             "previewedChannel",
             ChatChannel.create({
-              chatable: { users },
+              chatable: { users: cloneJSON(users) },
               isDraft: true,
             })
           );


### PR DESCRIPTION
Before this fix, selecting a user which doesn’t have a DM yet, would result in the creation of a new channel using selected users as the list of users for the chatable. This would have the consequence of mutating each selected users in the dm creator screen and it would then be impossible to remove a user from the selected users array as the user given to `removeObject` would now be a different object than the one in the array.
