### PR TITLE
DEV: Fix RUBYOPT for syntax-tree linting

### DIFF
--- a/.github/workflows/plugin-linting.yml
+++ b/.github/workflows/plugin-linting.yml
@@ -58,4 +58,4 @@ jobs:
 
       - name: Syntax Tree
         if: ${{ always() }}
-        run: RUBYOPT="-W0" bundle exec stree check --print-width=100 --plugins=plugin/trailing_comma **/*.rb Gemfile **/*.rake
+        run: RUBYOPT="-W:no-experimental" bundle exec stree check --print-width=100 --plugins=plugin/trailing_comma **/*.rb Gemfile **/*.rake


### PR DESCRIPTION
-W0 suppresses all warnings, _including_ the syntax-tree
ones, whereas we just want to suppress these experimental
feature warnings to stop noise:

> warning: Pattern matching is experimental, and the behavior may change in future versions of Ruby!

Followup to 2c7bdf674322f8dac7d6566b879802171eac27da
