### PR TITLE
DEV: Move mobileView check out of `FullPageChat.isPreferred`

### DIFF
--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -29,10 +29,15 @@ const CHAT_ONLINE_OPTIONS = {
 };
 
 export default Service.extend({
-  activeChannel: null,
-  allChannels: null,
   appEvents: service(),
   chatNotificationManager: service(),
+  fullPageChat: service(),
+  presence: service(),
+  router: service(),
+  site: service(),
+
+  activeChannel: null,
+  allChannels: null,
   cook: null,
   directMessageChannels: null,
   hasFetchedChannels: false,
@@ -40,13 +45,10 @@ export default Service.extend({
   idToTitleMap: null,
   lastUserTrackingMessageId: null,
   messageId: null,
-  presence: service(),
   presenceChannel: null,
   publicChannels: null,
-  router: service(),
   sidebarActive: false,
   unreadUrgentCount: null,
-  fullPageChat: service(),
   _chatOpen: false,
   _fetchingChannels: null,
   directMessagesLimit: 20,

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -468,7 +468,11 @@ export default Service.extend({
 
     this.setActiveChannel(channel);
 
-    if (this.fullPageChat.isActive || this.fullPageChat.isPreferred) {
+    if (
+      this.fullPageChat.isActive ||
+      this.site.mobileView ||
+      this.fullPageChat.isPreferred
+    ) {
       const queryParams = messageId ? { messageId } : {};
 
       return this.router.transitionTo(

--- a/assets/javascripts/discourse/services/full-page-chat.js
+++ b/assets/javascripts/discourse/services/full-page-chat.js
@@ -1,6 +1,5 @@
 import KeyValueStore from "discourse/lib/key-value-store";
 import Service from "@ember/service";
-import Site from "discourse/models/site";
 
 const FULL_PAGE = "fullPage";
 const STORE_NAMESPACE_CHAT_WINDOW = "discourse_chat_window_";
@@ -25,9 +24,7 @@ export default class FullPageChat extends Service {
   }
 
   get isPreferred() {
-    return !!(
-      Site.currentProp("mobileView") || this.store.getObject(FULL_PAGE)
-    );
+    return !!this.store.getObject(FULL_PAGE);
   }
 
   set isPreferred(value) {

--- a/assets/javascripts/discourse/widgets/chat-header-icon.js
+++ b/assets/javascripts/discourse/widgets/chat-header-icon.js
@@ -65,7 +65,11 @@ export default createWidget("header-chat-link", {
       return;
     }
 
-    if (this.chat.sidebarActive || this.fullPageChat.isPreferred) {
+    if (
+      this.chat.sidebarActive ||
+      this.site.mobileView ||
+      this.fullPageChat.isPreferred
+    ) {
       this.fullPageChat.isPreferred = true;
       return this.router.transitionTo("chat");
     } else {


### PR DESCRIPTION
```
x.isPreferred = false;
x.isPreferred == true
```

…was a bit confusing, and the mobile-related logic didn't fit the name (on mobile, fullscreen isn't "preferred" - it's "required" 😛)
