### PR TITLE
FIX: Don't scope MB messages only to staff groups for public channels

### DIFF
--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -106,6 +106,7 @@ class ChatChannel < ActiveRecord::Base
 
   def allowed_group_ids
     return if !category_channel?
+    return if category_channel? && !read_restricted?
 
     staff_groups = Group::AUTO_GROUPS.slice(:staff, :moderators, :admins).values
     chatable.secure_group_ids.to_a.concat(staff_groups)

--- a/spec/models/chat_channel_spec.rb
+++ b/spec/models/chat_channel_spec.rb
@@ -35,6 +35,13 @@ describe ChatChannel do
     it "returns nil when for DMs" do
       expect(direct_message_channel.allowed_group_ids).to eq(nil)
     end
+
+    it "returns nil for public channels" do
+      public_category = Fabricate(:category, read_restricted: false)
+      public_channel = Fabricate(:chat_channel, chatable: public_category)
+
+      expect(public_channel.allowed_group_ids).to eq(nil)
+    end
   end
 
   describe "#read_restricted?" do


### PR DESCRIPTION
`Category#secure_group_ids` returns nil for public categories.