### PR TITLE
FIX: various optimisations on mobile for live pane

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -271,7 +271,7 @@ export default Component.extend({
     const loadingMore = this.get(loadingMoreKey);
 
     if (!canLoadMore || loadingMore || this.loading || !this.messages.length) {
-      return;
+      return Promise.resolve();
     }
 
     this.set(loadingMoreKey, true);
@@ -303,12 +303,6 @@ export default Component.extend({
               : this.messages.concat(newMessages)
           );
 
-          // this part is especially important on safari to avoid a bug where
-          // manually scrolling, scrolls to the first prepended message
-          const focusedMessage = loadingPast
-            ? newMessages.lastObject
-            : newMessages.firstObject;
-          this.scrollToMessage(focusedMessage.messageLookupId);
           schedule("afterRender", () => {
             this._observeMessages(newMessages);
           });
@@ -589,15 +583,9 @@ export default Component.extend({
         return;
       }
 
-      // Ensure the focused message starts at 1/6 of pane
-      // to properly display separators
-      const aboveMessageOffset = this.element.clientHeight / 6;
-
-      this._scrollerEl.scrollTop =
-        messageEl.offsetTop -
-        (opts.position === "top"
-          ? this._scrollerEl.offsetTop + aboveMessageOffset
-          : this._scrollerEl.offsetHeight);
+      messageEl.scrollIntoView({
+        block: opts.position === "top" ? "start" : "end",
+      });
 
       if (opts.highlight) {
         messageEl.classList.add("highlighted");
@@ -656,13 +644,27 @@ export default Component.extend({
           this._scrollerEl.scrollTop
       ) <= STICKY_SCROLL_LENIENCE;
     if (atTop) {
-      this._fetchMoreMessages(PAST);
+      this._fetchMoreMessages(PAST).then((newMessages) => {
+        if (!newMessages) {
+          return;
+        }
+        // prevents a white screen bug on safari
+        this.scrollToMessage(newMessages.lastObject.messageLookupId);
+      });
       return;
     } else {
       this._updateLastReadMessage();
 
       if (Math.abs(this._scrollerEl.scrollTop) <= STICKY_SCROLL_LENIENCE) {
-        this._fetchMoreMessages(FUTURE);
+        this._fetchMoreMessages(FUTURE).then((newMessages) => {
+          if (!newMessages) {
+            return;
+          }
+          // prevents a white screen bug on safari
+          this.scrollToMessage(newMessages.firstObject.messageLookupId, {
+            position: "bottom",
+          });
+        });
       }
     }
 
@@ -1340,6 +1342,18 @@ export default Component.extend({
 
   @action
   onHoverMessage(message, options = {}) {
+    discourseDebounce(
+      this,
+      this.debouncedOnHoverMessage,
+      message,
+      options,
+      true,
+      200
+    );
+  },
+
+  @bind
+  debouncedOnHoverMessage(message, options = {}) {
     if (this.site.mobileView && options.desktopOnly) {
       return;
     }

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -1,6 +1,6 @@
 {{d-progress-bar
   key="chat-live-pane-loader"
-  isLoading=(or this.loadingMorePast this.loadingMoreFuture)
+  isLoading=(or this.loadingMorePast this.loadingMoreFuture this.loading)
 }}
 
 {{#if (and fullPage includeHeader)}}

--- a/assets/stylesheets/common/chat-message-separator.scss
+++ b/assets/stylesheets/common/chat-message-separator.scss
@@ -4,6 +4,7 @@
   display: flex;
   font-size: var(--font-down-1);
   position: relative;
+  -webkit-transform: translateZ(0px);
 
   &.new-message {
     color: var(--danger-medium);

--- a/assets/stylesheets/common/chat-message.scss
+++ b/assets/stylesheets/common/chat-message.scss
@@ -174,7 +174,6 @@
   .chat-message-reaction-list,
   .chat-transcript-reactions {
     @include unselectable;
-    position: relative;
     margin-top: 0.25em;
     display: flex;
     flex-wrap: wrap;

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -327,6 +327,7 @@ $float-height: 530px;
     transition: scrollbar-color 0.2s ease-in-out;
     display: flex;
     flex-direction: column-reverse;
+    -webkit-overflow-scrolling: touch;
 
     &::-webkit-scrollbar {
       width: 15px;
@@ -657,8 +658,6 @@ body.has-full-page-chat {
   .chat-live-pane {
     box-sizing: border-box;
     height: 100%;
-    border-radius: 0 var(--full-page-border-radius)
-      var(--full-page-border-radius) 0;
   }
 }
 


### PR DESCRIPTION
- uses scrollIntoView instead of custom code
- prevents scrollable list to lag behind rendering by removing relative where possible and using `-webkit-overflow-scrolling: touch;` and ` -webkit-transform: translateZ(0px);` on relative element
- displays loading bar on initial loading
- applies safari white screen fix only on intentional scroll and not when automatically filling pane
- delays onHoverMessage to improve perf when scrolling on desktop
- removes unexpected border radius
