### PR TITLE
UX: makes oneboxes full width to prevent different width

### DIFF
--- a/assets/stylesheets/common/chat-message-images.scss
+++ b/assets/stylesheets/common/chat-message-images.scss
@@ -1,11 +1,6 @@
 $max_image_height: 150px;
 
 .chat-message {
-  aside.onebox {
-    max-width: -moz-fit-content;
-    max-width: fit-content;
-  }
-
   // append selectors to set images to a
   // max height of $max_image_height
   .chat-message-collapser .onebox img:not(.ytp-thumbnail-image),


### PR DESCRIPTION
Before:

<img width="1033" alt="Screenshot 2022-08-12 at 13 17 55" src="https://user-images.githubusercontent.com/339945/184343721-c00d55ae-892c-422e-a40e-db7724ede6c2.png">

After:

<img width="969" alt="Screenshot 2022-08-12 at 13 18 12" src="https://user-images.githubusercontent.com/339945/184343742-6c72c7d1-c319-4db1-8492-5dd2762256db.png">

