### PR TITLE
UX: always applies a 15px right margin to the drawer

### DIFF
--- a/assets/javascripts/discourse/components/topic-chat-float.js
+++ b/assets/javascripts/discourse/components/topic-chat-float.js
@@ -183,9 +183,14 @@ export default Component.extend({
       "--composer-height",
       composer.offsetHeight + "px"
     );
+
+    const composerIsClosed = composer.classList.contains("closed");
+    const minRightMargin = 15;
     this.element.style.setProperty(
       "--composer-right",
-      (composer.classList.contains("closed") ? 0 : composer.offsetLeft) + "px"
+      (composerIsClosed
+        ? minRightMargin
+        : Math.max(minRightMargin, composer.offsetLeft)) + "px"
     );
   },
 

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -1887,7 +1887,7 @@ acceptance("Discourse Chat - Drawer", function (needs) {
     const key = "--composer-right";
     const value = getComputedStyle(float).getPropertyValue(key);
 
-    assert.strictEqual(value, "0px");
+    assert.strictEqual(value, "15px");
   });
 });
 


### PR DESCRIPTION
It's nicer and avoids overlap with scrollbar