### PR TITLE
FIX: Do not allow chat uploads if secure_media is enabled

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -17,6 +17,7 @@ en:
     default_emoji_reactions: "Default emoji reactions for chat messages. Add up to 5 emojis for quick reaction."
     errors:
       chat_default_channel: "The default chat channel must be a public channel."
+      chat_upload_not_allowed_secure_media: "Chat uploads are not allowed if secure media is enabled."
   system_messages:
     chat_channel_archive_complete:
       title: "Chat Channel Archive Complete"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -17,7 +17,7 @@ en:
     default_emoji_reactions: "Default emoji reactions for chat messages. Add up to 5 emojis for quick reaction."
     errors:
       chat_default_channel: "The default chat channel must be a public channel."
-      chat_upload_not_allowed_secure_media: "Chat uploads are not allowed if secure media is enabled."
+      chat_upload_not_allowed_secure_media: "Chat uploads are not allowed when secure media site setting is enabled."
   system_messages:
     chat_channel_archive_complete:
       title: "Chat Channel Archive Complete"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -74,9 +74,9 @@ plugins:
   chat_allow_uploads:
     default: true
     client: true
+    validator: "ChatAllowUploadsValidator"
   max_chat_auto_joined_users:
     min: 0
     default: 10000
     hidden: true
     client: true
-    

--- a/db/migrate/20220802014549_disable_chat_uploads_if_secure_media_enabled.rb
+++ b/db/migrate/20220802014549_disable_chat_uploads_if_secure_media_enabled.rb
@@ -15,7 +15,7 @@ class DisableChatUploadsIfSecureMediaEnabled < ActiveRecord::Migration[7.0]
     secure_media_enabled =
       DB.query_single("SELECT value FROM site_settings WHERE name = 'secure_media'").first == "t"
 
-    if secure_media_enabled && chat_uploads_enabled && !ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"]
+    if secure_media_enabled && chat_uploads_enabled && !GlobalSetting.allow_unsecure_chat_uploads
       if chat_allow_uploads_value.nil?
         DB.exec(
           "

--- a/db/migrate/20220802014549_disable_chat_uploads_if_secure_media_enabled.rb
+++ b/db/migrate/20220802014549_disable_chat_uploads_if_secure_media_enabled.rb
@@ -9,16 +9,20 @@ class DisableChatUploadsIfSecureMediaEnabled < ActiveRecord::Migration[7.0]
   # The env var DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS can be set to keep
   # it enabled, but this is strongly advised against.
   def up
-    chat_allow_uploads_value = DB.query_single("SELECT value FROM site_settings WHERE name = 'chat_allow_uploads'").first
+    chat_allow_uploads_value =
+      DB.query_single("SELECT value FROM site_settings WHERE name = 'chat_allow_uploads'").first
     chat_uploads_enabled = chat_allow_uploads_value == "t"
-    secure_media_enabled = DB.query_single("SELECT value FROM site_settings WHERE name = 'secure_media'").first == "t"
+    secure_media_enabled =
+      DB.query_single("SELECT value FROM site_settings WHERE name = 'secure_media'").first == "t"
 
     if secure_media_enabled && chat_uploads_enabled && !ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"]
       if chat_allow_uploads_value.nil?
-        DB.exec("
+        DB.exec(
+          "
           INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
           VALUES('chat_allow_uploads', 5, 'f', NOW(), NOW())
-        ")
+        ",
+        )
       else
         DB.exec("UPDATE site_settings SET value = 'f' WHERE name = 'chat_allow_uploads'")
       end

--- a/db/migrate/20220802014549_disable_chat_uploads_if_secure_media_enabled.rb
+++ b/db/migrate/20220802014549_disable_chat_uploads_if_secure_media_enabled.rb
@@ -11,7 +11,10 @@ class DisableChatUploadsIfSecureMediaEnabled < ActiveRecord::Migration[7.0]
   def up
     chat_allow_uploads_value =
       DB.query_single("SELECT value FROM site_settings WHERE name = 'chat_allow_uploads'").first
-    chat_uploads_enabled = chat_allow_uploads_value == "t"
+
+    # nil means it is true, since the default value is true
+    chat_uploads_enabled = chat_allow_uploads_value == "t" || chat_allow_uploads_value.nil?
+
     secure_media_enabled =
       DB.query_single("SELECT value FROM site_settings WHERE name = 'secure_media'").first == "t"
 

--- a/db/migrate/20220802014549_disable_chat_uploads_if_secure_media_enabled.rb
+++ b/db/migrate/20220802014549_disable_chat_uploads_if_secure_media_enabled.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class DisableChatUploadsIfSecureMediaEnabled < ActiveRecord::Migration[7.0]
+  ##
+  # At this point in time, secure media is not compatible with discourse-chat,
+  # so if it is enabled then chat uploads must be disabled to avoid undesirable
+  # behaviour.
+  #
+  # The env var DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS can be set to keep
+  # it enabled, but this is strongly advised against.
+  def up
+    chat_allow_uploads_value = DB.query_single("SELECT value FROM site_settings WHERE name = 'chat_allow_uploads'").first
+    chat_uploads_enabled = chat_allow_uploads_value == "t"
+    secure_media_enabled = DB.query_single("SELECT value FROM site_settings WHERE name = 'secure_media'").first == "t"
+
+    if secure_media_enabled && chat_uploads_enabled && !ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"]
+      if chat_allow_uploads_value.nil?
+        DB.exec("
+          INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
+          VALUES('chat_allow_uploads', 5, 'f', NOW(), NOW())
+        ")
+      else
+        DB.exec("UPDATE site_settings SET value = 'f' WHERE name = 'chat_allow_uploads'")
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/secure_media_compatibility.rb
+++ b/lib/secure_media_compatibility.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class DiscourseChat::SecureMediaCompatibility
+  ##
+  # At this point in time, secure media is not compatible with discourse-chat,
+  # so if it is enabled then chat uploads must be disabled to avoid undesirable
+  # behaviour.
+  #
+  # The env var DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS can be set to keep
+  # it enabled, but this is strongly advised against.
+  def self.update_settings
+    if SiteSetting.secure_media && SiteSetting.chat_allow_uploads && !ENV['DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS']
+      SiteSetting.chat_allow_uploads = false
+      StaffActionLogger.new(Discourse.system_user).log_site_setting_change(
+        "chat_allow_uploads", true, false, context: "Disabled because secure_media is enabled"
+      )
+    end
+  end
+end

--- a/lib/secure_media_compatibility.rb
+++ b/lib/secure_media_compatibility.rb
@@ -10,7 +10,7 @@ class DiscourseChat::SecureMediaCompatibility
   # it enabled, but this is strongly advised against.
   def self.update_settings
     if SiteSetting.secure_media && SiteSetting.chat_allow_uploads &&
-         !ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"]
+         !GlobalSetting.allow_unsecure_chat_uploads
       SiteSetting.chat_allow_uploads = false
       StaffActionLogger.new(Discourse.system_user).log_site_setting_change(
         "chat_allow_uploads",

--- a/lib/secure_media_compatibility.rb
+++ b/lib/secure_media_compatibility.rb
@@ -9,10 +9,14 @@ class DiscourseChat::SecureMediaCompatibility
   # The env var DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS can be set to keep
   # it enabled, but this is strongly advised against.
   def self.update_settings
-    if SiteSetting.secure_media && SiteSetting.chat_allow_uploads && !ENV['DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS']
+    if SiteSetting.secure_media && SiteSetting.chat_allow_uploads &&
+         !ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"]
       SiteSetting.chat_allow_uploads = false
       StaffActionLogger.new(Discourse.system_user).log_site_setting_change(
-        "chat_allow_uploads", true, false, context: "Disabled because secure_media is enabled"
+        "chat_allow_uploads",
+        true,
+        false,
+        context: "Disabled because secure_media is enabled",
       )
     end
   end

--- a/lib/validators/chat_allow_uploads_validator.rb
+++ b/lib/validators/chat_allow_uploads_validator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ChatAllowUploadsValidator
+  def initialize(opts = {})
+    @opts = opts
+  end
+
+  def valid_value?(value)
+    return true if value == "f"
+    if value == "t" && SiteSetting.secure_media && !ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"]
+      return false
+    end
+    true
+  end
+
+  def error_message
+    if SiteSetting.secure_media && !ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"]
+      I18n.t("site_settings.errors.chat_upload_not_allowed_secure_media")
+    end
+  end
+end

--- a/lib/validators/chat_allow_uploads_validator.rb
+++ b/lib/validators/chat_allow_uploads_validator.rb
@@ -7,14 +7,14 @@ class ChatAllowUploadsValidator
 
   def valid_value?(value)
     return true if value == "f"
-    if value == "t" && SiteSetting.secure_media && !ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"]
+    if value == "t" && SiteSetting.secure_media && !GlobalSetting.allow_unsecure_chat_uploads
       return false
     end
     true
   end
 
   def error_message
-    if SiteSetting.secure_media && !ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"]
+    if SiteSetting.secure_media && !GlobalSetting.allow_unsecure_chat_uploads
       I18n.t("site_settings.errors.chat_upload_not_allowed_secure_media")
     end
   end

--- a/lib/validators/chat_allow_uploads_validator.rb
+++ b/lib/validators/chat_allow_uploads_validator.rb
@@ -6,16 +6,19 @@ class ChatAllowUploadsValidator
   end
 
   def valid_value?(value)
-    return true if value == "f"
-    if value == "t" && SiteSetting.secure_media && !GlobalSetting.allow_unsecure_chat_uploads
+    if value == "t" && prevent_enabling_chat_uploads?
       return false
     end
     true
   end
 
   def error_message
-    if SiteSetting.secure_media && !GlobalSetting.allow_unsecure_chat_uploads
+    if prevent_enabling_chat_uploads?
       I18n.t("site_settings.errors.chat_upload_not_allowed_secure_media")
     end
+  end
+
+  def prevent_enabling_chat_uploads?
+    SiteSetting.secure_media && !GlobalSetting.allow_unsecure_chat_uploads
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -191,8 +191,6 @@ after_initialize do
     load File.expand_path("../lib/discourse_dev/message.rb", __FILE__)
   end
 
-  DiscourseChat::SecureMediaCompatibility.update_settings
-
   UserNotifications.append_view_path(File.expand_path("../app/views", __FILE__))
 
   register_category_custom_field_type(DiscourseChat::HAS_CHAT_ENABLED, :boolean)
@@ -444,6 +442,10 @@ after_initialize do
       Rails.logger.warn(
         "Error updating user_options fields after chat retention settings changed: #{e}",
       )
+    end
+
+    if name == :secure_media && old_value == false && new_value == true
+      DiscourseChat::SecureMediaCompatibility.update_settings
     end
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -69,6 +69,7 @@ add_admin_route "chat.admin.title", "chat"
 
 # Site setting validators must be loaded before initialize
 require_relative "lib/validators/chat_default_channel_validator.rb"
+require_relative "lib/validators/chat_allow_uploads_validator.rb"
 require_relative "app/core_ext/plugin_instance.rb"
 
 after_initialize do
@@ -161,6 +162,7 @@ after_initialize do
   load File.expand_path("../lib/extensions/user_email_extension.rb", __FILE__)
   load File.expand_path("../lib/slack_compatibility.rb", __FILE__)
   load File.expand_path("../lib/post_notification_handler.rb", __FILE__)
+  load File.expand_path("../lib/secure_media_compatibility.rb", __FILE__)
   load File.expand_path("../app/jobs/regular/auto_manage_channel_memberships.rb", __FILE__)
   load File.expand_path("../app/jobs/regular/auto_join_channel_batch.rb", __FILE__)
   load File.expand_path("../app/jobs/regular/process_chat_message.rb", __FILE__)
@@ -188,6 +190,8 @@ after_initialize do
     load File.expand_path("../lib/discourse_dev/direct_channel.rb", __FILE__)
     load File.expand_path("../lib/discourse_dev/message.rb", __FILE__)
   end
+
+  DiscourseChat::SecureMediaCompatibility.update_settings
 
   UserNotifications.append_view_path(File.expand_path("../app/views", __FILE__))
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -72,6 +72,8 @@ require_relative "lib/validators/chat_default_channel_validator.rb"
 require_relative "lib/validators/chat_allow_uploads_validator.rb"
 require_relative "app/core_ext/plugin_instance.rb"
 
+GlobalSetting.add_default(:allow_unsecure_chat_uploads, false)
+
 after_initialize do
   module ::DiscourseChat
     PLUGIN_NAME = "discourse-chat"

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -306,8 +306,6 @@ describe "discourse-chat" do
   end
 
   describe "secure media compatibility" do
-    after { ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"] = nil }
-
     it "disables chat uploads if secure media changes from disabled to enabled" do
       enable_secure_media
       expect(SiteSetting.chat_allow_uploads).to eq(false)
@@ -319,8 +317,8 @@ describe "discourse-chat" do
       expect(last_history.context).to eq("Disabled because secure_media is enabled")
     end
 
-    it "does not disable chat uploads if the DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS env var is set" do
-      ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"] = "true"
+    it "does not disable chat uploads if the allow_unsecure_chat_uploads global setting is set" do
+      global_setting :allow_unsecure_chat_uploads, true
       expect { enable_secure_media }.not_to change { UserHistory.count }
       expect(SiteSetting.chat_allow_uploads).to eq(true)
     end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -306,6 +306,8 @@ describe "discourse-chat" do
   end
 
   describe "secure media compatibility" do
+    after { ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"] = nil }
+
     it "disables chat uploads if secure media changes from disabled to enabled" do
       enable_secure_media
       expect(SiteSetting.chat_allow_uploads).to eq(false)

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -306,10 +306,8 @@ describe "discourse-chat" do
   end
 
   describe "secure media compatibility" do
-    before { enable_secure_media }
-
-    it "disables chat uploads if secure media is enabled" do
-      DiscourseChat::SecureMediaCompatibility.update_settings
+    it "disables chat uploads if secure media changes from disabled to enabled" do
+      enable_secure_media
       expect(SiteSetting.chat_allow_uploads).to eq(false)
       last_history = UserHistory.last
       expect(last_history.action).to eq(UserHistory.actions[:change_site_setting])
@@ -321,7 +319,7 @@ describe "discourse-chat" do
 
     it "does not disable chat uploads if the DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS env var is set" do
       ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"] = "true"
-      expect { DiscourseChat::SecureMediaCompatibility.update_settings }.not_to change { UserHistory.count }
+      expect { enable_secure_media }.not_to change { UserHistory.count }
       expect(SiteSetting.chat_allow_uploads).to eq(true)
     end
   end

--- a/spec/validators/chat_allow_uploads_validator_spec.rb
+++ b/spec/validators/chat_allow_uploads_validator_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require "rails_helper"
-
-describe ChatAllowUploadsValidator do
+RSpec.describe ChatAllowUploadsValidator do
   it "always returns true if setting the value to false" do
     validator = described_class.new
     expect(validator.valid_value?("f")).to eq(true)

--- a/spec/validators/chat_allow_uploads_validator_spec.rb
+++ b/spec/validators/chat_allow_uploads_validator_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ChatAllowUploadsValidator do
+  it "always returns true if setting the value to false" do
+    validator = described_class.new
+    expect(validator.valid_value?("f")).to eq(true)
+  end
+
+  context "when secure media is enabled" do
+    before do
+      SiteSetting.chat_allow_uploads = false
+      enable_secure_media
+    end
+
+    it "does not allow chat uploads to be enabled" do
+      validator = described_class.new
+      expect(validator.valid_value?("t")).to eq(false)
+      expect(validator.error_message).to eq(I18n.t("site_settings.errors.chat_upload_not_allowed_secure_media"))
+    end
+
+    it "does allow chat uploads to be enabled if DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS is set" do
+      ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"] = "t"
+      validator = described_class.new
+      expect(validator.valid_value?("t")).to eq(true)
+      expect(validator.error_message).to eq(nil)
+    end
+  end
+end

--- a/spec/validators/chat_allow_uploads_validator_spec.rb
+++ b/spec/validators/chat_allow_uploads_validator_spec.rb
@@ -14,6 +14,8 @@ describe ChatAllowUploadsValidator do
       enable_secure_media
     end
 
+    after { ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"] = nil }
+
     it "does not allow chat uploads to be enabled" do
       validator = described_class.new
       expect(validator.valid_value?("t")).to eq(false)

--- a/spec/validators/chat_allow_uploads_validator_spec.rb
+++ b/spec/validators/chat_allow_uploads_validator_spec.rb
@@ -17,7 +17,9 @@ describe ChatAllowUploadsValidator do
     it "does not allow chat uploads to be enabled" do
       validator = described_class.new
       expect(validator.valid_value?("t")).to eq(false)
-      expect(validator.error_message).to eq(I18n.t("site_settings.errors.chat_upload_not_allowed_secure_media"))
+      expect(validator.error_message).to eq(
+        I18n.t("site_settings.errors.chat_upload_not_allowed_secure_media"),
+      )
     end
 
     it "does allow chat uploads to be enabled if DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS is set" do

--- a/spec/validators/chat_allow_uploads_validator_spec.rb
+++ b/spec/validators/chat_allow_uploads_validator_spec.rb
@@ -14,8 +14,6 @@ describe ChatAllowUploadsValidator do
       enable_secure_media
     end
 
-    after { ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"] = nil }
-
     it "does not allow chat uploads to be enabled" do
       validator = described_class.new
       expect(validator.valid_value?("t")).to eq(false)
@@ -24,8 +22,8 @@ describe ChatAllowUploadsValidator do
       )
     end
 
-    it "does allow chat uploads to be enabled if DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS is set" do
-      ENV["DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS"] = "t"
+    it "does allow chat uploads to be enabled if allow_unsecure_chat_uploads global setting is set" do
+      global_setting :allow_unsecure_chat_uploads, true
       validator = described_class.new
       expect(validator.valid_value?("t")).to eq(true)
       expect(validator.error_message).to eq(nil)

--- a/spec/validators/chat_allow_uploads_validator_spec.rb
+++ b/spec/validators/chat_allow_uploads_validator_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ChatAllowUploadsValidator do
       )
     end
 
-    it "does allow chat uploads to be enabled if allow_unsecure_chat_uploads global setting is set" do
+    it "allows chat uploads to be enabled if allow_unsecure_chat_uploads global setting is enabled" do
       global_setting :allow_unsecure_chat_uploads, true
       validator = described_class.new
       expect(validator.valid_value?("t")).to eq(true)


### PR DESCRIPTION
To avoid unexpected behaviour, since we do not currently
support securing chat uploads via the `secure_media` setting
we are disabling chat uploads if `secure_media` is also enabled
via an initial migration. We also disable chat uploads if `secure_media`
is changed from disabled to enabled, and we prevent changing
`chat_allow_uploads` to true via a site setting validator if `secure_media`
is enabled.

This condition can be overridden with `DISCOURSE_ALLOW_UNSECURE_CHAT_UPLOADS`
at operator risk. This condition will be removed once secure media
rework to allow for chat uploads is completed later in the year.