### PR TITLE
UX: adjust to fit composer on desktop, fix iPad layout

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -577,7 +577,6 @@ body.has-full-page-chat {
     Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   display: grid;
   grid-template-columns: var(--full-page-sidebar-width) 1fr;
-  grid-template-rows: calc(100vh - var(--header-offset));
 
   .channels-list {
     background: var(--primary-very-low);
@@ -866,17 +865,55 @@ html.has-full-page-chat {
     height: 100%;
     width: 100%;
 
-    #main,
-    .discourse-root {
-      height: calc(var(--chat-vh, 1vh) * 100);
+    #main-outlet {
+      display: flex;
+      flex-direction: column;
+
+      .full-page-chat {
+        height: 100%;
+        min-height: 0;
+      }
+
+      #main-chat-outlet {
+        min-height: 0;
+      }
+    }
+  }
+
+  // make space for the composer so it doesn't overlay chat content
+  &.composer-open {
+    #main-outlet {
+      max-height: calc(
+        100vh - calc(var(--header-offset) + calc(var(--composer-height)))
+      );
+    }
+  }
+
+  // these need to apply to desktop too, because iPads
+  &.discourse-touch {
+    #main-outlet-wrapper {
+      // restrict the row height, including when virtual keyboard is open
+      grid-template-rows: calc(
+        var(--chat-vh, 1vh) * 100 - var(--header-offset)
+      );
+      .sidebar-wrapper {
+        // prevents sidebar from overflowing behind the virtual keyboard
+        height: 100%;
+      }
     }
 
-    #main-outlet-wrapper,
-    #main-outlet,
     .full-page-chat,
     .chat-live-pane,
-    #main-chat-outlet {
-      height: calc(var(--chat-vh, 1vh) * 100 - var(--header-offset));
+    #main-outlet {
+      // allows containers to shrink to fit
+      min-height: 0;
+    }
+
+    #main-outlet {
+      // limits height for iPad
+      max-height: calc(
+        100vh - calc(var(--header-offset) + var(--composer-ipad-padding))
+      );
     }
   }
 }

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -881,6 +881,7 @@ html.has-full-page-chat {
     }
   }
 
+  // make space for the composer so it doesn't overlay chat content
   &.composer-open {
     #main-outlet {
       max-height: calc(
@@ -889,14 +890,19 @@ html.has-full-page-chat {
     }
   }
 
+  // these need to apply to desktop too, because iPads
   &.discourse-touch {
     #main-outlet-wrapper {
+      // restrict the row height, including when virtual keyboard is open
       grid-template-rows: calc(
         var(--chat-vh, 1vh) * 100 - var(--header-offset)
       );
+      .sidebar-wrapper {
+        // prevents sidebar from overflowing behind the virtual keyboard
+        height: 100%;
+      }
     }
 
-    .sidebar-container,
     .full-page-chat,
     .chat-live-pane,
     #main-outlet {
@@ -904,27 +910,11 @@ html.has-full-page-chat {
       min-height: 0;
     }
 
-    #main-chat-outlet {
-      height: 100%;
-    }
-
-    // iPad uses the desktop layout
     #main-outlet {
+      // limits height for iPad
       max-height: calc(
         100vh - calc(var(--header-offset) + var(--composer-ipad-padding))
       );
-    }
-
-    &.composer-open {
-      #main-outlet {
-        max-height: calc(
-          100vh -
-            calc(
-              var(--header-offset) + var(--composer-height) +
-                var(--composer-ipad-padding)
-            )
-        );
-      }
     }
   }
 }

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -868,6 +868,7 @@ html.has-full-page-chat {
     #main-outlet {
       display: flex;
       flex-direction: column;
+      max-height: calc(var(--chat-vh, 1vh) * 100 - var(--header-offset));
 
       .full-page-chat {
         height: 100%;
@@ -880,7 +881,6 @@ html.has-full-page-chat {
     }
   }
 
-  // make space for the composer so it doesn't overlay chat content
   &.composer-open {
     #main-outlet {
       max-height: calc(
@@ -889,19 +889,14 @@ html.has-full-page-chat {
     }
   }
 
-  // these need to apply to desktop too, because iPads
   &.discourse-touch {
     #main-outlet-wrapper {
-      // restrict the row height, including when virtual keyboard is open
       grid-template-rows: calc(
         var(--chat-vh, 1vh) * 100 - var(--header-offset)
       );
-      .sidebar-wrapper {
-        // prevents sidebar from overflowing behind the virtual keyboard
-        height: 100%;
-      }
     }
 
+    .sidebar-container,
     .full-page-chat,
     .chat-live-pane,
     #main-outlet {
@@ -909,11 +904,27 @@ html.has-full-page-chat {
       min-height: 0;
     }
 
+    #main-chat-outlet {
+      height: 100%;
+    }
+
+    // iPad uses the desktop layout
     #main-outlet {
-      // limits height for iPad
       max-height: calc(
         100vh - calc(var(--header-offset) + var(--composer-ipad-padding))
       );
+    }
+
+    &.composer-open {
+      #main-outlet {
+        max-height: calc(
+          100vh -
+            calc(
+              var(--header-offset) + var(--composer-height) +
+                var(--composer-ipad-padding)
+            )
+        );
+      }
     }
   }
 }

--- a/assets/stylesheets/mobile/mobile.scss
+++ b/assets/stylesheets/mobile/mobile.scss
@@ -111,17 +111,8 @@ body.has-full-page-chat {
 }
 
 html.has-full-page-chat body {
-  #main-outlet {
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-  }
-
-  #main-chat-outlet {
-    min-height: 0;
-  }
-
-  .full-page-chat {
-    display: block;
+  #main-outlet-wrapper {
+    // restricts the height of the page
+    grid-template-rows: calc(var(--chat-vh, 1vh) * 100 - var(--header-offset));
   }
 }


### PR DESCRIPTION
ok! I think I've got something for full-screen chat that will:

* adjust chat and sidebar height on desktop when the topic composer is open
* adjust chat and sidebar height on mobile and iPad when the virtual keyboard is open

The adjustments for desktop to accommodate the topic composer use `--composer-height` and otherwise adjusts similarly to mobile/ipad, so I think this should be less fragile than revamping the whole layout just for the topic composer (which is what I did in a previous attempt). 


Desktop - The composer still has a fixed position, but the height of the page adjusts to fit:
![Screen Shot 2022-07-29 at 5 08 40 PM](https://user-images.githubusercontent.com/1681963/181844380-88a01a4d-3af1-406e-a6cd-f95c26cd1a79.png)

iPad: 
![Screen Shot 2022-07-29 at 5 13 38 PM](https://user-images.githubusercontent.com/1681963/181844439-8359c492-c0d4-4868-93f8-1c47fdbc3b5a.png)

Mobile: 
![Screen Shot 2022-07-29 at 5 13 48 PM](https://user-images.githubusercontent.com/1681963/181844475-4641de43-4218-4b23-b840-450ac0371aad.png)

ᕕ(⌐■_■)ᕗ ♪♬
