### PR TITLE
FIX: checks if notification has a title or lets router handle it

### DIFF
--- a/assets/javascripts/discourse/routes/chat-channel.js
+++ b/assets/javascripts/discourse/routes/chat-channel.js
@@ -4,6 +4,7 @@ import EmberObject, { action } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 import { inject as service } from "@ember/service";
 import ChatChannel from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
+import slugifyChannel from "discourse/plugins/discourse-chat/discourse/lib/slugify-channel";
 
 export default DiscourseRoute.extend({
   chat: service(),
@@ -39,6 +40,12 @@ export default DiscourseRoute.extend({
   afterModel(model) {
     this.appEvents.trigger("chat:navigated-to-full-page");
     this.chat.setActiveChannel(model?.chatChannel);
+
+    const queryParams = this.paramsFor(this.routeName);
+    const slug = slugifyChannel(model.chatChannel.title);
+    if (queryParams?.channelTitle !== slug) {
+      this.replaceWith("chat.channel.index", model.chatChannel.id, slug);
+    }
   },
 
   setupController(controller) {

--- a/assets/javascripts/discourse/widgets/chat-invitation-notification-item.js
+++ b/assets/javascripts/discourse/widgets/chat-invitation-notification-item.js
@@ -9,6 +9,7 @@ import slugifyChannel from "discourse/plugins/discourse-chat/discourse/lib/slugi
 
 createWidgetFrom(DefaultNotificationItem, "chat-invitation-notification-item", {
   services: ["chat", "router"],
+
   text(data) {
     const username = formatUsername(data.invited_by_username);
     return I18n.t(data.message, { username });
@@ -33,7 +34,9 @@ createWidgetFrom(DefaultNotificationItem, "chat-invitation-notification-item", {
   },
 
   url(data) {
-    const title = slugifyChannel(data.chat_channel_title);
+    const title = data.chat_channel_title
+      ? slugifyChannel(data.chat_channel_title)
+      : "-";
     return `/chat/channel/${data.chat_channel_id}/${title}?messageId=${data.chat_message_id}`;
   },
 });

--- a/assets/javascripts/discourse/widgets/chat-mention-notification-item.js
+++ b/assets/javascripts/discourse/widgets/chat-mention-notification-item.js
@@ -9,6 +9,7 @@ import slugifyChannel from "discourse/plugins/discourse-chat/discourse/lib/slugi
 
 const chatNotificationItem = {
   services: ["chat", "router"],
+
   text(notificationName, data) {
     const username = formatUsername(data.mentioned_by_username);
     const identifier = data.identifier ? `@${data.identifier}` : null;
@@ -43,7 +44,9 @@ const chatNotificationItem = {
   },
 
   url(data) {
-    const title = slugifyChannel(data.chat_channel_title);
+    const title = data.chat_channel_title
+      ? slugifyChannel(data.chat_channel_title)
+      : "-";
     return `/chat/channel/${data.chat_channel_id}/${title}?messageId=${data.chat_message_id}`;
   },
 };

--- a/test/javascripts/acceptance/chat-channel-slug-test.js
+++ b/test/javascripts/acceptance/chat-channel-slug-test.js
@@ -1,0 +1,24 @@
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { currentURL, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { chatChannels } from "discourse/plugins/discourse-chat/chat-fixtures";
+
+acceptance("Discourse Chat - chat channel slug", function (needs) {
+  needs.user({ has_chat_enabled: true, can_chat: true });
+
+  needs.settings({ chat_enabled: true });
+
+  needs.pretender((server, helper) => {
+    server.get("/chat/chat_channels.json", () => helper.response(chatChannels));
+    server.get("/chat/:id/messages.json", () =>
+      helper.response({ chat_messages: [], meta: {} })
+    );
+  });
+
+  test("Replacing title param", async function (assert) {
+    await visit("/chat");
+    await visit("/chat/channel/11/-");
+
+    assert.equal(currentURL(), "/chat/channel/11/another-category");
+  });
+});


### PR DESCRIPTION
This will make any invalid slug title be replaced after model is loaded, eg:

`/chat/channel/1/-` will be replaced by `/chat/channel/1/channel-1-title`