### PR TITLE
FIX: prevents esc shortcut to remove content when in full page

### DIFF
--- a/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
+++ b/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
@@ -48,9 +48,9 @@ export default {
       return true;
     };
     const isDrawerExpanded = () => {
-      return (
-        document.querySelector(".topic-chat-container.expanded")?.length === 1
-      );
+      return document.querySelector(".topic-chat-float-container:not(.hidden)")
+        ? true
+        : false;
     };
 
     const modifyComposerSelection = (event, type) => {

--- a/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
+++ b/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
@@ -47,8 +47,11 @@ export default {
       }
       return true;
     };
-    const isDrawerExpanded = () =>
-      document.querySelector(".topic-chat-container.expanded").length === 1;
+    const isDrawerExpanded = () => {
+      return (
+        document.querySelector(".topic-chat-container.expanded")?.length === 1
+      );
+    };
 
     const modifyComposerSelection = (event, type) => {
       if (!isChatComposer(event.target)) {

--- a/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
+++ b/assets/javascripts/discourse/initializers/chat-keyboard-shortcuts.js
@@ -47,6 +47,8 @@ export default {
       }
       return true;
     };
+    const isDrawerExpanded = () =>
+      document.querySelector(".topic-chat-container.expanded").length === 1;
 
     const modifyComposerSelection = (event, type) => {
       if (!isChatComposer(event.target)) {
@@ -76,9 +78,14 @@ export default {
     };
 
     const closeChatDrawer = (event) => {
+      if (!isDrawerExpanded()) {
+        return;
+      }
+
       if (!isChatComposer(event.target)) {
         return;
       }
+
       event.preventDefault();
       event.stopPropagation();
       appEvents.trigger("chat:toggle-close", event);
@@ -183,7 +190,7 @@ export default {
           },
         },
       });
-      api.addKeyboardShortcut(`esc`, (event) => closeChatDrawer(event), {
+      api.addKeyboardShortcut("esc", (event) => closeChatDrawer(event), {
         global: true,
         help: {
           category: "chat",

--- a/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
+++ b/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
@@ -262,17 +262,39 @@ acceptance("Discourse Chat - Keyboard shortcuts", function (needs) {
     assert.ok(exists(".topic-chat-drawer-content"), "chat float is open");
   });
 
-  test("Escape to close chat float", async function (assert) {
+  test("Pressing Escape when drawer is opened", async function (assert) {
     await visit("/latest");
     this.chatService.set("sidebarActive", false);
     this.chatService.set("chatWindowFullPage", false);
-
     await click(".header-dropdown-toggle.open-chat");
     await settled();
-
     const composerInput = query(".chat-composer-input");
     await focus(composerInput);
     await triggerKeyEvent(composerInput, "keydown", "Escape");
-    assert.ok(!exists(".topic-chat-drawer-content"), "chat float is closed");
+
+    assert.ok(
+      exists(".topic-chat-float-container.hidden"),
+      "it closes the drawer"
+    );
+  });
+
+  test("Pressing Escape when full page is opened", async function (assert) {
+    this.chatService.set("sidebarActive", false);
+    this.chatService.set("chatWindowFullPage", true);
+    await visit("/chat/channel/75/@hawk");
+    const composerInput = query(".chat-composer-input");
+    await focus(composerInput);
+    await triggerKeyEvent(composerInput, "keydown", "Escape");
+
+    assert.equal(
+      currentURL(),
+      "/chat/channel/75/hawk",
+      "it doesn’t close full page chat"
+    );
+
+    assert.ok(
+      exists(".chat-message-container[data-id='177']"),
+      "it doesn’t remove channel content"
+    );
   });
 });

--- a/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
+++ b/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
@@ -271,6 +271,7 @@ acceptance("Discourse Chat - Keyboard shortcuts", function (needs) {
     const composerInput = query(".chat-composer-input");
     await focus(composerInput);
     await triggerKeyEvent(composerInput, "keydown", "Escape");
+    await settled();
 
     assert.ok(
       exists(".topic-chat-float-container.hidden"),


### PR DESCRIPTION
Prior to this fix navigating to a channel in full page and pressing <kbd>escape</kbd> would erase content of the live pane.