### PR TITLE
FIX: Don't show user status on direct message channels with multiple users

### DIFF
--- a/assets/javascripts/discourse/components/chat-channel-row.js
+++ b/assets/javascripts/discourse/components/chat-channel-row.js
@@ -64,10 +64,15 @@ export default Component.extend({
 
   @discourseComputed(
     "isDirectMessageRow",
+    "channel.chatable.users.[]",
     "channel.chatable.users.@each.status"
   )
   showUserStatus(isDirectMessageRow) {
-    return !!(isDirectMessageRow && this.channel.chatable.users[0].status);
+    return !!(
+      isDirectMessageRow &&
+      this.channel.chatable.users.length === 1 &&
+      this.channel.chatable.users[0].status
+    );
   },
 
   @action

--- a/test/javascripts/components/chat-channel-row-test.js
+++ b/test/javascripts/components/chat-channel-row-test.js
@@ -127,4 +127,28 @@ module("Discourse Chat | Component | chat-channel-row", function (hooks) {
       assert.ok(exists(".emoji[title='Off to dentist']"));
     },
   });
+
+  componentTest(
+    "doesn't show user status on a direct message channel with multiple users",
+    {
+      template: hbs`{{chat-channel-row channel=channel}}`,
+
+      beforeEach() {
+        const status = { description: "Off to dentist", emoji: "tooth" };
+        const channel = fabricators.directMessageChatChannel();
+        channel.chatable.users[0].status = status;
+        channel.chatable.users.push({
+          id: 2,
+          username: "bill",
+          name: null,
+          avatar_template: "/letter_avatar_proxy/v3/letter/t/31188e/{size}.png",
+        });
+        this.set("channel", channel);
+      },
+
+      async test(assert) {
+        assert.notOk(exists(".emoji[title='Off to dentist']"));
+      },
+    }
+  );
 });


### PR DESCRIPTION
We were showing user status next to the direct message channels with multiple users:

<img width="300" alt="Screenshot 2022-08-11 at 23 51 59" src="https://user-images.githubusercontent.com/1274517/184227548-02d5acca-3c4d-4f76-a89d-5a791d4795b0.png">

This PR removes status from such channels.

