### PR TITLE
DEV: Update dc-filter-input to use @glimmer/component

### DIFF
--- a/assets/javascripts/discourse/components/dc-filter-input.js
+++ b/assets/javascripts/discourse/components/dc-filter-input.js
@@ -1,3 +1,3 @@
-import GlimmerComponent from "discourse/components/glimmer";
+import Component from "@glimmer/component";
 
-export default class DcFilterInput extends GlimmerComponent {}
+export default class DcFilterInput extends Component {}


### PR DESCRIPTION
Now that all of our singletons have been converted to true Ember Services, we can remove our custom discourse/component/glimmer superclass and use explicit injection where needed (not needed here)

