### PR TITLE
FIX: prevents crash when joining channel

### DIFF
--- a/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -92,13 +92,13 @@ export default {
             }
 
             get suffixValue() {
-              return this.chatChannelTrackingState.unread_count > 0
+              return this.chatChannelTrackingState?.unread_count > 0
                 ? "circle"
                 : "";
             }
 
             get suffixCSSClass() {
-              return this.chatChannelTrackingState.unread_mentions > 0
+              return this.chatChannelTrackingState?.unread_mentions > 0
                 ? "urgent"
                 : "unread";
             }
@@ -278,7 +278,7 @@ export default {
             }
 
             get suffixValue() {
-              return this.chatChannelTrackingState.unread_count > 0
+              return this.chatChannelTrackingState?.unread_count > 0
                 ? "circle"
                 : "";
             }


### PR DESCRIPTION
While adding the channel to the sidebar, the tracking state might not have been created yet and this would cause an error.
