### PR TITLE
FIX: Don't fire multiple scroll events when scrolling to the future.

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -295,6 +295,14 @@ export default Component.extend({
           );
         }
         this.setCanLoadMoreDetails(messages.resultSetMeta);
+
+        if (!loadingPast && newMessages.length) {
+          // Adding newer messages also causes a scroll-down,
+          // firing another event, fetching messages again, and so on.
+          // Scroll to the first new one to prevent this.
+          this.scrollToMessage(newMessages.firstObject.messageLookupId);
+        }
+
         return messages;
       })
       .catch((err) => {


### PR DESCRIPTION
Regression added in #1133. Adding newer messages also causes a scroll-down,  firing another event, fetching messages again, and so on. Scroll to the first
new one to prevent this.
