### PR TITLE
FEATURE: Allow changing DM channel notification settings

### DIFF
--- a/app/jobs/regular/chat_notify_watching.rb
+++ b/app/jobs/regular/chat_notify_watching.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module Jobs
-  # TODO (martin) A spec for this whole class.
   class ChatNotifyWatching < ::Jobs::Base
     def execute(args = {})
       @chat_message =

--- a/app/models/user_chat_channel_membership.rb
+++ b/app/models/user_chat_channel_membership.rb
@@ -16,8 +16,6 @@ class UserChatChannelMembership < ActiveRecord::Base
 
   enum join_mode: { manual: 0, automatic: 1 }
 
-  validate :changes_for_direct_message_channels
-
   class << self
     def enforce_automatic_channel_memberships(channel)
       Jobs.enqueue(:auto_manage_channel_memberships, chat_channel_id: channel.id)
@@ -30,18 +28,6 @@ class UserChatChannelMembership < ActiveRecord::Base
         starts_at: user.id,
         ends_at: user.id,
       )
-    end
-  end
-
-  private
-
-  def changes_for_direct_message_channels
-    needs_validation =
-      VALIDATED_ATTRS.any? { |attr| changed_attribute_names_to_save.include?(attr.to_s) }
-    if needs_validation && chat_channel.direct_message_channel?
-      errors.add(:muted) if muted
-      errors.add(:desktop_notification_level) if desktop_notification_level.to_sym != :always
-      errors.add(:mobile_notification_level) if mobile_notification_level.to_sym != :always
     end
   end
 end

--- a/assets/javascripts/discourse/templates/components/chat-channel-settings-view.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-channel-settings-view.hbs
@@ -1,90 +1,90 @@
-{{#unless channel.isDirectMessageChannel}}
-  <div class="chat-form__section">
+<div class="chat-form__section">
+  <div class="chat-form__field">
+    <label class="chat-form__label">
+      <span>{{i18n "chat.settings.mute"}}</span>
+    </label>
+    <div class="chat-form__control">
+      {{combo-box
+        content=mutedOptions
+        value=channel.current_user_membership.muted
+        valueProperty="value"
+        class="channel-settings-view__muted-selector"
+        onChange=(action (fn this.saveNotificationSettings "muted"))
+      }}
+      {{#if savedMuted}}
+        <span class="channel-settings-view__saved">✓ Saved</span>
+      {{/if}}
+    </div>
+  </div>
+
+  {{#unless channel.current_user_membership.muted}}
     <div class="chat-form__field">
       <label class="chat-form__label">
-        <span>{{i18n "chat.settings.mute"}}</span>
+        <span>{{i18n "chat.settings.desktop_notification_level"}}</span>
       </label>
       <div class="chat-form__control">
         {{combo-box
-          content=mutedOptions
-          value=channel.current_user_membership.muted
+          content=notificationLevels
+          value=channel.current_user_membership.desktop_notification_level
           valueProperty="value"
-          class="channel-settings-view__muted-selector"
-          onChange=(action (fn this.saveNotificationSettings "muted"))
+          class="channel-settings-view__desktop-notification-level-selector"
+          onChange=(action
+            (fn this.saveNotificationSettings "desktop_notification_level")
+          )
         }}
-        {{#if savedMuted}}
+        {{#if savedDesktopNotificationLevel}}
           <span class="channel-settings-view__saved">✓ Saved</span>
         {{/if}}
       </div>
     </div>
 
-    {{#unless channel.current_user_membership.muted}}
-      <div class="chat-form__field">
-        <label class="chat-form__label">
-          <span>{{i18n "chat.settings.desktop_notification_level"}}</span>
-        </label>
-        <div class="chat-form__control">
-          {{combo-box
-            content=notificationLevels
-            value=channel.current_user_membership.desktop_notification_level
-            valueProperty="value"
-            class="channel-settings-view__desktop-notification-level-selector"
-            onChange=(action
-              (fn this.saveNotificationSettings "desktop_notification_level")
-            )
-          }}
-          {{#if savedDesktopNotificationLevel}}
-            <span class="channel-settings-view__saved">✓ Saved</span>
-          {{/if}}
-        </div>
+    <div class="chat-form__field">
+      <label class="chat-form__label">
+        <span>{{i18n "chat.settings.mobile_notification_level"}}</span>
+      </label>
+      <div class="chat-form__control">
+        {{combo-box
+          content=notificationLevels
+          value=channel.current_user_membership.mobile_notification_level
+          valueProperty="value"
+          class="channel-settings-view__mobile-notification-level-selector"
+          onChange=(action
+            (fn this.saveNotificationSettings "mobile_notification_level")
+          )
+        }}
+        {{#if savedMobileNotificationLevel}}
+          <span class="channel-settings-view__saved">✓ Saved</span>
+        {{/if}}
       </div>
+    </div>
+  {{/unless}}
+</div>
 
+{{#if (chat-guardian "can-edit-chat-channel")}}
+  {{#if autoJoinAvailable}}
+    <div class="chat-form__section">
       <div class="chat-form__field">
-        <label class="chat-form__label">
-          <span>{{i18n "chat.settings.mobile_notification_level"}}</span>
-        </label>
-        <div class="chat-form__control">
-          {{combo-box
-            content=notificationLevels
-            value=channel.current_user_membership.mobile_notification_level
-            valueProperty="value"
-            class="channel-settings-view__mobile-notification-level-selector"
-            onChange=(action
-              (fn this.saveNotificationSettings "mobile_notification_level")
-            )
+        {{#if channel.auto_join_users}}
+          {{d-button
+            action=(action "onDisableAutoJoinUsers")
+            label="chat.settings.disable_auto_join_users"
+            class="archive-btn chat-form__btn btn-flat"
+            icon="minus-circle"
           }}
-          {{#if savedMobileNotificationLevel}}
-            <span class="channel-settings-view__saved">✓ Saved</span>
-          {{/if}}
-        </div>
+        {{else}}
+          {{d-button
+            action=(action "onEnableAutoJoinUsers")
+            label="chat.settings.enable_auto_join_users"
+            class="archive-btn chat-form__btn btn-flat"
+            icon="user-plus"
+          }}
+        {{/if}}
       </div>
-    {{/unless}}
-  </div>
-
-  {{#if (chat-guardian "can-edit-chat-channel")}}
-    {{#if autoJoinAvailable}}
-      <div class="chat-form__section">
-        <div class="chat-form__field">
-          {{#if channel.auto_join_users}}
-            {{d-button
-              action=(action "onDisableAutoJoinUsers")
-              label="chat.settings.disable_auto_join_users"
-              class="archive-btn chat-form__btn btn-flat"
-              icon="minus-circle"
-            }}
-          {{else}}
-            {{d-button
-              action=(action "onEnableAutoJoinUsers")
-              label="chat.settings.enable_auto_join_users"
-              class="archive-btn chat-form__btn btn-flat"
-              icon="user-plus"
-            }}
-          {{/if}}
-        </div>
-      </div>
-    {{/if}}
+    </div>
   {{/if}}
+{{/if}}
 
+{{#unless channel.isDirectMessageChannel}}
   <div class="chat-form__section">
     {{#if (chat-guardian "can-edit-chat-channel")}}
       {{#if (chat-guardian "can-archive-channel" channel)}}

--- a/lib/chat_channel_fetcher.rb
+++ b/lib/chat_channel_fetcher.rb
@@ -156,12 +156,7 @@ module DiscourseChat::ChatChannelFetcher
               data["chat_message_id"] > (membership.last_read_message_id || 0)
           end
 
-        # direct message channels cannot be muted, so we always need the unread count
-        if channel.direct_message_channel?
-          membership.unread_count = unread_counts_per_channel[channel.id]
-        else
-          membership.unread_count = unread_counts_per_channel[channel.id] if !membership.muted
-        end
+        membership.unread_count = unread_counts_per_channel[channel.id] if !membership.muted
       end
     end
   end

--- a/spec/fabricators/chat_fabricator.rb
+++ b/spec/fabricators/chat_fabricator.rb
@@ -8,6 +8,14 @@ Fabricator(:chat_channel) do
   status { :open }
 end
 
+Fabricator(:direct_message_chat_channel, from: :chat_channel) do
+  transient :users
+  chatable do |attrs|
+    Fabricate(:direct_message_channel, users: attrs[:users] || [Fabricate(:user), Fabricate(:user)])
+  end
+  status { :open }
+end
+
 Fabricator(:chat_message) do
   chat_channel
   user

--- a/spec/jobs/regular/chat_notify_watching_spec.rb
+++ b/spec/jobs/regular/chat_notify_watching_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
       )
     end
 
-    it "sends a notification via MessageBus" do
+    it "sends a desktop notification" do
       messages = notification_messages_for(user2)
 
       expect(messages.first.data).to include(
@@ -64,7 +64,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
         )
       end
 
-      it "sends a notification via PostAlerter" do
+      it "sends a mobile notification" do
         PostAlerter.expects(:push_notification).with(
           user2,
           has_entries(
@@ -84,7 +84,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
     context "when the target user cannot chat" do
       before { SiteSetting.chat_allowed_groups = group.id }
 
-      it "does not send a notification via MessageBus" do
+      it "does not send a desktop notification" do
         expect(notification_messages_for(user2).count).to be_zero
       end
     end
@@ -92,7 +92,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
     context "when the target user cannot see the chat channel" do
       before { channel.update!(chatable: Fabricate(:private_category, group: group)) }
 
-      it "does not send a notification via MessageBus" do
+      it "does not send a desktop notification" do
         expect(notification_messages_for(user2).count).to be_zero
       end
     end
@@ -100,7 +100,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
     context "when the target user has seen the message already" do
       before { membership2.update!(last_read_message_id: message.id) }
 
-      it "does not send a notification via MessageBus" do
+      it "does not send a desktop notification" do
         expect(notification_messages_for(user2).count).to be_zero
       end
     end
@@ -108,7 +108,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
     context "when the target user is online via presence channel" do
       before { PresenceChannel.any_instance.expects(:user_ids).returns([user2.id]) }
 
-      it "does not send a notification via MessageBus" do
+      it "does not send a desktop notification" do
         expect(notification_messages_for(user2).count).to be_zero
       end
     end
@@ -116,7 +116,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
     context "when the target user is suspended" do
       before { user2.update!(suspended_till: 1.year.from_now) }
 
-      it "does not send a notification via MessageBus" do
+      it "does not send a desktop notification" do
         expect(notification_messages_for(user2).count).to be_zero
       end
     end
@@ -124,7 +124,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
     context "when the target user is inside the except_user_ids array" do
       let(:except_user_ids) { [user2.id] }
 
-      it "does not send a notification via MessageBus" do
+      it "does not send a desktop notification" do
         expect(notification_messages_for(user2).count).to be_zero
       end
     end
@@ -149,7 +149,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
       )
     end
 
-    it "sends a notification via MessageBus" do
+    it "sends a desktop notification" do
       messages = notification_messages_for(user2)
 
       expect(messages.first.data).to include(
@@ -170,7 +170,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
         )
       end
 
-      it "sends a notification via PostAlerter" do
+      it "sends a mobile notification" do
         PostAlerter.expects(:push_notification).with(
           user2,
           has_entries(
@@ -190,7 +190,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
     context "when the target user cannot chat" do
       before { SiteSetting.chat_allowed_groups = group.id }
 
-      it "does not send a notification via MessageBus" do
+      it "does not send a desktop notification" do
         expect(notification_messages_for(user2).count).to be_zero
       end
     end
@@ -198,7 +198,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
     context "when the target user cannot see the chat channel" do
       before { channel.update!(chatable: Fabricate(:private_category, group: group)) }
 
-      it "does not send a notification via MessageBus" do
+      it "does not send a desktop notification" do
         expect(notification_messages_for(user2).count).to be_zero
       end
     end
@@ -206,7 +206,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
     context "when the target user has seen the message already" do
       before { membership2.update!(last_read_message_id: message.id) }
 
-      it "does not send a notification via MessageBus" do
+      it "does not send a desktop notification" do
         expect(notification_messages_for(user2).count).to be_zero
       end
     end
@@ -214,7 +214,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
     context "when the target user is online via presence channel" do
       before { PresenceChannel.any_instance.expects(:user_ids).returns([user2.id]) }
 
-      it "does not send a notification via MessageBus" do
+      it "does not send a desktop notification" do
         expect(notification_messages_for(user2).count).to be_zero
       end
     end
@@ -222,7 +222,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
     context "when the target user is suspended" do
       before { user2.update!(suspended_till: 1.year.from_now) }
 
-      it "does not send a notification via MessageBus" do
+      it "does not send a desktop notification" do
         expect(notification_messages_for(user2).count).to be_zero
       end
     end
@@ -230,7 +230,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
     context "when the target user is inside the except_user_ids array" do
       let(:except_user_ids) { [user2.id] }
 
-      it "does not send a notification via MessageBus" do
+      it "does not send a desktop notification" do
         expect(notification_messages_for(user2).count).to be_zero
       end
     end
@@ -240,7 +240,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
         UserCommScreener.any_instance.expects(:allowing_actor_communication).returns([])
       end
 
-      it "does not send a notification via MessageBus" do
+      it "does not send a desktop notification" do
         expect(notification_messages_for(user2).count).to be_zero
       end
     end

--- a/spec/jobs/regular/chat_notify_watching_spec.rb
+++ b/spec/jobs/regular/chat_notify_watching_spec.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::ChatNotifyWatching do
+  fab!(:user1) { Fabricate(:user) }
+  fab!(:user2) { Fabricate(:user) }
+  fab!(:user3) { Fabricate(:user) }
+  fab!(:group) { Fabricate(:group) }
+  let(:except_user_ids) { [] }
+
+  before do
+    SiteSetting.chat_enabled = true
+    SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+  end
+
+  def run_job
+    described_class.new.execute(chat_message_id: message.id, except_user_ids: except_user_ids)
+  end
+
+  def notification_messages_for(user)
+    MessageBus
+      .track_publish { run_job }
+      .filter { |m| m.channel == "/chat/notification-alert/#{user.id}" }
+  end
+
+  context "for a category channel" do
+    fab!(:channel) { Fabricate(:chat_channel) }
+    fab!(:membership1) do
+      Fabricate(:user_chat_channel_membership, user: user1, chat_channel: channel)
+    end
+    fab!(:membership2) do
+      Fabricate(:user_chat_channel_membership, user: user2, chat_channel: channel)
+    end
+    fab!(:membership3) do
+      Fabricate(:user_chat_channel_membership, user: user3, chat_channel: channel)
+    end
+    fab!(:message) do
+      Fabricate(:chat_message, chat_channel: channel, user: user1, message: "this is a new message")
+    end
+
+    before do
+      membership2.update!(
+        desktop_notification_level: UserChatChannelMembership::NOTIFICATION_LEVELS[:always],
+      )
+    end
+
+    it "sends a notification via MessageBus" do
+      messages = notification_messages_for(user2)
+
+      expect(messages.first.data).to include(
+        {
+          username: user1.username,
+          notification_type: Notification.types[:chat_message],
+          post_url: "/chat/channel/#{channel.id}/#{channel.title(user2)}",
+          excerpt: message.message,
+        },
+      )
+    end
+
+    context "when mobile_notification_level is always and desktop_notification_level is none" do
+      before do
+        membership2.update!(
+          desktop_notification_level: UserChatChannelMembership::NOTIFICATION_LEVELS[:never],
+          mobile_notification_level: UserChatChannelMembership::NOTIFICATION_LEVELS[:always],
+        )
+      end
+
+      it "sends a notification via PostAlerter" do
+        PostAlerter.expects(:push_notification).with(
+          user2,
+          has_entries(
+            {
+              username: user1.username,
+              notification_type: Notification.types[:chat_message],
+              post_url: "/chat/channel/#{channel.id}/#{channel.title(user2)}",
+              excerpt: message.message,
+            },
+          ),
+        )
+        messages = notification_messages_for(user2)
+        expect(messages.length).to be_zero
+      end
+    end
+
+    context "when the target user cannot chat" do
+      before { SiteSetting.chat_allowed_groups = group.id }
+
+      it "does not send a notification via MessageBus" do
+        expect(notification_messages_for(user2).count).to be_zero
+      end
+    end
+
+    context "when the target user cannot see the chat channel" do
+      before { channel.update!(chatable: Fabricate(:private_category, group: group)) }
+
+      it "does not send a notification via MessageBus" do
+        expect(notification_messages_for(user2).count).to be_zero
+      end
+    end
+
+    context "when the target user has seen the message already" do
+      before { membership2.update!(last_read_message_id: message.id) }
+
+      it "does not send a notification via MessageBus" do
+        expect(notification_messages_for(user2).count).to be_zero
+      end
+    end
+
+    context "when the target user is online via presence channel" do
+      before { PresenceChannel.any_instance.expects(:user_ids).returns([user2.id]) }
+
+      it "does not send a notification via MessageBus" do
+        expect(notification_messages_for(user2).count).to be_zero
+      end
+    end
+
+    context "when the target user is suspended" do
+      before { user2.update!(suspended_till: 1.year.from_now) }
+
+      it "does not send a notification via MessageBus" do
+        expect(notification_messages_for(user2).count).to be_zero
+      end
+    end
+
+    context "when the target user is inside the except_user_ids array" do
+      let(:except_user_ids) { [user2.id] }
+
+      it "does not send a notification via MessageBus" do
+        expect(notification_messages_for(user2).count).to be_zero
+      end
+    end
+  end
+
+  context "for a direct message channel" do
+    fab!(:channel) { Fabricate(:direct_message_chat_channel, users: [user1, user2, user3]) }
+    fab!(:membership1) do
+      Fabricate(:user_chat_channel_membership, user: user1, chat_channel: channel)
+    end
+    fab!(:membership2) do
+      Fabricate(:user_chat_channel_membership, user: user2, chat_channel: channel)
+    end
+    fab!(:membership3) do
+      Fabricate(:user_chat_channel_membership, user: user3, chat_channel: channel)
+    end
+    fab!(:message) { Fabricate(:chat_message, chat_channel: channel, user: user1) }
+
+    before do
+      membership2.update!(
+        desktop_notification_level: UserChatChannelMembership::NOTIFICATION_LEVELS[:always],
+      )
+    end
+
+    it "sends a notification via MessageBus" do
+      messages = notification_messages_for(user2)
+
+      expect(messages.first.data).to include(
+        {
+          username: user1.username,
+          notification_type: Notification.types[:chat_message],
+          post_url: "/chat/channel/#{channel.id}/#{channel.title(user2)}",
+          excerpt: message.message,
+        },
+      )
+    end
+
+    context "when mobile_notification_level is always and desktop_notification_level is none" do
+      before do
+        membership2.update!(
+          desktop_notification_level: UserChatChannelMembership::NOTIFICATION_LEVELS[:never],
+          mobile_notification_level: UserChatChannelMembership::NOTIFICATION_LEVELS[:always],
+        )
+      end
+
+      it "sends a notification via PostAlerter" do
+        PostAlerter.expects(:push_notification).with(
+          user2,
+          has_entries(
+            {
+              username: user1.username,
+              notification_type: Notification.types[:chat_message],
+              post_url: "/chat/channel/#{channel.id}/#{channel.title(user2)}",
+              excerpt: message.message,
+            },
+          ),
+        )
+        messages = notification_messages_for(user2)
+        expect(messages.length).to be_zero
+      end
+    end
+
+    context "when the target user cannot chat" do
+      before { SiteSetting.chat_allowed_groups = group.id }
+
+      it "does not send a notification via MessageBus" do
+        expect(notification_messages_for(user2).count).to be_zero
+      end
+    end
+
+    context "when the target user cannot see the chat channel" do
+      before { channel.update!(chatable: Fabricate(:private_category, group: group)) }
+
+      it "does not send a notification via MessageBus" do
+        expect(notification_messages_for(user2).count).to be_zero
+      end
+    end
+
+    context "when the target user has seen the message already" do
+      before { membership2.update!(last_read_message_id: message.id) }
+
+      it "does not send a notification via MessageBus" do
+        expect(notification_messages_for(user2).count).to be_zero
+      end
+    end
+
+    context "when the target user is online via presence channel" do
+      before { PresenceChannel.any_instance.expects(:user_ids).returns([user2.id]) }
+
+      it "does not send a notification via MessageBus" do
+        expect(notification_messages_for(user2).count).to be_zero
+      end
+    end
+
+    context "when the target user is suspended" do
+      before { user2.update!(suspended_till: 1.year.from_now) }
+
+      it "does not send a notification via MessageBus" do
+        expect(notification_messages_for(user2).count).to be_zero
+      end
+    end
+
+    context "when the target user is inside the except_user_ids array" do
+      let(:except_user_ids) { [user2.id] }
+
+      it "does not send a notification via MessageBus" do
+        expect(notification_messages_for(user2).count).to be_zero
+      end
+    end
+
+    context "when the target user is preventing communication from the message creator" do
+      before do
+        UserCommScreener.any_instance.expects(:allowing_actor_communication).returns([])
+      end
+
+      it "does not send a notification via MessageBus" do
+        expect(notification_messages_for(user2).count).to be_zero
+      end
+    end
+  end
+end

--- a/spec/requests/api/chat_channel_notifications_settings_controller_spec.rb
+++ b/spec/requests/api/chat_channel_notifications_settings_controller_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require "rails_helper"
-
-describe DiscourseChat::Api::ChatChannelNotificationsSettingsController do
+RSpec.describe DiscourseChat::Api::ChatChannelNotificationsSettingsController do
   before do
     SiteSetting.chat_enabled = true
     SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
@@ -11,7 +9,7 @@ describe DiscourseChat::Api::ChatChannelNotificationsSettingsController do
   describe "#update" do
     include_examples "channel access example", :put, "/notifications_settings.json"
 
-    context "invalid params" do
+    context "category channel invalid params" do
       fab!(:chat_channel) { Fabricate(:chat_channel) }
       fab!(:user) { Fabricate(:user) }
       fab!(:membership) do
@@ -33,7 +31,7 @@ describe DiscourseChat::Api::ChatChannelNotificationsSettingsController do
       end
     end
 
-    context "valid params" do
+    context "category channel valid params" do
       fab!(:chat_channel) { Fabricate(:chat_channel) }
       fab!(:user) { Fabricate(:user) }
       fab!(:membership) do
@@ -79,37 +77,60 @@ describe DiscourseChat::Api::ChatChannelNotificationsSettingsController do
       end
     end
 
-    context "invalid params" do
-      fab!(:chatable) { Fabricate(:direct_message_channel) }
+    context "direct message channel invalid params" do
+      fab!(:user) { Fabricate(:user) }
+      fab!(:chatable) { Fabricate(:direct_message_channel, users: [user, Fabricate(:user)]) }
+      fab!(:chat_channel) { Fabricate(:chat_channel, chatable: chatable) }
+      fab!(:membership) do
+        Fabricate(:user_chat_channel_membership, user: user, chat_channel: chat_channel)
+      end
+
+      before { sign_in(user) }
+
+      it "doesn’t use invalid params" do
+        UserChatChannelMembership.any_instance.expects(:update!).with("muted" => "true").once
+
+        put "/chat/api/chat_channels/#{chat_channel.id}/notifications_settings.json",
+            params: {
+              muted: true,
+              foo: 1,
+            }
+
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "direct message channel valid params" do
+      fab!(:user) { Fabricate(:user) }
+      fab!(:chatable) { Fabricate(:direct_message_channel, users: [user, Fabricate(:user)]) }
       fab!(:chat_channel) { Fabricate(:chat_channel, chatable: chatable) }
       fab!(:membership) do
         Fabricate(
           :user_chat_channel_membership,
-          user: chatable.users[0],
-          chat_channel: chat_channel,
-          following: true,
           muted: false,
-          desktop_notification_level: UserChatChannelMembership::NOTIFICATION_LEVELS[:always],
-          mobile_notification_level: UserChatChannelMembership::NOTIFICATION_LEVELS[:always],
+          user: user,
+          chat_channel: chat_channel,
         )
       end
 
-      before { sign_in(chatable.users[0]) }
+      before { sign_in(user) }
 
-      it "raises a 422" do
+      it "updates the notifications settings" do
         put "/chat/api/chat_channels/#{chat_channel.id}/notifications_settings.json",
             params: {
               muted: true,
+              desktop_notification_level: "always",
+              mobile_notification_level: "never",
             }
 
-        expect(response.status).to eq(422)
-        expect(response.parsed_body["errors"][0]).to eq(
-          I18n.t(
-            "activerecord.errors.format",
-            attribute: "Muted",
-            message: I18n.t("activerecord.errors.messages.invalid"),
-          ),
-        )
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).to match_response_schema("user_chat_channel_membership")
+
+        membership.reload
+
+        expect(membership.muted).to eq(true)
+        expect(membership.desktop_notification_level).to eq("always")
+        expect(membership.mobile_notification_level).to eq("never")
       end
     end
   end

--- a/test/javascripts/components/chat-channel-settings-view-test.js
+++ b/test/javascripts/components/chat-channel-settings-view-test.js
@@ -58,7 +58,7 @@ module(
       },
     });
 
-    componentTest("saving desktop notifications", {
+    componentTest("saving mobile notifications", {
       template: hbs`{{chat-channel-settings-view channel=channel}}`,
 
       beforeEach() {
@@ -121,8 +121,8 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
-    componentTest("notification settings", {
-      template: hbs`{{chat-channel-settings-view channel=channel chat=chat}}`,
+    componentTest("saving desktop notifications", {
+      template: hbs`{{chat-channel-settings-view channel=channel}}`,
 
       beforeEach() {
         this.set(
@@ -134,13 +134,89 @@ module(
       },
 
       async test(assert) {
-        assert.notOk(
-          exists(".channel-settings-view__desktop-notification-level-selector")
+        pretender.put(
+          `/chat/api/chat_channels/${this.channel.id}/notifications_settings.json`,
+          () => {
+            return [
+              200,
+              { "Content-Type": "application/json" },
+              membershipFixture(this.channel.id),
+            ];
+          }
         );
-        assert.notOk(
-          exists(".channel-settings-view__mobile-notification-level-selector")
+
+        const sk = selectKit(
+          ".channel-settings-view__desktop-notification-level-selector"
         );
-        assert.notOk(exists(".channel-settings-view__muted-selector"));
+        await sk.expand();
+        await sk.selectRowByValue("mention");
+
+        assert.equal(sk.header().value(), "mention");
+      },
+    });
+
+    componentTest("saving mobile notifications", {
+      template: hbs`{{chat-channel-settings-view channel=channel}}`,
+
+      beforeEach() {
+        this.set(
+          "channel",
+          fabricators.chatChannel({
+            chatable_type: CHATABLE_TYPES.directMessageChannel,
+          })
+        );
+      },
+      async test(assert) {
+        pretender.put(
+          `/chat/api/chat_channels/${this.channel.id}/notifications_settings.json`,
+          () => {
+            return [
+              200,
+              { "Content-Type": "application/json" },
+              membershipFixture(this.channel.id),
+            ];
+          }
+        );
+
+        const sk = selectKit(
+          ".channel-settings-view__mobile-notification-level-selector"
+        );
+        await sk.expand();
+        await sk.selectRowByValue("mention");
+
+        assert.equal(sk.header().value(), "mention");
+      },
+    });
+
+    componentTest("muted", {
+      template: hbs`{{chat-channel-settings-view channel=channel}}`,
+
+      beforeEach() {
+        this.set(
+          "channel",
+          fabricators.chatChannel({
+            chatable_type: CHATABLE_TYPES.directMessageChannel,
+          })
+        );
+      },
+
+      async test(assert) {
+        pretender.put(
+          `/chat/api/chat_channels/${this.channel.id}/notifications_settings.json`,
+          () => {
+            return [
+              200,
+              { "Content-Type": "application/json" },
+              membershipFixture(this.channel.id, { muted: true }),
+            ];
+          }
+        );
+
+        const sk = selectKit(".channel-settings-view__muted-selector");
+        await sk.expand();
+        await sk.selectRowByName("Off");
+
+        assert.equal(sk.header().value(), "false");
       },
     });
   }


### PR DESCRIPTION
This commit allows users to change the Mute settings
for DM channels as they can for regular category channels,
as well as changing the desktop and mobile notification
levels for the channel if it is not muted. It also changes
the unread_count logic for DM channels -- since the channels
can now be muted, the unread count does not always show regardless
for DM channels.

<img src="https://user-images.githubusercontent.com/920448/185287214-da0fcb13-e329-40a6-8016-62422a2c674d.png" width="300">
