### PR TITLE
UX: show status next to posts using new component with rich tooltip

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-message-info.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message-info.hbs
@@ -18,9 +18,7 @@
       <span class="chat-message-info__username__name">{{this.name}}</span>
       {{#if this.showStatus}}
         <div class="chat-message-info__status">
-          {{emoji
-            @message.user.status.emoji
-            title=@message.user.status.description}}
+          <UserStatusMessage @status={{@message.user.status}} />
         </div>
       {{/if}}
     </span>

--- a/test/javascripts/components/chat-message-info-test.js
+++ b/test/javascripts/components/chat-message-info-test.js
@@ -106,9 +106,7 @@ module("Discourse Chat | Component | chat-message-info", function (hooks) {
     },
 
     async test(assert) {
-      assert.ok(
-        exists(".chat-message-info__status .emoji[title='off to dentist']")
-      );
+      assert.ok(exists(".chat-message-info__status .user-status-message"));
     },
   });
 


### PR DESCRIPTION
Before:

<img width="225" alt="Screenshot 2022-08-14 at 01 02 07" src="https://user-images.githubusercontent.com/1274517/184510672-37bbec34-2b61-4e45-90c0-f840a55993a9.png">

After:
<img width="239" alt="Screenshot 2022-08-14 at 01 04 46" src="https://user-images.githubusercontent.com/1274517/184510700-c410adb5-be60-43ec-95f6-9087892abc2a.png">



