### PR TITLE
UX: adjust fullscreen height for the iPad iOS app

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -892,6 +892,7 @@ html.has-full-page-chat {
 
   // these need to apply to desktop too, because iPads
   &.discourse-touch {
+    // iPad web
     #main-outlet-wrapper {
       // restrict the row height, including when virtual keyboard is open
       grid-template-rows: calc(
@@ -900,6 +901,17 @@ html.has-full-page-chat {
       .sidebar-wrapper {
         // prevents sidebar from overflowing behind the virtual keyboard
         height: 100%;
+      }
+    }
+
+    // iPad webview
+    .footer-nav-ipad {
+      #main-outlet-wrapper {
+        // restrict the row height, including when virtual keyboard is open
+        grid-template-rows: calc(
+          var(--chat-vh, 1vh) * 100 -
+            calc(var(--header-offset) + var(--footer-nav-height))
+        );
       }
     }
 


### PR DESCRIPTION
Fixes an issue where the content was too tall for iPads in the hub app, because of the added nav (`footer-nav.js`) above the header:

Before:

![Screen Shot 2022-08-01 at 1 10 35 PM](https://user-images.githubusercontent.com/1681963/182204937-e226d8e8-1e56-45b3-a735-30c4f5450295.png)

After:

![Screen Shot 2022-08-01 at 1 11 05 PM](https://user-images.githubusercontent.com/1681963/182204994-054ed0c2-1b11-42a0-bacf-b2451302e2b5.png)



This relies on a core commit to get `--footer-nav-height`, https://github.com/discourse/discourse/pull/17744