### PR TITLE
FIX: correctly links to channel message

### DIFF
--- a/assets/javascripts/discourse/components/chat-message.js
+++ b/assets/javascripts/discourse/components/chat-message.js
@@ -825,7 +825,7 @@ export default Component.extend({
 
     const { protocol, host } = window.location;
     let url = getURL(
-      `/chat/channel/${this.details.chat_channel_id}/chat?messageId=${this.message.id}`
+      `/chat/channel/${this.details.chat_channel_id}/-?messageId=${this.message.id}`
     );
     url = url.indexOf("/") === 0 ? protocol + "//" + host + url : url;
     clipboardCopy(url);

--- a/assets/javascripts/discourse/helpers/format-chat-date.js
+++ b/assets/javascripts/discourse/helpers/format-chat-date.js
@@ -17,7 +17,7 @@ registerUnbound("format-chat-date", function (message, details, mode) {
 
   if (details) {
     url = getURL(
-      `/chat/channel/${details.chat_channel_id}/chat?messageId=${message.id}`
+      `/chat/channel/${details.chat_channel_id}/-?messageId=${message.id}`
     );
   }
 

--- a/lib/onebox/templates/discourse_chat.mustache
+++ b/lib/onebox/templates/discourse_chat.mustache
@@ -39,7 +39,7 @@
     <div class="chat-transcript-datetime">
       <a href="{{url}}" title="{{created_at}}">{{created_at}}</a>
     </div>
-    <a class="chat-transcript-channel" href="/chat/chat_channels/{{channel_id}}">
+    <a class="chat-transcript-channel" href="/chat/channel/{{channel_id}}/-">
       {{#is_category}}
         <span class="category-chat-badge" style="color: #{{color}}">
           <svg class="fa d-icon d-icon-hashtag svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#hashtag"></use></svg>

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -209,7 +209,7 @@ describe "discourse-chat" do
               <div class="chat-transcript-datetime">
                 <a href="#{chat_url}?messageId=#{chat_message.id}" title="#{chat_message.created_at}">#{chat_message.created_at}</a>
               </div>
-              <a class="chat-transcript-channel" href="/chat/chat_channels/#{chat_channel.id}">
+              <a class="chat-transcript-channel" href="/chat/channel/#{chat_channel.id}/-">
                 <span class="category-chat-badge" style="color: ##{chat_channel.chatable.color}">
                   <svg class="fa d-icon d-icon-hashtag svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#hashtag"></use></svg>
                 </span>

--- a/test/javascripts/unit/helpers/format-chat-date-test.js
+++ b/test/javascripts/unit/helpers/format-chat-date-test.js
@@ -1,0 +1,20 @@
+import { module, test } from "qunit";
+import hbs from "htmlbars-inline-precompile";
+import { render } from "@ember/test-helpers";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { query } from "discourse/tests/helpers/qunit-helpers";
+
+module("Discourse Chat | Unit | Helpers | format-chat-date", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("link to chat message", async function (assert) {
+    this.set("details", { chat_channel_id: 1 });
+    this.set("message", { id: 1 });
+    await render(hbs`{{format-chat-date this.message this.details}}`);
+
+    assert.equal(
+      query(".chat-time").getAttribute("href"),
+      "/chat/channel/1/-?messageId=1"
+    );
+  });
+});


### PR DESCRIPTION
Note this commit will require a rebake on affected posts to work.

This commit also fixed format-chat-date and copy message link codepaths to generate a correct URL to a chat message.

In the future it could be improved to simply rely on `channel.slug` both in frontend/backend but using `-` is  good solution for now as it will get replaced at runtime.
