### PR TITLE
FIX: removes ideal first channel logic from unfollowChatChannel

### DIFF
--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -665,18 +665,7 @@ export default Service.extend({
   async unfollowChannel(channel) {
     return ChatApi.unfollowChatChannel(channel).then(() => {
       this._unsubscribeFromChatChannel(channel);
-
-      return this.stopTrackingChannel(channel).then(() => {
-        return this.getIdealFirstChannelIdAndTitle().then((channelInfo) => {
-          if (channelInfo) {
-            return this.getChannelBy("id", channelInfo.id).then((c) => {
-              return this.openChannel(c);
-            });
-          } else {
-            return this.router.transitionTo("chat");
-          }
-        });
-      });
+      this.stopTrackingChannel(channel);
     });
   },
 

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -666,6 +666,10 @@ export default Service.extend({
     return ChatApi.unfollowChatChannel(channel).then(() => {
       this._unsubscribeFromChatChannel(channel);
       this.stopTrackingChannel(channel);
+
+      if (channel.isDirectMessageChannel) {
+        this.router.transitionTo("chat");
+      }
     });
   },
 


### PR DESCRIPTION
This logic shouldn't be here, but in openChannel, this is causing various bugs and doing more work than necessary ATM, eg: when unfollowing a channel currently it will first go to index, pick ideal first channel and then it will open the channel you just unfollowed. Removing this logic will avoid all of this.
