### PR TITLE
FIX: enforces focus of composer after send

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -601,6 +601,12 @@ export default Component.extend(TextareaTextManipulation, {
 
   @action
   sendClicked() {
+    if (this.site.mobileView) {
+      // prevents android to hide the keyboard after sending a message
+      // we do a focusTextarea later but it's too late for android
+      document.querySelector(this.composerFocusSelector).focus();
+    }
+
     if (this.sendDisabled) {
       return;
     }

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -590,6 +590,8 @@ acceptance("Discourse Chat - without unread", function (needs) {
 
     await triggerKeyEvent(composerInput, "keydown", "Enter");
 
+    assert.equal(document.activeElement, composerInput);
+
     assert.equal(composerInput.innerText.trim(), "", "composer input cleared");
 
     assert.deepEqual(


### PR DESCRIPTION
This is especially needed on android where our existing `focusTextarea` is happening way too far down the chain. This fix attempts to refocus the input as soon as possible. It's hard to test this exact behavior, but a check to ensure we get focus has been added.
