### PR TITLE
Ux avatar border chat

### DIFF
--- a/assets/stylesheets/common/chat-channel-title.scss
+++ b/assets/stylesheets/common/chat-channel-title.scss
@@ -1,7 +1,6 @@
 .chat-channel-title {
   display: flex;
   align-items: center;
-  @include ellipsis;
 
   .category-chat-private .d-icon {
     background-color: var(--secondary);

--- a/assets/stylesheets/common/chat-channel-title.scss
+++ b/assets/stylesheets/common/chat-channel-title.scss
@@ -18,6 +18,7 @@
   .category-chat-name,
   .topic-chat-name,
   .tag-chat-name,
+  &__usernames,
   .dm-usernames {
     @include ellipsis;
     font-size: var(--font-0);

--- a/assets/stylesheets/common/chat-drawer.scss
+++ b/assets/stylesheets/common/chat-drawer.scss
@@ -106,6 +106,7 @@ body.composer-open .topic-chat-float-container {
 }
 
 .topic-chat-drawer-header__title {
+  @include ellipsis;
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -133,7 +134,7 @@ body.composer-open .topic-chat-float-container {
 
   .chat-channel-title {
     font-weight: 700;
-    width: calc(95% - 0.5em);
+    width: 100%;
 
     .chat-name,
     .topic-chat-name,


### PR DESCRIPTION
Removing some overflow to fix:
<img width="330" alt="image" src="https://user-images.githubusercontent.com/101828855/182548477-432bd6ab-59a8-4494-94c6-bdeb2bfde8fe.png">

And adding a fix for too long usernames pushing the icons out
<img width="424" alt="image" src="https://user-images.githubusercontent.com/101828855/182550945-64b0b706-ba71-4bcc-9632-41b45d5d70ef.png">

so it uses ellipsis
<img width="412" alt="image" src="https://user-images.githubusercontent.com/101828855/182550835-8397280d-8635-43d9-96dd-3a69ae373953.png">




- [x] chat-scoped -- core unaffected

### View mode

- [ ] docked (windowed/drawer)

### Browsers

- [ ] safari
- [ ] chrome
- [ ] firefox

### Device

- [x] desktop – wide screen
- [x] mobile – `?mobile_view=1`

### Ember

- [ ] ember-cli
- [ ] legacy
