### PR TITLE
DEV: Use `@service` in chat sidebar section

### DIFF
--- a/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -5,12 +5,12 @@ import I18n from "I18n";
 import { bind } from "discourse-common/utils/decorators";
 import { tracked } from "@glimmer/tracking";
 import showModal from "discourse/lib/show-modal";
-import { getOwner } from "discourse-common/lib/get-owner";
 import { DRAFT_CHANNEL_VIEW } from "discourse/plugins/discourse-chat/discourse/services/chat";
 import { avatarUrl } from "discourse/lib/utilities";
 import { dasherize } from "@ember/string";
 import { emojiUnescape } from "discourse/lib/text";
 import { decorateUsername } from "discourse/helpers/decorate-username-selector";
+import { inject as service } from "@ember/service";
 
 export default {
   name: "chat-sidebar",
@@ -314,6 +314,7 @@ export default {
           };
 
           const SidebarChatDirectMessagesSection = class extends BaseCustomSidebarSection {
+            @service site;
             @tracked sectionLinks = [];
 
             constructor() {
@@ -372,14 +373,13 @@ export default {
             }
 
             get actions() {
-              const site = getOwner(this).lookup("service:site");
               return [
                 {
                   id: "startDm",
                   title: I18n.t("chat.direct_messages.new"),
                   action: () => {
                     if (
-                      site.mobileView ||
+                      this.site.mobileView ||
                       this.chatService.router.currentRouteName.startsWith("")
                     ) {
                       this.chatService.router.transitionTo(


### PR DESCRIPTION
This reverts commit 784f15aa84178b65f9ed1758d03768a04fc70317. (which was a revert of the original implementation)

The original didn't work because section objects had no owner. That is now fixed in https://github.com/discourse/discourse/pull/17827

Also adds a test