### PR TITLE
FEATURE: Keyboard shortcut to toggle open/close of chat drawer

### DIFF
--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -38,6 +38,7 @@ export default Component.extend({
     this.appEvents.on("chat:navigated-to-full-page", this, "close");
     this.appEvents.on("chat:open-view", this, "openView");
     this.appEvents.on("chat:toggle-open", this, "toggleChat");
+    this.appEvents.on("chat:toggle-close", this, "close");
     this.appEvents.on(
       "chat:open-channel-for-chatable",
       this,
@@ -73,6 +74,7 @@ export default Component.extend({
       this.appEvents.off("chat:open-view", this, "openView");
       this.appEvents.off("chat:navigated-to-full-page", this, "close");
       this.appEvents.off("chat:toggle-open", this, "toggleChat");
+      this.appEvents.off("chat:toggle-close", this, "close");
       this.appEvents.off(
         "chat:open-channel-for-chatable",
         this,

--- a/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
+++ b/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
@@ -56,6 +56,21 @@ export default {
       appEvents.trigger("chat:open-insert-link-modal", { event });
     };
 
+    const openChatDrawer = (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      appEvents.trigger("chat:toggle-open", event);
+    };
+
+    const closeChatDrawer = (event) => {
+      if (!isChatComposer(event.target)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      appEvents.trigger("chat:toggle-close", event);
+    };
+
     withPluginApi("0.12.1", (api) => {
       api.addKeyboardShortcut(`${KEY_MODIFIER}+k`, openChannelSelector, {
         global: true,
@@ -145,6 +160,26 @@ export default {
           },
         }
       );
+      api.addKeyboardShortcut(`-`, (event) => openChatDrawer(event), {
+        global: true,
+        help: {
+          category: "chat",
+          name: "chat.keyboard_shortcuts.drawer_open",
+          definition: {
+            keys1: ["-"],
+          },
+        },
+      });
+      api.addKeyboardShortcut(`esc`, (event) => closeChatDrawer(event), {
+        global: true,
+        help: {
+          category: "chat",
+          name: "chat.keyboard_shortcuts.drawer_close",
+          definition: {
+            keys1: ["esc"],
+          },
+        },
+      });
     });
   },
 };

--- a/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
+++ b/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
@@ -38,6 +38,16 @@ export default {
     };
 
     const isChatComposer = (el) => el.classList.contains("chat-composer-input");
+    const isInputSelection = (el) => {
+      const inputs = ["input", "textarea", "select", "button"];
+      const elementTagName = el?.tagName.toLowerCase();
+
+      if (inputs.includes(elementTagName)) {
+        return false;
+      }
+      return true;
+    };
+
     const modifyComposerSelection = (event, type) => {
       if (!isChatComposer(event.target)) {
         return;
@@ -57,6 +67,9 @@ export default {
     };
 
     const openChatDrawer = (event) => {
+      if (!isInputSelection(event.target)) {
+        return;
+      }
       event.preventDefault();
       event.stopPropagation();
       appEvents.trigger("chat:toggle-open", event);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -411,6 +411,8 @@ en:
           composer_bold: "%{shortcut} Bold (composer only)"
           composer_italic: "%{shortcut} Italic (composer only)"
           composer_code: "%{shortcut} Code (composer only)"
+          drawer_open: "%{shortcut} Open chat drawer"
+          drawer_close: "%{shortcut} Close chat drawer"
     topic_statuses:
       chat:
         help: "Chat is enabled for this topic"

--- a/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
+++ b/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
@@ -259,18 +259,20 @@ acceptance("Discourse Chat - Keyboard shortcuts", function (needs) {
 
     await triggerKeyEvent(document.body, "keydown", "-");
     await settled();
-    assert.ok(visible(".topic-chat-float-container"), "chat float is open");
+    assert.ok(exists(".topic-chat-drawer-content"), "chat float is open");
   });
 
   test("Escape to close chat float", async function (assert) {
     await visit("/latest");
     this.chatService.set("sidebarActive", false);
     this.chatService.set("chatWindowFullPage", false);
+
     await click(".header-dropdown-toggle.open-chat");
     await settled();
-    assert.ok(
-      exists(".topic-chat-float-container.hidden"),
-      "chat drawer hidden"
-    );
+
+    const composerInput = query(".chat-composer-input");
+    await focus(composerInput);
+    await triggerKeyEvent(document.body, "keydown", "Escape");
+    assert.ok(!exists(".topic-chat-drawer-content"), "chat float is closed");
   });
 });

--- a/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
+++ b/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
@@ -251,4 +251,26 @@ acceptance("Discourse Chat - Keyboard shortcuts", function (needs) {
       "modal dismissed after submitting link"
     );
   });
+
+  test("toggle chat in float", async function (assert) {
+    await visit("/latest");
+    this.chatService.set("sidebarActive", false);
+    this.chatService.set("chatWindowFullPage", false);
+
+    await triggerKeyEvent(document.body, "keydown", "-");
+    await settled();
+    assert.ok(
+      query(".topic-chat-container").classList.contains("visible"),
+      "chat float is open"
+    );
+
+    const composerInput = query(".chat-composer-input");
+    await focus(composerInput);
+    await triggerKeyEvent(composerInput, "keydown", "Escape");
+    await settled();
+    assert.ok(
+      exists(".topic-chat-float-container.hidden"),
+      "chat drawer hidden"
+    );
+  });
 });

--- a/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
+++ b/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
@@ -252,21 +252,21 @@ acceptance("Discourse Chat - Keyboard shortcuts", function (needs) {
     );
   });
 
-  test("toggle chat in float", async function (assert) {
+  test("Dash key (-) opens chat float", async function (assert) {
     await visit("/latest");
     this.chatService.set("sidebarActive", false);
     this.chatService.set("chatWindowFullPage", false);
 
     await triggerKeyEvent(document.body, "keydown", "-");
     await settled();
-    assert.ok(
-      query(".topic-chat-container").classList.contains("visible"),
-      "chat float is open"
-    );
+    assert.ok(visible(".topic-chat-float-container"), "chat float is open");
+  });
 
-    const composerInput = query(".chat-composer-input");
-    await focus(composerInput);
-    await triggerKeyEvent(composerInput, "keydown", "Escape");
+  test("Escape to close chat float", async function (assert) {
+    await visit("/latest");
+    this.chatService.set("sidebarActive", false);
+    this.chatService.set("chatWindowFullPage", false);
+    await click(".header-dropdown-toggle.open-chat");
     await settled();
     assert.ok(
       exists(".topic-chat-float-container.hidden"),

--- a/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
+++ b/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
@@ -272,7 +272,7 @@ acceptance("Discourse Chat - Keyboard shortcuts", function (needs) {
 
     const composerInput = query(".chat-composer-input");
     await focus(composerInput);
-    await triggerKeyEvent(document.body, "keydown", "Escape");
+    await triggerKeyEvent(composerInput, "keydown", "Escape");
     assert.ok(!exists(".topic-chat-drawer-content"), "chat float is closed");
   });
 });


### PR DESCRIPTION
This PR adds the functionality to:
- open the chat drawer using the key <kbd>-</kbd>
- close the chat drawer while focused on the input using the key <kbd>esc</kbd>

It also adds the details to the shortcut menu:
<img width="304" alt="Screen Shot 2022-08-03 at 3 48 35 PM" src="https://user-images.githubusercontent.com/30090424/182725567-b5f7a7cd-e3a9-42cf-a79a-087cc5d6ca89.png">