### PR TITLE
DEV: Fix rspec warnings

### DIFF
--- a/spec/lib/chat_message_bookmarkable_spec.rb
+++ b/spec/lib/chat_message_bookmarkable_spec.rb
@@ -164,16 +164,14 @@ describe ChatMessageBookmarkable do
       guardian = Guardian.new(user)
       expect {
         subject.validate_before_create(guardian, bookmark1.bookmarkable)
-      }.not_to raise_error(Discourse::InvalidAccess)
+      }.not_to raise_error
     end
 
     it "raises InvalidAccess if the chat message is deleted" do
       expect { subject.validate_before_create(guardian, bookmark1.bookmarkable) }.not_to raise_error
       bookmark1.bookmarkable.trash!
       bookmark1.reload
-      expect { subject.validate_before_create(guardian, bookmark1.bookmarkable) }.to raise_error(
-        Discourse::InvalidAccess,
-      )
+      expect { subject.validate_before_create(guardian, bookmark1.bookmarkable) }.to raise_error(Discourse::InvalidAccess)
     end
   end
 

--- a/spec/lib/chat_message_reactor_spec.rb
+++ b/spec/lib/chat_message_reactor_spec.rb
@@ -81,7 +81,7 @@ describe DiscourseChat::ChatMessageReactor do
           react_action: :add,
           emoji: ":#{Emoji.all.first.name}:",
         )
-      }.to_not raise_error(Discourse::InvalidAccess)
+      }.to_not raise_error
     end
   end
 


### PR DESCRIPTION
```
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. `NoMethodError`, `NameError` and `ArgumentError`), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`.
```
