### PR TITLE
FIX: only acting user should track channel on creation

### DIFF
--- a/app/jobs/regular/chat_notify_mentioned.rb
+++ b/app/jobs/regular/chat_notify_mentioned.rb
@@ -16,18 +16,19 @@ module Jobs
       @chat_channel = @chat_message.chat_channel
       @already_notified_user_ids = args[:already_notified_user_ids] || []
       user_ids_to_notify = args[:to_notify_ids_map] || {}
-
       user_ids_to_notify.each { |mention_type, ids| process_mentions(ids, mention_type.to_sym) }
     end
 
     private
 
     def get_memberships(user_ids)
-      UserChatChannelMembership.includes(:user).where(
-        user_id: (user_ids - @already_notified_user_ids),
-        chat_channel_id: @chat_message.chat_channel_id,
-        following: true,
-      )
+      query =
+        UserChatChannelMembership.includes(:user).where(
+          user_id: (user_ids - @already_notified_user_ids),
+          chat_channel_id: @chat_message.chat_channel_id,
+        )
+      query = query.where(following: true) if @chat_channel.public_channel?
+      query
     end
 
     def build_data_for(membership, identifier_type:)

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -504,6 +504,10 @@ export default class Chat extends Service {
   }
 
   async startTrackingChannel(channel) {
+    if (!channel.current_user_membership.following) {
+      return;
+    }
+
     let existingChannel = await this.getChannelBy("id", channel.id);
     if (existingChannel) {
       return existingChannel; // User is already tracking this channel. return!

--- a/lib/chat_notifier.rb
+++ b/lib/chat_notifier.rb
@@ -202,7 +202,9 @@ class DiscourseChat::ChatNotifier
     participants, welcome_to_join =
       potential_participants.partition do |participant|
         participant.user_chat_channel_memberships.any? do |m|
-          m.chat_channel_id == @chat_channel.id && m.following == true
+          predicate = m.chat_channel_id == @chat_channel.id
+          predicate = predicate && m.following == true if @chat_channel.public_channel?
+          predicate
         end
       end
 

--- a/spec/components/chat_mailer_spec.rb
+++ b/spec/components/chat_mailer_spec.rb
@@ -3,51 +3,49 @@
 require "rails_helper"
 
 describe DiscourseChat::ChatMailer do
+  fab!(:chatters_group) { Fabricate(:group) }
+  fab!(:sender) { Fabricate(:user, group_ids: [chatters_group.id]) }
+  fab!(:user_1) { Fabricate(:user, group_ids: [chatters_group.id], last_seen_at: 15.minutes.ago) }
+  fab!(:chat_channel) { Fabricate(:chat_channel) }
+  fab!(:chat_message) { Fabricate(:chat_message, user: sender, chat_channel: chat_channel) }
+  fab!(:user_1_chat_channel_membership) do
+    Fabricate(
+      :user_chat_channel_membership,
+      user: user_1,
+      chat_channel: chat_channel,
+      last_read_message_id: nil,
+    )
+  end
+  fab!(:private_chat_channel) do
+    DiscourseChat::DirectMessageChannelCreator.create!(
+      acting_user: sender,
+      target_users: [sender, user_1],
+    )
+  end
+
   before do
     SiteSetting.chat_enabled = true
+    SiteSetting.chat_allowed_groups = chatters_group.id
 
-    @chatters_group = Fabricate(:group)
-    SiteSetting.chat_allowed_groups = @chatters_group.id
-
-    @sender = Fabricate(:user, group_ids: [@chatters_group.id])
-    @user_1 = Fabricate(:user, group_ids: [@chatters_group.id], last_seen_at: 15.minutes.ago)
-
-    @chat_channel = Fabricate(:chat_channel)
-    @chat_message = Fabricate(:chat_message, user: @sender, chat_channel: @chat_channel)
-
-    Fabricate(:user_chat_channel_membership, user: @sender, chat_channel: @chat_channel)
-
-    @user_membership =
-      Fabricate(
-        :user_chat_channel_membership,
-        user: @user_1,
-        chat_channel: @chat_channel,
-        last_read_message_id: nil,
-      )
-
-    @private_channel =
-      DiscourseChat::DirectMessageChannelCreator.create!(
-        acting_user: @sender,
-        target_users: [@sender, @user_1],
-      )
+    Fabricate(:user_chat_channel_membership, user: sender, chat_channel: chat_channel)
   end
 
   def assert_summary_skipped
     expect(
-      job_enqueued?(job: :user_email, args: { type: "chat_summary", user_id: @user_1.id }),
+      job_enqueued?(job: :user_email, args: { type: "chat_summary", user_id: user_1.id }),
     ).to eq(false)
   end
 
   def assert_only_queued_once
-    expect_job_enqueued(job: :user_email, args: { type: "chat_summary", user_id: @user_1.id })
+    expect_job_enqueued(job: :user_email, args: { type: "chat_summary", user_id: user_1.id })
     expect(Jobs::UserEmail.jobs.size).to eq(1)
   end
 
   describe "for chat mentions" do
-    before { @mention = Fabricate(:chat_mention, user: @user_1, chat_message: @chat_message) }
+    fab!(:mention) { Fabricate(:chat_mention, user: user_1, chat_message: chat_message) }
 
     it "skips users without chat access" do
-      @chatters_group.remove(@user_1)
+      chatters_group.remove(user_1)
 
       described_class.send_unread_mentions_summary
 
@@ -55,7 +53,7 @@ describe DiscourseChat::ChatMailer do
     end
 
     it "skips users with summaries disabled" do
-      @user_1.user_option.update(chat_email_frequency: UserOption.chat_email_frequencies[:never])
+      user_1.user_option.update(chat_email_frequency: UserOption.chat_email_frequencies[:never])
 
       described_class.send_unread_mentions_summary
 
@@ -63,7 +61,7 @@ describe DiscourseChat::ChatMailer do
     end
 
     it "skips a job if the user haven't read the channel since the last summary" do
-      @user_membership.update!(last_unread_mention_when_emailed_id: @chat_message.id)
+      user_1_chat_channel_membership.update!(last_unread_mention_when_emailed_id: chat_message.id)
 
       described_class.send_unread_mentions_summary
 
@@ -71,7 +69,7 @@ describe DiscourseChat::ChatMailer do
     end
 
     it "skips without chat enabled" do
-      @user_1.user_option.update(
+      user_1.user_option.update(
         chat_enabled: false,
         chat_email_frequency: UserOption.chat_email_frequencies[:when_away],
       )
@@ -88,29 +86,43 @@ describe DiscourseChat::ChatMailer do
     end
 
     it "skips the job when the user was mentioned but already read the message" do
-      @user_membership.update!(last_read_message_id: @chat_message.id)
+      user_1_chat_channel_membership.update!(last_read_message_id: chat_message.id)
 
       described_class.send_unread_mentions_summary
 
       assert_summary_skipped
     end
 
-    it "skips the job when the user is not following the channel anymore" do
-      @user_membership.update!(last_read_message_id: @chat_message.id - 1, following: false)
+    it "skips the job when the user is not following a public channel anymore" do
+      user_1_chat_channel_membership.update!(
+        last_read_message_id: chat_message.id - 1,
+        following: false,
+      )
 
       described_class.send_unread_mentions_summary
 
       assert_summary_skipped
+    end
+
+    it "doesn’t skip the job when the user is not following a direct channel" do
+      private_chat_channel
+        .user_chat_channel_memberships
+        .where(user_id: user_1.id)
+        .update!(last_read_message_id: chat_message.id - 1, following: false)
+
+      described_class.send_unread_mentions_summary
+
+      assert_only_queued_once
     end
 
     it "skips users with unread messages from a different channel" do
-      @user_membership.update!(last_read_message_id: @chat_message.id)
+      user_1_chat_channel_membership.update!(last_read_message_id: chat_message.id)
       second_channel = Fabricate(:chat_channel)
       Fabricate(
         :user_chat_channel_membership,
-        user: @user_1,
+        user: user_1,
         chat_channel: second_channel,
-        last_read_message_id: @chat_message.id - 1,
+        last_read_message_id: chat_message.id - 1,
       )
 
       described_class.send_unread_mentions_summary
@@ -119,8 +131,8 @@ describe DiscourseChat::ChatMailer do
     end
 
     it "only queues the job once for users who are member of multiple groups with chat access" do
-      chatters_group_2 = Fabricate(:group, users: [@user_1])
-      SiteSetting.chat_allowed_groups = [@chatters_group, chatters_group_2].map(&:id).join("|")
+      chatters_group_2 = Fabricate(:group, users: [user_1])
+      SiteSetting.chat_allowed_groups = [chatters_group, chatters_group_2].map(&:id).join("|")
 
       described_class.send_unread_mentions_summary
 
@@ -128,7 +140,7 @@ describe DiscourseChat::ChatMailer do
     end
 
     it "skips users when the mention was deleted" do
-      @chat_message.trash!
+      chat_message.trash!
 
       described_class.send_unread_mentions_summary
 
@@ -136,21 +148,21 @@ describe DiscourseChat::ChatMailer do
     end
 
     it "queues the job if the user has unread mentions and already read all the messages in the previous summary" do
-      @user_membership.update!(
-        last_read_message_id: @chat_message.id,
-        last_unread_mention_when_emailed_id: @chat_message.id,
+      user_1_chat_channel_membership.update!(
+        last_read_message_id: chat_message.id,
+        last_unread_mention_when_emailed_id: chat_message.id,
       )
-      unread_message = Fabricate(:chat_message, chat_channel: @chat_channel, user: @sender)
-      Fabricate(:chat_mention, user: @user_1, chat_message: unread_message)
+      unread_message = Fabricate(:chat_message, chat_channel: chat_channel, user: sender)
+      Fabricate(:chat_mention, user: user_1, chat_message: unread_message)
 
       described_class.send_unread_mentions_summary
 
-      expect_job_enqueued(job: :user_email, args: { type: "chat_summary", user_id: @user_1.id })
+      expect_job_enqueued(job: :user_email, args: { type: "chat_summary", user_id: user_1.id })
       expect(Jobs::UserEmail.jobs.size).to eq(1)
     end
 
     it "skips users who were seen recently" do
-      @user_1.update!(last_seen_at: 2.minutes.ago)
+      user_1.update!(last_seen_at: 2.minutes.ago)
 
       described_class.send_unread_mentions_summary
 
@@ -158,29 +170,29 @@ describe DiscourseChat::ChatMailer do
     end
 
     it "doesn't mix mentions from other users" do
-      @mention.destroy!
-      user_2 = Fabricate(:user, groups: [@chatters_group], last_seen_at: 20.minutes.ago)
+      mention.destroy!
+      user_2 = Fabricate(:user, groups: [chatters_group], last_seen_at: 20.minutes.ago)
       user_2_membership =
         Fabricate(
           :user_chat_channel_membership,
           user: user_2,
-          chat_channel: @chat_channel,
+          chat_channel: chat_channel,
           last_read_message_id: nil,
         )
-      new_message = Fabricate(:chat_message, chat_channel: @chat_channel, user: @sender)
+      new_message = Fabricate(:chat_message, chat_channel: chat_channel, user: sender)
       Fabricate(:chat_mention, user: user_2, chat_message: new_message)
 
       described_class.send_unread_mentions_summary
 
       expect(
-        job_enqueued?(job: :user_email, args: { type: "chat_summary", user_id: @user_1.id }),
+        job_enqueued?(job: :user_email, args: { type: "chat_summary", user_id: user_1.id }),
       ).to eq(false)
       expect_job_enqueued(job: :user_email, args: { type: "chat_summary", user_id: user_2.id })
       expect(Jobs::UserEmail.jobs.size).to eq(1)
     end
 
     it "skips users when the message is older than 1 week" do
-      @chat_message.update!(created_at: 1.5.weeks.ago)
+      chat_message.update!(created_at: 1.5.weeks.ago)
 
       described_class.send_unread_mentions_summary
 
@@ -191,14 +203,15 @@ describe DiscourseChat::ChatMailer do
       before { Jobs.run_immediately! }
 
       it "doesn't send the same summary the summary again if the user haven't read any channel messages since the last one" do
-        @user_membership.update!(last_read_message_id: @chat_message.id - 1)
+        user_1_chat_channel_membership.update!(last_read_message_id: chat_message.id - 1)
         described_class.send_unread_mentions_summary
 
-        expect(@user_membership.reload.last_unread_mention_when_emailed_id).to eq(@chat_message.id)
+        expect(user_1_chat_channel_membership.reload.last_unread_mention_when_emailed_id).to eq(
+          chat_message.id,
+        )
 
-        another_channel_message =
-          Fabricate(:chat_message, chat_channel: @chat_channel, user: @sender)
-        Fabricate(:chat_mention, user: @user_1, chat_message: another_channel_message)
+        another_channel_message = Fabricate(:chat_message, chat_channel: chat_channel, user: sender)
+        Fabricate(:chat_mention, user: user_1, chat_message: another_channel_message)
 
         expect { described_class.send_unread_mentions_summary }.to change(
           Jobs::UserEmail.jobs,
@@ -209,27 +222,29 @@ describe DiscourseChat::ChatMailer do
       it "only updates the last_message_read_when_emailed_id on the channel with unread mentions" do
         another_channel = Fabricate(:chat_channel)
         another_channel_message =
-          Fabricate(:chat_message, chat_channel: another_channel, user: @sender)
-        Fabricate(:chat_mention, user: @user_1, chat_message: another_channel_message)
+          Fabricate(:chat_message, chat_channel: another_channel, user: sender)
+        Fabricate(:chat_mention, user: user_1, chat_message: another_channel_message)
         another_channel_membership =
           Fabricate(
             :user_chat_channel_membership,
-            user: @user_1,
+            user: user_1,
             chat_channel: another_channel,
             last_read_message_id: another_channel_message.id,
           )
-        @user_membership.update!(last_read_message_id: @chat_message.id - 1)
+        user_1_chat_channel_membership.update!(last_read_message_id: chat_message.id - 1)
 
         described_class.send_unread_mentions_summary
 
-        expect(@user_membership.reload.last_unread_mention_when_emailed_id).to eq(@chat_message.id)
+        expect(user_1_chat_channel_membership.reload.last_unread_mention_when_emailed_id).to eq(
+          chat_message.id,
+        )
         expect(another_channel_membership.reload.last_unread_mention_when_emailed_id).to be_nil
       end
     end
   end
 
   describe "for direct messages" do
-    before { Fabricate(:chat_message, user: @sender, chat_channel: @private_channel) }
+    before { Fabricate(:chat_message, user: sender, chat_channel: private_chat_channel) }
 
     it "queue a job when the user has unread private mentions" do
       described_class.send_unread_mentions_summary
@@ -238,7 +253,7 @@ describe DiscourseChat::ChatMailer do
     end
 
     it "only queues the job once when the user has mentions and private messages" do
-      Fabricate(:chat_mention, user: @user_1, chat_message: @chat_message)
+      Fabricate(:chat_mention, user: user_1, chat_message: chat_message)
 
       described_class.send_unread_mentions_summary
 
@@ -246,15 +261,15 @@ describe DiscourseChat::ChatMailer do
     end
 
     it "Doesn't mix or update mentions from other users when joining tables" do
-      user_2 = Fabricate(:user, groups: [@chatters_group], last_seen_at: 20.minutes.ago)
+      user_2 = Fabricate(:user, groups: [chatters_group], last_seen_at: 20.minutes.ago)
       user_2_membership =
         Fabricate(
           :user_chat_channel_membership,
           user: user_2,
-          chat_channel: @chat_channel,
-          last_read_message_id: @chat_message.id,
+          chat_channel: chat_channel,
+          last_read_message_id: chat_message.id,
         )
-      Fabricate(:chat_mention, user: user_2, chat_message: @chat_message)
+      Fabricate(:chat_mention, user: user_2, chat_message: chat_message)
 
       described_class.send_unread_mentions_summary
 

--- a/spec/components/chat_message_creator_spec.rb
+++ b/spec/components/chat_message_creator_spec.rb
@@ -8,6 +8,7 @@ describe DiscourseChat::ChatMessageCreator do
   fab!(:user1) { Fabricate(:user, group_ids: [Group::AUTO_GROUPS[:everyone]]) }
   fab!(:user2) { Fabricate(:user) }
   fab!(:user3) { Fabricate(:user) }
+  fab!(:user4) { Fabricate(:user) }
   fab!(:admin_group) do
     Fabricate(
       :public_group,
@@ -231,15 +232,11 @@ describe DiscourseChat::ChatMessageCreator do
     end
 
     it "publishes inaccessible mentions when user isn't aren't a part of the channel" do
-      user3
-        .user_chat_channel_memberships
-        .where(chat_channel: public_chat_channel)
-        .update(following: false)
       ChatPublisher.expects(:publish_inaccessible_mentions).once
       DiscourseChat::ChatMessageCreator.create(
         chat_channel: public_chat_channel,
         user: admin1,
-        content: "hello @#{user3.username}",
+        content: "hello @#{user4.username}",
       )
     end
 

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -3,70 +3,49 @@
 require "rails_helper"
 
 describe UserNotifications do
+  fab!(:chatters_group) { Fabricate(:group) }
+  fab!(:sender) { Fabricate(:user, group_ids: [chatters_group.id]) }
+  fab!(:user) { Fabricate(:user, group_ids: [chatters_group.id]) }
+
+  before do
+    SiteSetting.chat_enabled = true
+    SiteSetting.chat_allowed_groups = chatters_group.id
+  end
+
   describe ".chat_summary" do
-    before do
-      @chatters_group = Fabricate(:group)
-      @sender =
-        Fabricate(:user, name: "A name", username: "username", group_ids: [@chatters_group.id])
-      @user = Fabricate(:user, group_ids: [@chatters_group.id])
-
-      @chat_channel = Fabricate(:chat_channel)
-      @chat_message = Fabricate(:chat_message, user: @sender, chat_channel: @chat_channel)
-
-      Fabricate(:user_chat_channel_membership, chat_channel: @chat_channel, user: @sender)
-      @user_membership =
-        Fabricate(
-          :user_chat_channel_membership,
-          chat_channel: @chat_channel,
-          user: @user,
-          last_read_message_id: @chat_message.id - 2,
+    context "private channel" do
+      fab!(:channel) do
+        DiscourseChat::DirectMessageChannelCreator.create!(
+          acting_user: sender,
+          target_users: [sender, user],
         )
+      end
 
-      SiteSetting.chat_enabled = true
-      SiteSetting.chat_allowed_groups = @chatters_group.id
-    end
-
-    it "doesn't return an email if there are no unread mentions" do
-      email = described_class.chat_summary(@user, {})
-
-      expect(email.to).to be_blank
-    end
-
-    describe "email subject" do
-      context "DM messages" do
-        before do
-          @dm_channel =
-            DiscourseChat::DirectMessageChannelCreator.create!(
-              acting_user: @sender,
-              target_users: [@sender, @user],
-            )
-          Fabricate(:chat_message, user: @sender, chat_channel: @dm_channel)
-        end
-
+      context "email subject" do
         it "includes the sender username in the subject" do
           expected_subject =
             I18n.t(
               "user_notifications.chat_summary.subject.direct_message",
               count: 1,
               email_prefix: SiteSetting.title,
-              message_title: @sender.username,
+              message_title: sender.username,
             )
-
-          email = described_class.chat_summary(@user, {})
+          Fabricate(:chat_message, user: sender, chat_channel: channel)
+          email = described_class.chat_summary(user, {})
 
           expect(email.subject).to eq(expected_subject)
-          expect(email.subject).to include(@sender.username)
+          expect(email.subject).to include(sender.username)
         end
 
         it "only includes the name of the user who sent the message even if the DM has multiple participants" do
-          another_participant = Fabricate(:user, group_ids: [@chatters_group.id])
+          another_participant = Fabricate(:user, group_ids: [chatters_group.id])
           Fabricate(
             :user_chat_channel_membership_for_dm,
             user: another_participant,
-            chat_channel: @dm_channel,
+            chat_channel: channel,
           )
           DirectMessageUser.create!(
-            direct_message_channel: @dm_channel.chatable,
+            direct_message_channel: channel.chatable,
             user: another_participant,
           )
           expected_subject =
@@ -74,374 +53,414 @@ describe UserNotifications do
               "user_notifications.chat_summary.subject.direct_message",
               count: 1,
               email_prefix: SiteSetting.title,
-              message_title: @sender.username,
+              message_title: sender.username,
             )
-
-          email = described_class.chat_summary(@user, {})
+          Fabricate(:chat_message, user: sender, chat_channel: channel)
+          email = described_class.chat_summary(user, {})
 
           expect(email.subject).to eq(expected_subject)
-          expect(email.subject).to include(@sender.username)
+          expect(email.subject).to include(sender.username)
           expect(email.subject).not_to include(another_participant.username)
         end
 
         it "includes both channel titles when there are exactly two with unread messages" do
-          another_dm_user = Fabricate(:user, group_ids: [@chatters_group.id])
-          dm_channel_2 =
+          another_dm_user = Fabricate(:user, group_ids: [chatters_group.id])
+          another_channel =
             DiscourseChat::DirectMessageChannelCreator.create!(
-              acting_user: @user,
-              target_users: [another_dm_user, @user],
+              acting_user: user,
+              target_users: [another_dm_user, user],
             )
-          chat_message = Fabricate(:chat_message, user: another_dm_user, chat_channel: dm_channel_2)
+          Fabricate(:chat_message, user: another_dm_user, chat_channel: another_channel)
+          Fabricate(:chat_message, user: sender, chat_channel: channel)
+          email = described_class.chat_summary(user, {})
 
-          email = described_class.chat_summary(@user, {})
-
-          expect(email.subject).to include(@sender.username)
+          expect(email.subject).to include(sender.username)
           expect(email.subject).to include(another_dm_user.username)
         end
 
         it "displays a count when there are more than two DMs with unread messages" do
-          2.times do
-            another_dm_user = Fabricate(:user, group_ids: [@chatters_group.id])
-            dm_channel =
+          user = Fabricate(:user, group_ids: [chatters_group.id])
+
+          3.times do
+            sender = Fabricate(:user, group_ids: [chatters_group.id])
+            channel =
               DiscourseChat::DirectMessageChannelCreator.create!(
-                acting_user: @user,
-                target_users: [another_dm_user, @user],
+                acting_user: sender,
+                target_users: [user, sender],
               )
-            chat_message = Fabricate(:chat_message, user: another_dm_user, chat_channel: dm_channel)
+            user
+              .user_chat_channel_memberships
+              .where(chat_channel_id: channel.id)
+              .update!(following: true)
+
+            Fabricate(:chat_message, user: sender, chat_channel: channel)
           end
+
           expected_count_text = I18n.t("user_notifications.chat_summary.subject.others", count: 2)
 
-          email = described_class.chat_summary(@user, {})
+          email = described_class.chat_summary(user, {})
 
           expect(email.subject).to include(expected_count_text)
         end
-      end
 
-      context "regular mentions" do
-        before { Fabricate(:chat_mention, user: @user, chat_message: @chat_message) }
+        it "returns an email if the user is not following the direct channel" do
+          user
+            .user_chat_channel_memberships
+            .where(chat_channel_id: channel.id)
+            .update!(following: false)
+          Fabricate(:chat_message, user: sender, chat_channel: channel)
+          email = described_class.chat_summary(user, {})
 
-        it "includes the sender username in the subject" do
-          expected_subject =
-            I18n.t(
-              "user_notifications.chat_summary.subject.chat_channel",
-              count: 1,
-              email_prefix: SiteSetting.title,
-              message_title: @chat_channel.title(@user),
-            )
-
-          email = described_class.chat_summary(@user, {})
-
-          expect(email.subject).to eq(expected_subject)
-          expect(email.subject).to include(@chat_channel.title(@user))
-        end
-
-        it "includes both channel titles when there are exactly two with unread mentions" do
-          another_chat_channel = Fabricate(:chat_channel, name: "Test channel")
-          another_chat_message =
-            Fabricate(:chat_message, user: @sender, chat_channel: another_chat_channel)
-          Fabricate(
-            :user_chat_channel_membership,
-            chat_channel: another_chat_channel,
-            user: @sender,
-          )
-          Fabricate(
-            :user_chat_channel_membership,
-            chat_channel: another_chat_channel,
-            user: @user,
-            last_read_message_id: another_chat_message.id - 2,
-          )
-          Fabricate(:chat_mention, user: @user, chat_message: another_chat_message)
-
-          email = described_class.chat_summary(@user, {})
-
-          expect(email.subject).to include(@chat_channel.title(@user))
-          expect(email.subject).to include(another_chat_channel.title(@user))
-        end
-
-        it "displays a count when there are more than two channels with unread mentions" do
-          2.times do |n|
-            another_chat_channel = Fabricate(:chat_channel, name: "Test channel #{n}")
-            another_chat_message =
-              Fabricate(:chat_message, user: @sender, chat_channel: another_chat_channel)
-            Fabricate(
-              :user_chat_channel_membership,
-              chat_channel: another_chat_channel,
-              user: @sender,
-            )
-            Fabricate(
-              :user_chat_channel_membership,
-              chat_channel: another_chat_channel,
-              user: @user,
-              last_read_message_id: another_chat_message.id - 2,
-            )
-            Fabricate(:chat_mention, user: @user, chat_message: another_chat_message)
-          end
-          expected_count_text = I18n.t("user_notifications.chat_summary.subject.others", count: 2)
-
-          email = described_class.chat_summary(@user, {})
-
-          expect(email.subject).to include(expected_count_text)
-        end
-      end
-
-      context "both unread DM messages and mentions" do
-        before do
-          @dm_channel =
-            DiscourseChat::DirectMessageChannelCreator.create!(
-              acting_user: @sender,
-              target_users: [@sender, @user],
-            )
-          Fabricate(:chat_message, user: @sender, chat_channel: @dm_channel)
-          Fabricate(:chat_mention, user: @user, chat_message: @chat_message)
-        end
-
-        it "always includes the DM second" do
-          expected_other_text =
-            I18n.t(
-              "user_notifications.chat_summary.subject.other_direct_message",
-              message_title: @sender.username,
-            )
-
-          email = described_class.chat_summary(@user, {})
-
-          expect(email.subject).to include(expected_other_text)
+          expect(email.to).to contain_exactly(user.email)
         end
       end
     end
 
-    describe "When there are mentions" do
-      before { Fabricate(:chat_mention, user: @user, chat_message: @chat_message) }
+    context "public channel" do
+      fab!(:channel) { Fabricate(:chat_channel) }
+      fab!(:chat_message) { Fabricate(:chat_message, user: sender, chat_channel: channel) }
+      fab!(:user_membership) do
+        Fabricate(
+          :user_chat_channel_membership,
+          chat_channel: channel,
+          user: user,
+          last_read_message_id: chat_message.id - 2,
+        )
+      end
 
-      describe "selecting mentions" do
-        it "doesn't return an email if the user can't see chat" do
-          SiteSetting.chat_allowed_groups = ""
+      it "doesn't return an email if there are no unread mentions" do
+        email = described_class.chat_summary(user, {})
 
-          email = described_class.chat_summary(@user, {})
+        expect(email.to).to be_blank
+      end
 
-          expect(email.to).to be_blank
-        end
+      describe "email subject" do
+        context "regular mentions" do
+          before { Fabricate(:chat_mention, user: user, chat_message: chat_message) }
 
-        it "doesn't return an email if the user can't see any of the included channels" do
-          @chat_channel.chatable.destroy!
+          it "includes the sender username in the subject" do
+            expected_subject =
+              I18n.t(
+                "user_notifications.chat_summary.subject.chat_channel",
+                count: 1,
+                email_prefix: SiteSetting.title,
+                message_title: channel.title(user),
+              )
 
-          email = described_class.chat_summary(@user, {})
+            email = described_class.chat_summary(user, {})
 
-          expect(email.to).to be_blank
-        end
+            expect(email.subject).to eq(expected_subject)
+            expect(email.subject).to include(channel.title(user))
+          end
 
-        it "doesn't return an email if the user is not following the channel" do
-          @user_membership.update!(following: false)
-
-          email = described_class.chat_summary(@user, {})
-
-          expect(email.to).to be_blank
-        end
-
-        it "doesn't return an email if the membership object doesn't exist" do
-          @user_membership.destroy!
-
-          email = described_class.chat_summary(@user, {})
-
-          expect(email.to).to be_blank
-        end
-
-        it "doesn't return an email if the sender was deleted" do
-          @sender.destroy!
-
-          email = described_class.chat_summary(@user, {})
-
-          expect(email.to).to be_blank
-        end
-
-        it "doesn't return an email when the user already saw the mention" do
-          @user_membership.update!(last_read_message_id: @chat_message.id)
-
-          email = described_class.chat_summary(@user, {})
-
-          expect(email.to).to be_blank
-        end
-
-        it "returns an email when the user haven't read a message yet" do
-          @user_membership.update!(last_read_message_id: nil)
-
-          email = described_class.chat_summary(@user, {})
-
-          expect(email.to).to contain_exactly(@user.email)
-        end
-
-        it "doesn't return an email when the unread count belongs to a different channel" do
-          @user_membership.update!(last_read_message_id: @chat_message.id)
-          second_channel = Fabricate(:chat_channel)
-          Fabricate(
-            :user_chat_channel_membership,
-            chat_channel: second_channel,
-            user: @user,
-            last_read_message_id: @chat_message.id - 1,
-          )
-
-          email = described_class.chat_summary(@user, {})
-
-          expect(email.to).to be_blank
-        end
-
-        it "doesn't return an email if the message was deleted" do
-          @chat_message.trash!
-
-          email = described_class.chat_summary(@user, {})
-
-          expect(email.to).to be_blank
-        end
-
-        it "returns an email when the user has unread private messages" do
-          @user_membership.update!(last_read_message_id: @chat_message.id)
-          private_channel =
-            DiscourseChat::DirectMessageChannelCreator.create!(
-              acting_user: @sender,
-              target_users: [@sender, @user],
+          it "includes both channel titles when there are exactly two with unread mentions" do
+            another_chat_channel = Fabricate(:chat_channel, name: "Test channel")
+            another_chat_message =
+              Fabricate(:chat_message, user: sender, chat_channel: another_chat_channel)
+            Fabricate(
+              :user_chat_channel_membership,
+              chat_channel: another_chat_channel,
+              user: sender,
             )
-          Fabricate(:chat_message, user: @sender, chat_channel: private_channel)
+            Fabricate(
+              :user_chat_channel_membership,
+              chat_channel: another_chat_channel,
+              user: user,
+              last_read_message_id: another_chat_message.id - 2,
+            )
+            Fabricate(:chat_mention, user: user, chat_message: another_chat_message)
 
-          email = described_class.chat_summary(@user, {})
+            email = described_class.chat_summary(user, {})
 
-          expect(email.to).to contain_exactly(@user.email)
+            expect(email.subject).to include(channel.title(user))
+            expect(email.subject).to include(another_chat_channel.title(user))
+          end
+
+          it "displays a count when there are more than two channels with unread mentions" do
+            2.times do |n|
+              another_chat_channel = Fabricate(:chat_channel, name: "Test channel #{n}")
+              another_chat_message =
+                Fabricate(:chat_message, user: sender, chat_channel: another_chat_channel)
+              Fabricate(
+                :user_chat_channel_membership,
+                chat_channel: another_chat_channel,
+                user: sender,
+              )
+              Fabricate(
+                :user_chat_channel_membership,
+                chat_channel: another_chat_channel,
+                user: user,
+                last_read_message_id: another_chat_message.id - 2,
+              )
+              Fabricate(:chat_mention, user: user, chat_message: another_chat_message)
+            end
+            expected_count_text = I18n.t("user_notifications.chat_summary.subject.others", count: 2)
+
+            email = described_class.chat_summary(user, {})
+
+            expect(email.subject).to include(expected_count_text)
+          end
         end
 
-        it "returns an email if the user read all the messages included in the previous summary" do
-          @user_membership.update!(
-            last_read_message_id: @chat_message.id,
-            last_unread_mention_when_emailed_id: @chat_message.id,
-          )
+        context "both unread DM messages and mentions" do
+          before do
+            channel =
+              DiscourseChat::DirectMessageChannelCreator.create!(
+                acting_user: sender,
+                target_users: [sender, user],
+              )
+            Fabricate(:chat_message, user: sender, chat_channel: channel)
+            Fabricate(:chat_mention, user: user, chat_message: chat_message)
+          end
 
-          new_message = Fabricate(:chat_message, user: @sender, chat_channel: @chat_channel)
-          Fabricate(:chat_mention, user: @user, chat_message: new_message)
+          it "always includes the DM second" do
+            expected_other_text =
+              I18n.t(
+                "user_notifications.chat_summary.subject.other_direct_message",
+                message_title: sender.username,
+              )
 
-          email = described_class.chat_summary(@user, {})
+            email = described_class.chat_summary(user, {})
 
-          expect(email.to).to contain_exactly(@user.email)
-        end
-
-        it "doesn't return an email if the mention is older than 1 week" do
-          @chat_message.update!(created_at: 1.5.weeks.ago)
-
-          email = described_class.chat_summary(@user, {})
-
-          expect(email.to).to be_blank
+            expect(email.subject).to include(expected_other_text)
+          end
         end
       end
 
-      describe "mail contents" do
-        it "returns an email when the user has unread mentions" do
-          email = described_class.chat_summary(@user, {})
+      describe "When there are mentions" do
+        before { Fabricate(:chat_mention, user: user, chat_message: chat_message) }
 
-          expect(email.to).to contain_exactly(@user.email)
-          expect(email.html_part.body.to_s).to include(@chat_message.cooked_for_excerpt)
+        describe "selecting mentions" do
+          it "doesn't return an email if the user can't see chat" do
+            SiteSetting.chat_allowed_groups = ""
 
-          user_avatar = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row img")
+            email = described_class.chat_summary(user, {})
 
-          expect(user_avatar.attribute("src").value).to eq(@sender.small_avatar_url)
-          expect(user_avatar.attribute("alt").value).to eq(@sender.username)
-
-          more_messages_channel_link =
-            Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".more-messages-link")
-
-          expect(more_messages_channel_link.attribute("href").value).to eq(@chat_message.full_url)
-          expect(more_messages_channel_link.text).to include(
-            I18n.t("user_notifications.chat_summary.view_messages", count: 1),
-          )
-        end
-
-        it "displays the sender's name when the site is configured to prioritize it" do
-          SiteSetting.enable_names = true
-          SiteSetting.prioritize_username_in_ux = false
-
-          email = described_class.chat_summary(@user, {})
-
-          user_name = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row span")
-          expect(user_name.text).to include(@sender.name)
-
-          user_avatar = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row img")
-
-          expect(user_avatar.attribute("alt").value).to eq(@sender.name)
-        end
-
-        it "displays the sender's username when the site is configured to prioritize it" do
-          SiteSetting.enable_names = true
-          SiteSetting.prioritize_username_in_ux = true
-
-          email = described_class.chat_summary(@user, {})
-
-          user_name = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row span")
-          expect(user_name.text).to include(@sender.username)
-
-          user_avatar = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row img")
-
-          expect(user_avatar.attribute("alt").value).to eq(@sender.username)
-        end
-
-        it "displays the sender's username when names are disabled" do
-          SiteSetting.enable_names = false
-          SiteSetting.prioritize_username_in_ux = false
-
-          email = described_class.chat_summary(@user, {})
-
-          user_name = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row span")
-          expect(user_name.text).to include(@sender.username)
-
-          user_avatar = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row img")
-
-          expect(user_avatar.attribute("alt").value).to eq(@sender.username)
-        end
-
-        it "displays the sender's username when the site is configured to prioritize it" do
-          SiteSetting.enable_names = false
-          SiteSetting.prioritize_username_in_ux = true
-
-          email = described_class.chat_summary(@user, {})
-
-          user_name = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row span")
-          expect(user_name.text).to include(@sender.username)
-
-          user_avatar = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row img")
-
-          expect(user_avatar.attribute("alt").value).to eq(@sender.username)
-        end
-
-        it "includes a view more link when there are more than two mentions" do
-          2.times do
-            msg = Fabricate(:chat_message, user: @sender, chat_channel: @chat_channel)
-            Fabricate(:chat_mention, user: @user, chat_message: msg)
+            expect(email.to).to be_blank
           end
 
-          email = described_class.chat_summary(@user, {})
-          more_messages_channel_link =
-            Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".more-messages-link")
+          it "doesn't return an email if the user can't see any of the included channels" do
+            channel.chatable.destroy!
 
-          expect(more_messages_channel_link.attribute("href").value).to eq(@chat_message.full_url)
-          expect(more_messages_channel_link.text).to include(
-            I18n.t("user_notifications.chat_summary.view_more", count: 1),
-          )
+            email = described_class.chat_summary(user, {})
+
+            expect(email.to).to be_blank
+          end
+
+          it "doesn't return an email if the user is not following the channel" do
+            user_membership.update!(following: false)
+
+            email = described_class.chat_summary(user, {})
+
+            expect(email.to).to be_blank
+          end
+
+          it "doesn't return an email if the membership object doesn't exist" do
+            user_membership.destroy!
+
+            email = described_class.chat_summary(user, {})
+
+            expect(email.to).to be_blank
+          end
+
+          it "doesn't return an email if the sender was deleted" do
+            sender.destroy!
+
+            email = described_class.chat_summary(user, {})
+
+            expect(email.to).to be_blank
+          end
+
+          it "doesn't return an email when the user already saw the mention" do
+            user_membership.update!(last_read_message_id: chat_message.id)
+
+            email = described_class.chat_summary(user, {})
+
+            expect(email.to).to be_blank
+          end
+
+          it "returns an email when the user haven't read a message yet" do
+            user_membership.update!(last_read_message_id: nil)
+
+            email = described_class.chat_summary(user, {})
+
+            expect(email.to).to contain_exactly(user.email)
+          end
+
+          it "doesn't return an email when the unread count belongs to a different channel" do
+            user_membership.update!(last_read_message_id: chat_message.id)
+            second_channel = Fabricate(:chat_channel)
+            Fabricate(
+              :user_chat_channel_membership,
+              chat_channel: second_channel,
+              user: user,
+              last_read_message_id: chat_message.id - 1,
+            )
+
+            email = described_class.chat_summary(user, {})
+
+            expect(email.to).to be_blank
+          end
+
+          it "doesn't return an email if the message was deleted" do
+            chat_message.trash!
+
+            email = described_class.chat_summary(user, {})
+
+            expect(email.to).to be_blank
+          end
+
+          it "returns an email when the user has unread private messages" do
+            user_membership.update!(last_read_message_id: chat_message.id)
+            channel =
+              DiscourseChat::DirectMessageChannelCreator.create!(
+                acting_user: sender,
+                target_users: [sender, user],
+              )
+            Fabricate(:chat_message, user: sender, chat_channel: channel)
+
+            email = described_class.chat_summary(user, {})
+
+            expect(email.to).to contain_exactly(user.email)
+          end
+
+          it "returns an email if the user read all the messages included in the previous summary" do
+            user_membership.update!(
+              last_read_message_id: chat_message.id,
+              last_unread_mention_when_emailed_id: chat_message.id,
+            )
+
+            new_message = Fabricate(:chat_message, user: sender, chat_channel: channel)
+            Fabricate(:chat_mention, user: user, chat_message: new_message)
+
+            email = described_class.chat_summary(user, {})
+
+            expect(email.to).to contain_exactly(user.email)
+          end
+
+          it "doesn't return an email if the mention is older than 1 week" do
+            chat_message.update!(created_at: 1.5.weeks.ago)
+
+            email = described_class.chat_summary(user, {})
+
+            expect(email.to).to be_blank
+          end
         end
 
-        it "doesn't repeat mentions we already sent" do
-          @user_membership.update!(
-            last_read_message_id: @chat_message.id - 1,
-            last_unread_mention_when_emailed_id: @chat_message.id,
-          )
+        describe "mail contents" do
+          it "returns an email when the user has unread mentions" do
+            email = described_class.chat_summary(user, {})
 
-          new_message =
-            Fabricate(
-              :chat_message,
-              user: @sender,
-              chat_channel: @chat_channel,
-              cooked: "New message",
+            expect(email.to).to contain_exactly(user.email)
+            expect(email.html_part.body.to_s).to include(chat_message.cooked_for_excerpt)
+
+            user_avatar =
+              Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row img")
+
+            expect(user_avatar.attribute("src").value).to eq(sender.small_avatar_url)
+            expect(user_avatar.attribute("alt").value).to eq(sender.username)
+
+            more_messages_channel_link =
+              Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".more-messages-link")
+
+            expect(more_messages_channel_link.attribute("href").value).to eq(chat_message.full_url)
+            expect(more_messages_channel_link.text).to include(
+              I18n.t("user_notifications.chat_summary.view_messages", count: 1),
             )
-          Fabricate(:chat_mention, user: @user, chat_message: new_message)
+          end
 
-          email = described_class.chat_summary(@user, {})
-          body = email.html_part.body.to_s
+          it "displays the sender's name when the site is configured to prioritize it" do
+            SiteSetting.enable_names = true
+            SiteSetting.prioritize_username_in_ux = false
 
-          expect(body).not_to include(@chat_message.cooked_for_excerpt)
-          expect(body).to include(new_message.cooked_for_excerpt)
+            email = described_class.chat_summary(user, {})
+
+            user_name = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row span")
+            expect(user_name.text).to include(sender.name)
+
+            user_avatar =
+              Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row img")
+
+            expect(user_avatar.attribute("alt").value).to eq(sender.name)
+          end
+
+          it "displays the sender's username when the site is configured to prioritize it" do
+            SiteSetting.enable_names = true
+            SiteSetting.prioritize_username_in_ux = true
+
+            email = described_class.chat_summary(user, {})
+
+            user_name = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row span")
+            expect(user_name.text).to include(sender.username)
+
+            user_avatar =
+              Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row img")
+
+            expect(user_avatar.attribute("alt").value).to eq(sender.username)
+          end
+
+          it "displays the sender's username when names are disabled" do
+            SiteSetting.enable_names = false
+            SiteSetting.prioritize_username_in_ux = false
+
+            email = described_class.chat_summary(user, {})
+
+            user_name = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row span")
+            expect(user_name.text).to include(sender.username)
+
+            user_avatar =
+              Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row img")
+
+            expect(user_avatar.attribute("alt").value).to eq(sender.username)
+          end
+
+          it "displays the sender's username when the site is configured to prioritize it" do
+            SiteSetting.enable_names = false
+            SiteSetting.prioritize_username_in_ux = true
+
+            email = described_class.chat_summary(user, {})
+
+            user_name = Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row span")
+            expect(user_name.text).to include(sender.username)
+
+            user_avatar =
+              Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".message-row img")
+
+            expect(user_avatar.attribute("alt").value).to eq(sender.username)
+          end
+
+          it "includes a view more link when there are more than two mentions" do
+            2.times do
+              msg = Fabricate(:chat_message, user: sender, chat_channel: channel)
+              Fabricate(:chat_mention, user: user, chat_message: msg)
+            end
+
+            email = described_class.chat_summary(user, {})
+            more_messages_channel_link =
+              Nokogiri::HTML5.fragment(email.html_part.body.to_s).css(".more-messages-link")
+
+            expect(more_messages_channel_link.attribute("href").value).to eq(chat_message.full_url)
+            expect(more_messages_channel_link.text).to include(
+              I18n.t("user_notifications.chat_summary.view_more", count: 1),
+            )
+          end
+
+          it "doesn't repeat mentions we already sent" do
+            user_membership.update!(
+              last_read_message_id: chat_message.id - 1,
+              last_unread_mention_when_emailed_id: chat_message.id,
+            )
+
+            new_message =
+              Fabricate(:chat_message, user: sender, chat_channel: channel, cooked: "New message")
+            Fabricate(:chat_mention, user: user, chat_message: new_message)
+
+            email = described_class.chat_summary(user, {})
+            body = email.html_part.body.to_s
+
+            expect(body).not_to include(chat_message.cooked_for_excerpt)
+            expect(body).to include(new_message.cooked_for_excerpt)
+          end
         end
       end
     end

--- a/spec/requests/chat_channel_controller_spec.rb
+++ b/spec/requests/chat_channel_controller_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe DiscourseChat::ChatChannelsController do
             )
         end
 
-        it "returns correct DMs for user1" do
+        it "returns correct DMs for creator" do
           sign_in(user1)
 
           get "/chat/chat_channels.json"
@@ -140,26 +140,32 @@ RSpec.describe DiscourseChat::ChatChannelsController do
           ).to match_array([@dm1.id, @dm2.id, @dm3.id])
         end
 
-        it "returns correct DMs for user2" do
+        it "returns correct DMs when not following" do
           sign_in(user2)
 
           get "/chat/chat_channels.json"
           expect(
             response.parsed_body["direct_message_channels"].map { |c| c["id"] },
-          ).to match_array([@dm1.id, @dm3.id, @dm4.id])
+          ).to match_array([])
         end
 
-        it "returns correct DMs for user3" do
+        it "returns correct DMs when following" do
+          user3
+            .user_chat_channel_memberships
+            .where(chat_channel_id: @dm3.id)
+            .update!(following: true)
+
           sign_in(user3)
 
           get "/chat/chat_channels.json"
-          expect(
-            response.parsed_body["direct_message_channels"].map { |c| c["id"] },
-          ).to match_array([@dm2.id, @dm3.id, @dm4.id])
+          dm3_response = response.parsed_body
+          expect(dm3_response["direct_message_channels"].map { |c| c["id"] }).to match_array(
+            [@dm3.id],
+          )
         end
 
-        it "correctly set unread_count for DMs" do
-          sign_in(user3)
+        it "correctly set unread_count for DMs for creator" do
+          sign_in(user1)
           DiscourseChat::ChatMessageCreator.create(
             chat_channel: @dm2,
             user: user1,
@@ -168,7 +174,38 @@ RSpec.describe DiscourseChat::ChatChannelsController do
           get "/chat/chat_channels.json"
           dm2_response =
             response.parsed_body["direct_message_channels"].detect { |c| c["id"] == @dm2.id }
-          expect(dm2_response["current_user_membership"]["unread_count"]).to eq(1)
+          expect(dm2_response["current_user_membership"]["unread_count"]).to eq(0)
+        end
+
+        it "correctly set membership for DMs when user is not following" do
+          sign_in(user2)
+          DiscourseChat::ChatMessageCreator.create(
+            chat_channel: @dm2,
+            user: user1,
+            content: "What's going on?!",
+          )
+          get "/chat/chat_channels.json"
+          dm2_channel =
+            response.parsed_body["direct_message_channels"].detect { |c| c["id"] == @dm2.id }
+          expect(dm2_channel).to be_nil
+        end
+
+        it "correctly set unread_count for DMs when user is following" do
+          user3
+            .user_chat_channel_memberships
+            .where(chat_channel_id: @dm2.id)
+            .update!(following: true)
+
+          sign_in(user3)
+          DiscourseChat::ChatMessageCreator.create(
+            chat_channel: @dm2,
+            user: user1,
+            content: "What's going on?!",
+          )
+          get "/chat/chat_channels.json"
+          dm3_response =
+            response.parsed_body["direct_message_channels"].detect { |c| c["id"] == @dm2.id }
+          expect(dm3_response["current_user_membership"]["unread_count"]).to eq(1)
         end
       end
     end
@@ -198,7 +235,9 @@ RSpec.describe DiscourseChat::ChatChannelsController do
       expect(response.status).to eq(200)
       expect(response.parsed_body["memberships_count"]).to eq(1)
       expect(response.parsed_body["current_user_membership"]["following"]).to eq(true)
-      expect(response.parsed_body["current_user_membership"]["chat_channel_id"]).to eq(chat_channel.id)
+      expect(response.parsed_body["current_user_membership"]["chat_channel_id"]).to eq(
+        chat_channel.id,
+      )
     end
   end
 
@@ -218,7 +257,9 @@ RSpec.describe DiscourseChat::ChatChannelsController do
       expect(response.status).to eq(200)
       expect(response.parsed_body["memberships_count"]).to eq(0)
       expect(response.parsed_body["current_user_membership"]["following"]).to eq(false)
-      expect(response.parsed_body["current_user_membership"]["chat_channel_id"]).to eq(chat_channel.id)
+      expect(response.parsed_body["current_user_membership"]["chat_channel_id"]).to eq(
+        chat_channel.id,
+      )
     end
 
     it "allows to unfollow a direct_message_channel" do

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -1267,26 +1267,32 @@ acceptance(
       baseChatPretenders(server, helper);
       chatChannelPretender(server, helper);
 
+      const channel = {
+        chatable: {},
+        chatable_id: 88,
+        chatable_type: "Category",
+        chatable_url: null,
+        id: 88,
+        title: "Something",
+        last_message_sent_at: "2021-11-08T21:26:05.710Z",
+        current_user_membership: {
+          last_read_message_id: null,
+          unread_count: 0,
+          unread_mentions: 0,
+        },
+      };
+
       server.get("/chat/api/chat_channels.json", () => {
         return helper.response([fabricators.chatChannel()]);
       });
 
+      server.get("/chat/chat_channels/:id.json", () => {
+        return helper.response(channel);
+      });
+
       server.put("/chat/chat_channels", () => {
         return helper.response({
-          chat_channel: {
-            chatable: {},
-            chatable_id: 88,
-            chatable_type: "Category",
-            chatable_url: null,
-            id: 88,
-            title: "Something",
-            last_message_sent_at: "2021-11-08T21:26:05.710Z",
-            current_user_membership: {
-              last_read_message_id: null,
-              unread_count: 0,
-              unread_mentions: 0,
-            },
-          },
+          chat_channel: channel,
         });
       });
     });

--- a/test/javascripts/unit/services/chat-test.js
+++ b/test/javascripts/unit/services/chat-test.js
@@ -5,6 +5,7 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import { settled } from "@ember/test-helpers";
 import { test } from "qunit";
+import fabricators from "../../helpers/fabricators";
 
 acceptance("Discourse Chat | Unit | Service | chat", function (needs) {
   needs.hooks.beforeEach(function () {
@@ -57,6 +58,18 @@ acceptance("Discourse Chat | Unit | Service | chat", function (needs) {
     assert.equal(
       this.currentUser.chat_channel_tracking_state[1].unread_count,
       2
+    );
+  });
+
+  test("attempts to track a non followed channel", async function (assert) {
+    this.currentUser.set("chat_channel_tracking_state", {});
+    const channel = fabricators.chatChannel();
+    await this.chatService.startTrackingChannel(channel);
+
+    assert.false(channel.current_user_membership.following);
+    assert.notOk(
+      this.currentUser.chat_channel_tracking_state[channel.id],
+      "it doesn’t track it"
     );
   });
 


### PR DESCRIPTION
Other users of the channel should only start tracking once a new message is sent. This is to cover cases where the DM channel can be created _without_ sending a message, such as from the user card "Chat" button.