### PR TITLE
DEV: Add `last_message_sent_at` to channel fixtures

### DIFF
--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -226,6 +226,7 @@ acceptance("Discourse Chat - without unread", function (needs) {
           id: 75,
           title: "hawk",
           chatable_type: "DirectMessageChannel",
+          last_message_sent_at: "2021-07-20T08:14:16.950Z",
           chatable: {
             users: [{ username: "hawk" }],
           },

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -25,7 +25,6 @@ import {
   directMessageChannels,
   generateChatView,
   messageContents,
-  siteChannel,
 } from "discourse/plugins/discourse-chat/chat-fixtures";
 import Session from "discourse/models/session";
 import { cloneJSON } from "discourse-common/lib/object";
@@ -125,17 +124,6 @@ const baseChatPretenders = (server, helper) => {
   );
 };
 
-function siteChannelPretender(
-  server,
-  helper,
-  opts = { unread_count: 0, muted: false }
-) {
-  let copy = cloneJSON(siteChannel);
-  copy.current_user_membership.unread_count = opts.unread_count;
-  copy.current_user_membership.muted = opts.muted;
-  server.get("/chat/chat_channels/9.json", () => helper.response(copy));
-}
-
 function directMessageChannelPretender(
   server,
   helper,
@@ -193,7 +181,6 @@ acceptance("Discourse Chat - without unread", function (needs) {
   });
   needs.pretender((server, helper) => {
     baseChatPretenders(server, helper);
-    siteChannelPretender(server, helper);
     directMessageChannelPretender(server, helper);
     chatChannelPretender(server, helper);
     const hawkAsJson = {
@@ -1130,7 +1117,6 @@ acceptance(
     });
     needs.pretender((server, helper) => {
       baseChatPretenders(server, helper);
-      siteChannelPretender(server, helper);
       directMessageChannelPretender(server, helper);
       chatChannelPretender(server, helper, [
         { id: 11, unread_count: 2, muted: false },
@@ -1201,7 +1187,6 @@ acceptance(
     });
     needs.pretender((server, helper) => {
       baseChatPretenders(server, helper);
-      siteChannelPretender(server, helper, { unread_count: 2, muted: false });
       chatChannelPretender(server, helper, [
         { id: 9, unread_count: 2, muted: false },
       ]);
@@ -1235,7 +1220,6 @@ acceptance(
     });
     needs.pretender((server, helper) => {
       baseChatPretenders(server, helper);
-      siteChannelPretender(server, helper, { unread_count: 2, muted: false });
       chatChannelPretender(server, helper, [
         { id: 9, unread_count: 2, muted: false },
       ]);
@@ -1320,7 +1304,6 @@ acceptance(
     });
     needs.pretender((server, helper) => {
       baseChatPretenders(server, helper);
-      siteChannelPretender(server, helper, { unread_count: 2, muted: false });
       directMessageChannelPretender(server, helper);
       // chat channel with ID 75 is direct message channel.
       chatChannelPretender(server, helper, [
@@ -1454,7 +1437,6 @@ acceptance("Discourse Chat - chat preferences", function (needs) {
   });
   needs.pretender((server, helper) => {
     baseChatPretenders(server, helper);
-    siteChannelPretender(server, helper);
     directMessageChannelPretender(server, helper);
     chatChannelPretender(server, helper);
   });
@@ -1521,7 +1503,6 @@ acceptance("Discourse Chat - plugin API", function (needs) {
   });
   needs.pretender((server, helper) => {
     baseChatPretenders(server, helper);
-    siteChannelPretender(server, helper);
     directMessageChannelPretender(server, helper);
     chatChannelPretender(server, helper);
   });
@@ -1558,7 +1539,6 @@ acceptance("Discourse Chat - image uploads", function (needs) {
   });
   needs.pretender((server, helper) => {
     baseChatPretenders(server, helper);
-    siteChannelPretender(server, helper);
     directMessageChannelPretender(server, helper);
     chatChannelPretender(server, helper);
 

--- a/test/javascripts/acceptance/core-sidebar-test.js
+++ b/test/javascripts/acceptance/core-sidebar-test.js
@@ -48,6 +48,7 @@ acceptance("Discourse Chat - Core Sidebar", function (needs) {
       chatable_url: null,
       id: 76,
       title: "@sam",
+      last_message_sent_at: "2021-06-01T11:15:00.000Z",
       current_user_membership: {
         unread_count: 0,
         muted: false,
@@ -63,6 +64,7 @@ acceptance("Discourse Chat - Core Sidebar", function (needs) {
             title: "dev :bug:",
             chatable_type: "Category",
             chatable: { slug: "dev", read_restricted: true },
+            last_message_sent_at: "2021-11-08T21:26:05.710Z",
             current_user_membership: {
               unread_count: 0,
               unread_mentions: 0,
@@ -73,6 +75,7 @@ acceptance("Discourse Chat - Core Sidebar", function (needs) {
             title: "general",
             chatable_type: "Category",
             chatable: { slug: "general" },
+            last_message_sent_at: "2021-11-08T21:26:05.710Z",
             current_user_membership: {
               unread_count: 1,
               unread_mentions: 0,
@@ -83,6 +86,7 @@ acceptance("Discourse Chat - Core Sidebar", function (needs) {
             title: "random",
             chatable_type: "Category",
             chatable: { slug: "random" },
+            last_message_sent_at: "2021-11-08T21:26:05.710Z",
             current_user_membership: {
               unread_count: 1,
               unread_mentions: 1,
@@ -327,6 +331,7 @@ acceptance("Discourse Chat - Plugin Sidebar", function (needs) {
             title: "dev :bug:",
             chatable_type: "Category",
             chatable: { slug: "dev", read_restricted: true },
+            last_message_sent_at: "2021-11-08T21:26:05.710Z",
             current_user_membership: {
               unread_count: 1,
               unread_mentions: 1,
@@ -337,6 +342,7 @@ acceptance("Discourse Chat - Plugin Sidebar", function (needs) {
             title: "general",
             chatable_type: "Category",
             chatable: { slug: "general" },
+            last_message_sent_at: "2021-11-08T21:26:05.710Z",
             current_user_membership: {
               unread_count: 1,
               unread_mentions: 1,
@@ -347,6 +353,7 @@ acceptance("Discourse Chat - Plugin Sidebar", function (needs) {
             title: "random",
             chatable_type: "Category",
             chatable: { slug: "random" },
+            last_message_sent_at: "2021-11-08T21:26:05.710Z",
             current_user_membership: {
               unread_count: 1,
               unread_mentions: 1,

--- a/test/javascripts/chat-fixtures.js
+++ b/test/javascripts/chat-fixtures.js
@@ -95,6 +95,8 @@ export const chatChannels = {
       chatable_type: "Category",
       chatable_url: "/c/bug/1",
       title: "Site",
+      status: "open",
+      chatable: chatables[1],
       current_user_membership: {
         unread_count: 0,
         muted: false,

--- a/test/javascripts/chat-fixtures.js
+++ b/test/javascripts/chat-fixtures.js
@@ -31,6 +31,7 @@ export const directMessageChannels = [
         muted: false,
         following: true,
       },
+      last_message_sent_at: "2021-07-20T08:14:16.950Z",
     },
   },
   {
@@ -61,6 +62,7 @@ export const directMessageChannels = [
         muted: false,
         following: true,
       },
+      last_message_sent_at: "2021-07-05T12:04:00.850Z",
     },
   },
 ];
@@ -97,6 +99,7 @@ export const chatChannels = {
       title: "Site",
       status: "open",
       chatable: chatables[1],
+      last_message_sent_at: "2021-07-24T08:14:16.950Z",
       current_user_membership: {
         unread_count: 0,
         muted: false,
@@ -111,6 +114,7 @@ export const chatChannels = {
       title: "Bug",
       status: "open",
       chatable: chatables[1],
+      last_message_sent_at: "2021-07-15T08:14:16.950Z",
       current_user_membership: {
         unread_count: 0,
         muted: false,
@@ -125,6 +129,7 @@ export const chatChannels = {
       title: "Public category",
       status: "open",
       chatable: chatables[8],
+      last_message_sent_at: "2021-07-14T08:14:16.950Z",
       current_user_membership: {
         unread_count: 0,
         muted: false,
@@ -139,6 +144,7 @@ export const chatChannels = {
       title: "Public category (read-only)",
       status: "read_only",
       chatable: chatables[8],
+      last_message_sent_at: "2021-07-10T08:14:16.950Z",
       current_user_membership: {
         unread_count: 0,
         muted: false,
@@ -153,6 +159,7 @@ export const chatChannels = {
       title: "Public category (closed)",
       status: "closed",
       chatable: chatables[8],
+      last_message_sent_at: "2021-07-21T08:14:16.950Z",
       current_user_membership: {
         unread_count: 0,
         muted: false,
@@ -167,6 +174,7 @@ export const chatChannels = {
       title: "Public category (archived)",
       status: "archived",
       chatable: chatables[8],
+      last_message_sent_at: "2021-07-25T08:14:16.950Z",
       current_user_membership: {
         unread_count: 0,
         muted: false,
@@ -181,6 +189,7 @@ export const chatChannels = {
       title: "Another Category",
       status: "open",
       chatable: chatables[12],
+      last_message_sent_at: "2021-07-02T08:14:16.950Z",
       current_user_membership: {
         unread_count: 0,
         muted: false,

--- a/test/javascripts/chat-fixtures.js
+++ b/test/javascripts/chat-fixtures.js
@@ -2,20 +2,6 @@ import { deepMerge } from "discourse-common/lib/object";
 
 export const messageContents = ["Hello world", "What up", "heyo!"];
 
-export const siteChannel = {
-  chatable: null,
-  chatable_id: -1,
-  chatable_type: "Site",
-  chatable_url: "http://localhost:3000",
-  id: 9,
-  title: "Site",
-  current_user_membership: {
-    unread_count: 0,
-    muted: false,
-    following: true,
-  },
-};
-
 export const directMessageChannels = [
   {
     chat_channel: {
@@ -103,7 +89,18 @@ const chatables = {
 
 export const chatChannels = {
   public_channels: [
-    siteChannel,
+    {
+      id: 9,
+      chatable_id: 1,
+      chatable_type: "Category",
+      chatable_url: "/c/bug/1",
+      title: "Site",
+      current_user_membership: {
+        unread_count: 0,
+        muted: false,
+        following: true,
+      },
+    },
     {
       id: 7,
       chatable_id: 1,

--- a/test/javascripts/components/chat-message-test.js
+++ b/test/javascripts/components/chat-message-test.js
@@ -16,6 +16,7 @@ module("Discourse Chat | Component | chat-message", function (hooks) {
       chatable_type: "Category",
       id: 9,
       title: "Site",
+      last_message_sent_at: "2021-11-08T21:26:05.710Z",
       current_user_membership: {
         unread_count: 0,
         muted: false,

--- a/test/javascripts/helpers/fabricators.js
+++ b/test/javascripts/helpers/fabricators.js
@@ -30,6 +30,7 @@ export default {
     title: "My category title",
     name: "My category name",
     chatable: categoryChatableFabricator(),
+    last_message_sent_at: "2021-11-08T21:26:05.710Z",
   }),
 
   chatChannelMessage: Fabricator(EmberObject, {
@@ -44,5 +45,6 @@ export default {
     chatable_type: CHATABLE_TYPES.directMessageChannel,
     status: "open",
     chatable: directChannelChatableFabricator(),
+    last_message_sent_at: "2021-11-08T21:26:05.710Z",
   }),
 };

--- a/test/javascripts/unit/services/chat-test.js
+++ b/test/javascripts/unit/services/chat-test.js
@@ -26,6 +26,7 @@ acceptance("Discourse Chat | Unit | Service | chat", function (needs) {
             id: 1,
             title: "something",
             chatable_type: "Category",
+            last_message_sent_at: "2021-11-08T21:26:05.710Z",
             current_user_membership: {
               unread_count: 2,
               last_read_message_id: 123,


### PR DESCRIPTION
Beside being correct (that is a non-null attribute) it fixes issues with tests on Firefox.