### PR TITLE
UX: increases max count of fetched public channels from 20 to 50

### DIFF
--- a/lib/chat_channel_fetcher.rb
+++ b/lib/chat_channel_fetcher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module DiscourseChat::ChatChannelFetcher
-  MAX_RESULTS = 20
+  MAX_PUBLIC_CHANNEL_RESULTS = 50
 
   def self.structured(guardian)
     memberships = UserChatChannelMembership.where(user_id: guardian.user.id)
@@ -94,7 +94,10 @@ module DiscourseChat::ChatChannelFetcher
         )
     end
 
-    options[:limit] = (options[:limit] || MAX_RESULTS).to_i.clamp(1, MAX_RESULTS)
+    options[:limit] = (options[:limit] || MAX_PUBLIC_CHANNEL_RESULTS).to_i.clamp(
+      1,
+      MAX_PUBLIC_CHANNEL_RESULTS,
+    )
     options[:offset] = [options[:offset].to_i, 0].max
 
     channels = channels.limit(options[:limit]).offset(options[:offset])

--- a/spec/lib/chat_channel_fetcher_spec.rb
+++ b/spec/lib/chat_channel_fetcher_spec.rb
@@ -195,11 +195,12 @@ describe DiscourseChat::ChatChannelFetcher do
     end
 
     it "ensures limit has a max value" do
-      25.times { Fabricate(:chat_channel) }
+      over_limit = DiscourseChat::ChatChannelFetcher::MAX_RESULTS + 1
+      over_limit.times { Fabricate(:chat_channel) }
 
-      expect(subject.secured_public_channels(guardian, memberships, limit: 25).length).to eq(
-        DiscourseChat::ChatChannelFetcher::MAX_RESULTS,
-      )
+      expect(
+        subject.secured_public_channels(guardian, memberships, limit: over_limit).length,
+      ).to eq(DiscourseChat::ChatChannelFetcher::MAX_RESULTS)
     end
 
     it "does not show the user category channels they cannot access" do

--- a/spec/lib/chat_channel_fetcher_spec.rb
+++ b/spec/lib/chat_channel_fetcher_spec.rb
@@ -195,12 +195,12 @@ describe DiscourseChat::ChatChannelFetcher do
     end
 
     it "ensures limit has a max value" do
-      over_limit = DiscourseChat::ChatChannelFetcher::MAX_RESULTS + 1
+      over_limit = DiscourseChat::ChatChannelFetcher::MAX_PUBLIC_CHANNEL_RESULTS + 1
       over_limit.times { Fabricate(:chat_channel) }
 
       expect(
         subject.secured_public_channels(guardian, memberships, limit: over_limit).length,
-      ).to eq(DiscourseChat::ChatChannelFetcher::MAX_RESULTS)
+      ).to eq(DiscourseChat::ChatChannelFetcher::MAX_PUBLIC_CHANNEL_RESULTS)
     end
 
     it "does not show the user category channels they cannot access" do


### PR DESCRIPTION
This has effects on the number of public channels we display in the sidebar, in the future we might want to separate this case from others.
