### PR TITLE
Revert "DEV: Fix `site:main` deprecation"

### DIFF
--- a/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -372,7 +372,7 @@ export default {
             }
 
             get actions() {
-              const site = getOwner(this).lookup("site:main");
+              const site = getOwner(this).lookup("service:site");
               return [
                 {
                   id: "startDm",

--- a/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -5,12 +5,12 @@ import I18n from "I18n";
 import { bind } from "discourse-common/utils/decorators";
 import { tracked } from "@glimmer/tracking";
 import showModal from "discourse/lib/show-modal";
+import { getOwner } from "discourse-common/lib/get-owner";
 import { DRAFT_CHANNEL_VIEW } from "discourse/plugins/discourse-chat/discourse/services/chat";
 import { avatarUrl } from "discourse/lib/utilities";
 import { dasherize } from "@ember/string";
 import { emojiUnescape } from "discourse/lib/text";
 import { decorateUsername } from "discourse/helpers/decorate-username-selector";
-import { inject as service } from "@ember/service";
 
 export default {
   name: "chat-sidebar",
@@ -314,7 +314,6 @@ export default {
           };
 
           const SidebarChatDirectMessagesSection = class extends BaseCustomSidebarSection {
-            @service site;
             @tracked sectionLinks = [];
 
             constructor() {
@@ -373,13 +372,14 @@ export default {
             }
 
             get actions() {
+              const site = getOwner(this).lookup("site:main");
               return [
                 {
                   id: "startDm",
                   title: I18n.t("chat.direct_messages.new"),
                   action: () => {
                     if (
-                      this.site.mobileView ||
+                      site.mobileView ||
                       this.chatService.router.currentRouteName.startsWith("")
                     ) {
                       this.chatService.router.transitionTo(


### PR DESCRIPTION
Reverts discourse/discourse-chat#1144

This was generating the following exception: "Uncaught TypeError: Cannot read properties of undefined (reading 'lookup')" when trying to create a new "personal chat".