### PR TITLE
FIX: Don't try to scroll to the last read message when fetching from latest.

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1038,7 +1038,7 @@ export default Component.extend({
       });
 
     if (this.details.can_load_more_future) {
-      msgCreationPromise.then(this._fetchAndScrollToLatest);
+      msgCreationPromise.then(() => this._fetchAndScrollToLatest());
     } else {
       const stagedMessage = this._prepareSingleMessage(
         // We need to add the user and created at for presentation of staged message
@@ -1350,10 +1350,7 @@ export default Component.extend({
   restickScrolling(event) {
     event.preventDefault();
 
-    return this._fetchAndScrollToLatest().then(() => {
-      this.set("stickyScroll", true);
-      this._stickScrollToBottom();
-    });
+    return this._fetchAndScrollToLatest();
   },
 
   focusComposer() {
@@ -1491,7 +1488,8 @@ export default Component.extend({
     return this.fetchMessages(this.chatChannel, {
       fetchFromLastMessage: true,
     }).then(() => {
-      this.scrollToMessage(this.messages[this.messages.length - 1].id);
+      this.set("stickyScroll", true);
+      this._stickScrollToBottom();
     });
   },
 });


### PR DESCRIPTION
Either clicking the jump arrow or sending a message when there are unloaded ones will fetch the latest page and scroll to the latest one. Calling `_markLastReadMessage()` in these scenarios will break the scrolling since it also tries to scroll to the last read message immediately after, which we can't guarantee it's on the loaded page.
