### PR TITLE
FIX: Don't stage sent message if there are more to load.

### DIFF
--- a/test/javascripts/acceptance/chat-live-pane-test.js
+++ b/test/javascripts/acceptance/chat-live-pane-test.js
@@ -1,8 +1,9 @@
-import { settled, visit } from "@ember/test-helpers";
+import { click, fillIn, settled, visit } from "@ember/test-helpers";
 import {
   acceptance,
   exists,
   publishToMessageBus,
+  query,
 } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 
@@ -35,21 +36,48 @@ acceptance(
     needs.settings({
       chat_enabled: true,
     });
+
+    let loadAllMessages = false;
+
+    needs.hooks.beforeEach(() => {
+      loadAllMessages = false;
+    });
+
     needs.pretender((server, helper) => {
-      server.get("/chat/:chatChannelId/messages.json", () =>
-        helper.response({
-          meta: {
-            can_flag: true,
-            user_silenced: true,
-            can_load_more_future: true,
-          },
-          chat_messages: [buildMessage(1), buildMessage(2)],
-        })
-      );
+      server.get("/chat/:chatChannelId/messages.json", () => {
+        if (loadAllMessages) {
+          return helper.response({
+            meta: {
+              can_load_more_future: false,
+            },
+            chat_messages: [
+              buildMessage(1),
+              buildMessage(2),
+              buildMessage(3),
+              buildMessage(4),
+            ],
+          });
+        } else {
+          return helper.response({
+            meta: {
+              can_flag: true,
+              user_silenced: false,
+              can_load_more_future: true,
+            },
+            chat_messages: [buildMessage(1), buildMessage(2)],
+          });
+        }
+      });
 
       server.get("/chat/chat_channels.json", () =>
         helper.response({
-          public_channels: [],
+          public_channels: [
+            {
+              id: 1,
+              title: "something",
+              current_user_membership: { following: true },
+            },
+          ],
           direct_message_channels: [],
         })
       );
@@ -57,6 +85,14 @@ acceptance(
       server.get("/chat/chat_channels/:chatChannelId", () =>
         helper.response({ id: 1, title: "something" })
       );
+
+      server.post("/chat/drafts", () => {
+        return helper.response([]);
+      });
+
+      server.post("/chat/:chatChannelId.json", () => {
+        return helper.response({ success: "OK" });
+      });
     });
 
     test("doesn't create a gap in history by adding new messages", async function (assert) {
@@ -90,6 +126,21 @@ acceptance(
       await settled();
 
       assert.ok(exists(".chat-message-reaction.cat"));
+    });
+
+    test("Sending a new message when there are still unloaded ones will fetch them", async function (assert) {
+      await visit("/chat/channel/1/cat");
+
+      assert.notOk(exists(`.chat-message-container[data-id='${3}']`));
+
+      loadAllMessages = true;
+      const composerInput = query(".chat-composer-input");
+      await fillIn(composerInput, "test text");
+      await click(".send-btn");
+      await settled();
+
+      assert.ok(exists(`.chat-message-container[data-id='${3}']`));
+      assert.ok(exists(`.chat-message-container[data-id='${4}']`));
     });
   }
 );


### PR DESCRIPTION
When a user sends a message, we upsert it at the end and force a scroll to the future, assuming we have all the latest messages loaded. However, this is not
always the case, which causes the scroll to load old messages.

This PR handles this scenario by loading the latest, then scrolling to the newly created message.