### PR TITLE
DEV: Add created_at index for ChatMessage

### DIFF
--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -220,6 +220,6 @@ end
 #
 # Indexes
 #
+#  idx_chat_messages_by_created_at_not_deleted            (created_at) WHERE (deleted_at IS NULL)
 #  index_chat_messages_on_chat_channel_id_and_created_at  (chat_channel_id,created_at)
-#  index_chat_messages_on_created_at                      (created_at)
 #

--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -221,4 +221,5 @@ end
 # Indexes
 #
 #  index_chat_messages_on_chat_channel_id_and_created_at  (chat_channel_id,created_at)
+#  index_chat_messages_on_created_at                      (created_at)
 #

--- a/db/migrate/20220729032237_add_index_to_chat_message_created_at.rb
+++ b/db/migrate/20220729032237_add_index_to_chat_message_created_at.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexToChatMessageCreatedAt < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :chat_messages, :created_at, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20220729032237_add_index_to_chat_message_created_at.rb
+++ b/db/migrate/20220729032237_add_index_to_chat_message_created_at.rb
@@ -4,6 +4,17 @@ class AddIndexToChatMessageCreatedAt < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
 
   def change
-    add_index :chat_messages, :created_at, algorithm: :concurrently
+    execute <<~SQL
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS
+    idx_chat_messages_by_created_at_not_deleted
+    ON chat_messages (created_at)
+    WHERE deleted_at IS NULL
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+    DROP INDEX IF EXISTS idx_chat_messages_by_created_at_not_deleted
+    SQL
   end
 end


### PR DESCRIPTION
Follow up to ddab84061ccfa2003fa52e73b1c364a7014c47e4,
there could be a lot of messages in the chat message
table, so we want to make sure these stat queries are
using an index.
