### PR TITLE
FIX:  do not call throttled fn immediately to avoid missing update on…

### DIFF
--- a/assets/javascripts/discourse/components/chat-vh.js
+++ b/assets/javascripts/discourse/components/chat-vh.js
@@ -41,6 +41,6 @@ export default class ChatVh extends Component {
 
   @bind
   setVHThrottler() {
-    throttle(this, this.setVH, 100);
+    throttle(this, this.setVH, 100, false);
   }
 }


### PR DESCRIPTION
… fast resizing

Before this fix, resizing the window very fast could cause the resizer to be 100ms late on the real state of the window.
