### PR TITLE
FIX: escape HTML in channel name & description

### DIFF
--- a/app/serializers/chat_channel_serializer.rb
+++ b/app/serializers/chat_channel_serializer.rb
@@ -28,6 +28,10 @@ class ChatChannelSerializer < ApplicationSerializer
     object.description.present?
   end
 
+  def description
+     ERB::Util.html_escape(object.description)
+  end
+
   def memberships_count
     object.user_count
   end
@@ -37,7 +41,7 @@ class ChatChannelSerializer < ApplicationSerializer
   end
 
   def title
-    object.name || object.title(scope.user)
+    ERB::Util.html_escape(object.name || object.title(scope.user))
   end
 
   def chatable

--- a/spec/serializer/chat_channel_serializer_spec.rb
+++ b/spec/serializer/chat_channel_serializer_spec.rb
@@ -10,6 +10,20 @@ describe ChatChannelSerializer do
   let(:guardian) { Guardian.new(guardian_user) }
   subject { described_class.new(chat_channel, scope: guardian, root: nil) }
 
+  describe "title" do
+    it "escapes HTML" do
+      chat_channel.name = "Best <b>channel</b> ever!"
+      expect(subject.as_json[:title]).to eq("Best &lt;b&gt;channel&lt;/b&gt; ever!")
+    end
+  end
+
+  describe "description" do
+    it "escapes HTML" do
+      chat_channel.description = "Best <b>channel</b> ever!"
+      expect(subject.as_json[:description]).to eq("Best &lt;b&gt;channel&lt;/b&gt; ever!")
+    end
+  end
+
   describe "archive status" do
     context "when user is not staff" do
       let(:guardian_user) { user }


### PR DESCRIPTION
Escape HTML when serializing the channel name and description.

We might want to revisit this later on when we'll introduce support for Markdown/HTML in those fields (at least description).