### PR TITLE
UX: show status on the direct message chats list using the new component with rich tooltip

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-row.hbs
@@ -11,10 +11,7 @@
   {{chat-channel-title channel=channel unreadIndicator=true}}
 
   {{#if this.showUserStatus}}
-    {{emoji
-      channel.chatable.users.firstObject.status.emoji
-      title=channel.chatable.users.firstObject.status.description
-    }}
+    <UserStatusMessage @status={{channel.chatable.users.firstObject.status}} />
   {{/if}}
 
   {{#if (and options.leaveButton channel.isFollowing (not site.mobileView))}}

--- a/test/javascripts/components/chat-channel-row-test.js
+++ b/test/javascripts/components/chat-channel-row-test.js
@@ -124,7 +124,7 @@ module("Discourse Chat | Component | chat-channel-row", function (hooks) {
     },
 
     async test(assert) {
-      assert.ok(exists(".emoji[title='Off to dentist']"));
+      assert.ok(exists(".user-status-message"));
     },
   });
 
@@ -147,7 +147,7 @@ module("Discourse Chat | Component | chat-channel-row", function (hooks) {
       },
 
       async test(assert) {
-        assert.notOk(exists(".emoji[title='Off to dentist']"));
+        assert.notOk(exists(".user-status-message"));
       },
     }
   );


### PR DESCRIPTION
Before:

<img width="250" alt="Screenshot 2022-08-14 at 01 16 06" src="https://user-images.githubusercontent.com/1274517/184511044-f5a0ab36-4922-46bb-ba8d-b174b01f61df.png">

After:

<img width="250" alt="Screenshot 2022-08-14 at 01 16 57" src="https://user-images.githubusercontent.com/1274517/184511047-f07414fc-13db-48ed-a137-288ed99852e6.png">


