### PR TITLE
FEATURE: hides public channels section if unusable

### DIFF
--- a/assets/javascripts/discourse/components/channels-list.js
+++ b/assets/javascripts/discourse/components/channels-list.js
@@ -42,11 +42,14 @@ export default class ChannelsList extends Component {
     "currentUser.{staff,has_joinable_public_channels}"
   )
   get displayPublicChannels() {
-    return (
-      !this.publicChannelsEmpty ||
-      this.currentUser?.staff ||
-      this.currentUser?.has_joinable_public_channels
-    );
+    if (this.publicChannelsEmpty) {
+      return (
+        this.currentUser?.staff ||
+        this.currentUser?.has_joinable_public_channels
+      );
+    }
+
+    return true;
   }
 
   @computed("inSidebar")

--- a/assets/javascripts/discourse/components/channels-list.js
+++ b/assets/javascripts/discourse/components/channels-list.js
@@ -37,6 +37,18 @@ export default class ChannelsList extends Component {
     }`;
   }
 
+  @computed(
+    "publicChannelsEmpty",
+    "currentUser.{staff,has_joinable_public_channels}"
+  )
+  get displayPublicChannels() {
+    return (
+      !this.publicChannelsEmpty ||
+      this.currentUser?.staff ||
+      this.currentUser?.has_joinable_public_channels
+    );
+  }
+
   @computed("inSidebar")
   get directMessageChannelClasses() {
     return `channels-list-container direct-message-channels ${

--- a/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/assets/javascripts/discourse/initializers/chat-setup.js
@@ -79,7 +79,10 @@ export default {
 
       document.body.classList.add("chat-enabled");
 
-      this.chatService.getChannels();
+      const currentUser = api.getCurrentUser();
+      if (currentUser?.chat_channels) {
+        this.chatService.setupWithCurrentUser(currentUser);
+      }
 
       const chatNotificationManager = container.lookup(
         "service:chat-notification-manager"

--- a/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/assets/javascripts/discourse/initializers/chat-setup.js
@@ -81,7 +81,9 @@ export default {
 
       const currentUser = api.getCurrentUser();
       if (currentUser?.chat_channels) {
-        this.chatService.setupWithCurrentUser(currentUser);
+        this.chatService.setupWithPreloadedChannels(currentUser.chat_channels);
+      } else {
+        this.chatService.getChannels();
       }
 
       const chatNotificationManager = container.lookup(

--- a/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -22,189 +22,197 @@ export default {
     }
 
     withPluginApi("1.3.0", (api) => {
-      api.addSidebarSection(
-        (BaseCustomSidebarSection, BaseCustomSidebarSectionLink) => {
-          const SidebarChatChannelsSectionLink = class extends BaseCustomSidebarSectionLink {
-            @tracked chatChannelTrackingState =
-              this.chatService.currentUser.chat_channel_tracking_state[
-                this.channel.id
-              ];
+      const currentUser = api.getCurrentUser();
+      const hasPublicChannels =
+        currentUser?.chat_channels?.public_channels?.length;
+      const shouldDisplayPublicChannelsSection = hasPublicChannels
+        ? true
+        : currentUser?.staff || currentUser?.has_joinable_public_channels;
 
-            constructor({ channel, chatService }) {
-              super(...arguments);
-              this.channel = channel;
-              this.chatService = chatService;
-
-              this.chatService.appEvents.on(
-                "chat:user-tracking-state-changed",
-                this._refreshTrackingState
-              );
-            }
-
-            @bind
-            willDestroy() {
-              this.chatService.appEvents.off(
-                "chat:user-tracking-state-changed",
-                this._refreshTrackingState
-              );
-            }
-
-            @bind
-            _refreshTrackingState() {
-              this.chatChannelTrackingState =
+      shouldDisplayPublicChannelsSection &&
+        api.addSidebarSection(
+          (BaseCustomSidebarSection, BaseCustomSidebarSectionLink) => {
+            const SidebarChatChannelsSectionLink = class extends BaseCustomSidebarSectionLink {
+              @tracked chatChannelTrackingState =
                 this.chatService.currentUser.chat_channel_tracking_state[
                   this.channel.id
                 ];
-            }
 
-            get name() {
-              return dasherize(slugifyChannel(this.channel.title));
-            }
+              constructor({ channel, chatService }) {
+                super(...arguments);
+                this.channel = channel;
+                this.chatService = chatService;
 
-            get route() {
-              return "chat.channel";
-            }
-
-            get models() {
-              return [this.channel.id, slugifyChannel(this.channel.title)];
-            }
-
-            get title() {
-              return this.channel.title;
-            }
-
-            get text() {
-              return htmlSafe(emojiUnescape(this.channel.title));
-            }
-
-            get prefixType() {
-              return "icon";
-            }
-
-            get prefixValue() {
-              return "hashtag";
-            }
-
-            get prefixColor() {
-              return this.channel.chatable.color;
-            }
-
-            get prefixBadge() {
-              return this.channel.chatable.read_restricted ? "lock" : "";
-            }
-
-            get suffixType() {
-              return "icon";
-            }
-
-            get suffixValue() {
-              return this.chatChannelTrackingState?.unread_count > 0
-                ? "circle"
-                : "";
-            }
-
-            get suffixCSSClass() {
-              return this.chatChannelTrackingState?.unread_mentions > 0
-                ? "urgent"
-                : "unread";
-            }
-          };
-
-          const SidebarChatChannelsSection = class extends BaseCustomSidebarSection {
-            @tracked sectionLinks = [];
-
-            @tracked sectionIndicator =
-              this.chatService.publicChannels &&
-              this.chatService.publicChannels[0].current_user_membership
-                .unread_count;
-
-            constructor() {
-              super(...arguments);
-
-              if (container.isDestroyed) {
-                return;
+                this.chatService.appEvents.on(
+                  "chat:user-tracking-state-changed",
+                  this._refreshTrackingState
+                );
               }
-              this.chatService = container.lookup("service:chat");
-              this.chatService.appEvents.on(
-                "chat:refresh-channels",
-                this._refreshChannels
-              );
-              this._refreshChannels();
-            }
 
-            @bind
-            willDestroy() {
-              if (!this.chatService) {
-                return;
+              @bind
+              willDestroy() {
+                this.chatService.appEvents.off(
+                  "chat:user-tracking-state-changed",
+                  this._refreshTrackingState
+                );
               }
-              this.chatService.appEvents.off(
-                "chat:refresh-channels",
-                this._refreshChannels
-              );
-            }
 
-            @bind
-            _refreshChannels() {
-              const newSectionLinks = [];
-              this.chatService.getChannels().then((channels) => {
-                channels.publicChannels.forEach((channel) => {
-                  newSectionLinks.push(
-                    new SidebarChatChannelsSectionLink({
-                      channel,
-                      chatService: this.chatService,
-                    })
-                  );
-                });
-                this.sectionLinks = newSectionLinks;
-              });
-            }
+              @bind
+              _refreshTrackingState() {
+                this.chatChannelTrackingState =
+                  this.chatService.currentUser.chat_channel_tracking_state[
+                    this.channel.id
+                  ];
+              }
 
-            get name() {
-              return "chat-channels";
-            }
+              get name() {
+                return dasherize(slugifyChannel(this.channel.title));
+              }
 
-            get title() {
-              return I18n.t("chat.chat_channels");
-            }
+              get route() {
+                return "chat.channel";
+              }
 
-            get text() {
-              return I18n.t("chat.chat_channels");
-            }
+              get models() {
+                return [this.channel.id, slugifyChannel(this.channel.title)];
+              }
 
-            get actions() {
-              const actions = [
-                {
-                  id: "browseChannels",
-                  title: I18n.t("chat.channels_list_popup.browse"),
-                  action: () => {
-                    this.chatService.router.transitionTo("chat.browse");
-                  },
-                },
-              ];
-              if (this.sidebar.currentUser.staff) {
-                actions.push({
-                  id: "openCreateChannelModal",
-                  title: I18n.t("chat.channels_list_popup.create"),
-                  action: () => {
-                    showModal("create-channel");
-                  },
+              get title() {
+                return this.channel.title;
+              }
+
+              get text() {
+                return htmlSafe(emojiUnescape(this.channel.title));
+              }
+
+              get prefixType() {
+                return "icon";
+              }
+
+              get prefixValue() {
+                return "hashtag";
+              }
+
+              get prefixColor() {
+                return this.channel.chatable.color;
+              }
+
+              get prefixBadge() {
+                return this.channel.chatable.read_restricted ? "lock" : "";
+              }
+
+              get suffixType() {
+                return "icon";
+              }
+
+              get suffixValue() {
+                return this.chatChannelTrackingState?.unread_count > 0
+                  ? "circle"
+                  : "";
+              }
+
+              get suffixCSSClass() {
+                return this.chatChannelTrackingState?.unread_mentions > 0
+                  ? "urgent"
+                  : "unread";
+              }
+            };
+
+            const SidebarChatChannelsSection = class extends BaseCustomSidebarSection {
+              @tracked sectionLinks = [];
+
+              @tracked sectionIndicator =
+                this.chatService.publicChannels &&
+                this.chatService.publicChannels[0].current_user_membership
+                  .unread_count;
+
+              constructor() {
+                super(...arguments);
+
+                if (container.isDestroyed) {
+                  return;
+                }
+                this.chatService = container.lookup("service:chat");
+                this.chatService.appEvents.on(
+                  "chat:refresh-channels",
+                  this._refreshChannels
+                );
+                this._refreshChannels();
+              }
+
+              @bind
+              willDestroy() {
+                if (!this.chatService) {
+                  return;
+                }
+                this.chatService.appEvents.off(
+                  "chat:refresh-channels",
+                  this._refreshChannels
+                );
+              }
+
+              @bind
+              _refreshChannels() {
+                const newSectionLinks = [];
+                this.chatService.getChannels().then((channels) => {
+                  channels.publicChannels.forEach((channel) => {
+                    newSectionLinks.push(
+                      new SidebarChatChannelsSectionLink({
+                        channel,
+                        chatService: this.chatService,
+                      })
+                    );
+                  });
+                  this.sectionLinks = newSectionLinks;
                 });
               }
-              return actions;
-            }
 
-            get actionsIcon() {
-              return "cog";
-            }
+              get name() {
+                return "chat-channels";
+              }
 
-            get links() {
-              return this.sectionLinks;
-            }
-          };
+              get title() {
+                return I18n.t("chat.chat_channels");
+              }
 
-          return SidebarChatChannelsSection;
-        }
-      );
+              get text() {
+                return I18n.t("chat.chat_channels");
+              }
+
+              get actions() {
+                const actions = [
+                  {
+                    id: "browseChannels",
+                    title: I18n.t("chat.channels_list_popup.browse"),
+                    action: () => {
+                      this.chatService.router.transitionTo("chat.browse");
+                    },
+                  },
+                ];
+                if (this.sidebar.currentUser.staff) {
+                  actions.push({
+                    id: "openCreateChannelModal",
+                    title: I18n.t("chat.channels_list_popup.create"),
+                    action: () => {
+                      showModal("create-channel");
+                    },
+                  });
+                }
+                return actions;
+              }
+
+              get actionsIcon() {
+                return "cog";
+              }
+
+              get links() {
+                return this.sectionLinks;
+              }
+            };
+
+            return SidebarChatChannelsSection;
+          }
+        );
 
       api.addSidebarSection(
         (BaseCustomSidebarSection, BaseCustomSidebarSectionLink) => {

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -75,9 +75,9 @@ export default class Chat extends Service {
     }
   }
 
-  setupWithCurrentUser(user) {
+  setupWithPreloadedChannels(channels) {
     this.currentUser.set("chat_channel_tracking_state", {});
-    this._processChannels(user.chat_channels || {});
+    this._processChannels(channels || {});
     this.userChatChannelTrackingStateChanged();
     this.appEvents.trigger("chat:refresh-channels");
   }

--- a/assets/javascripts/discourse/templates/components/channels-list.hbs
+++ b/assets/javascripts/discourse/templates/components/channels-list.hbs
@@ -4,38 +4,38 @@
   class="channels-list"
   {{on "scroll" (action "storeScrollPosition")}}
 >
-  <div class="chat-channel-divider">
-    {{#if inSidebar}}
-      <span
-        class="title-caret"
-        id="public-channels-caret"
-        role="button"
-        title="toggle nav list"
-        {{action "toggleChannelSection" "public-channels"}}
-        data-toggleable="public-channels"
-      >
-        {{d-icon "angle-up"}}
-      </span>
-    {{/if}}
-    <span class="channel-title">{{i18n "chat.chat_channels"}}</span>
-
-    {{#if currentUser.staff}}
-      {{dropdown-select-box
-        options=(hash icon="cog" placementStrategy="absolute")
-        content=channelsActions
-        onChange=(action "handleChannelAction")
-        class="edit-channels-dropdown"
-      }}
-    {{else}}
-      {{d-button
-        action=(action "browseChannels")
-        icon="pencil-alt"
-        class="btn-flat edit-channel-membership-btn title-action"
-      }}
-    {{/if}}
-  </div>
-
   {{#if displayPublicChannels}}
+    <div class="chat-channel-divider public-channels-section">
+      {{#if inSidebar}}
+        <span
+          class="title-caret"
+          id="public-channels-caret"
+          role="button"
+          title="toggle nav list"
+          {{action "toggleChannelSection" "public-channels"}}
+          data-toggleable="public-channels"
+        >
+          {{d-icon "angle-up"}}
+        </span>
+      {{/if}}
+      <span class="channel-title">{{i18n "chat.chat_channels"}}</span>
+
+      {{#if currentUser.staff}}
+        {{dropdown-select-box
+          options=(hash icon="cog" placementStrategy="absolute")
+          content=channelsActions
+          onChange=(action "handleChannelAction")
+          class="edit-channels-dropdown"
+        }}
+      {{else}}
+        {{d-button
+          action=(action "browseChannels")
+          icon="pencil-alt"
+          class="btn-flat edit-channel-membership-btn title-action"
+        }}
+      {{/if}}
+    </div>
+
     <div id="public-channels" class={{publicChannelClasses}}>
       {{#if publicChannelsEmpty}}
         <div class="public-channel-empty-message">
@@ -62,7 +62,7 @@
     args=(hash inSidebar=inSidebar)
   }}
 
-  <div class="chat-channel-divider">
+  <div class="chat-channel-divider direct-message-channels-section">
     {{#if inSidebar}}
       <span
         class="title-caret"

--- a/assets/javascripts/discourse/templates/components/channels-list.hbs
+++ b/assets/javascripts/discourse/templates/components/channels-list.hbs
@@ -35,24 +35,26 @@
     {{/if}}
   </div>
 
-  <div id="public-channels" class={{publicChannelClasses}}>
-    {{#if publicChannelsEmpty}}
-      <div class="public-channel-empty-message">
-        <span class="channel-title">{{i18n "chat.no_public_channels"}}</span>
-        {{#link-to "chat.browse"}}
-          {{i18n "chat.click_to_join"}}
-        {{/link-to}}
-      </div>
-    {{else}}
-      {{#each publicChannels as |channel|}}
-        {{chat-channel-row
-          channel=channel
-          switchChannel=onSelect
-          options=(hash settingsButton=true)
-        }}
-      {{/each}}
-    {{/if}}
-  </div>
+  {{#if displayPublicChannels}}
+    <div id="public-channels" class={{publicChannelClasses}}>
+      {{#if publicChannelsEmpty}}
+        <div class="public-channel-empty-message">
+          <span class="channel-title">{{i18n "chat.no_public_channels"}}</span>
+          {{#link-to "chat.browse"}}
+            {{i18n "chat.click_to_join"}}
+          {{/link-to}}
+        </div>
+      {{else}}
+        {{#each publicChannels as |channel|}}
+          {{chat-channel-row
+            channel=channel
+            switchChannel=onSelect
+            options=(hash settingsButton=true)
+          }}
+        {{/each}}
+      {{/if}}
+    </div>
+  {{/if}}
 
   {{plugin-outlet
     name="below-public-chat-channels"

--- a/plugin.rb
+++ b/plugin.rb
@@ -406,6 +406,11 @@ after_initialize do
     ).present?
   end
 
+  add_to_serializer(:current_user, :chat_channels) do
+    structured = DiscourseChat::ChatChannelFetcher.structured(self.scope)
+    ChatChannelIndexSerializer.new(structured, scope: self.scope, root: false).as_json
+  end
+
   add_to_serializer(:current_user, :include_needs_channel_retention_reminder?) do
     include_has_chat_enabled? && object.staff? &&
       !object.user_option.dismissed_channel_retention_reminder &&

--- a/plugin.rb
+++ b/plugin.rb
@@ -395,6 +395,17 @@ after_initialize do
 
   add_to_serializer(:current_user, :needs_dm_retention_reminder) { true }
 
+  add_to_serializer(:current_user, :has_joinable_public_channels) do
+    memberships = UserChatChannelMembership.where(user_id: self.scope.user.id)
+    DiscourseChat::ChatChannelFetcher.secured_public_channels(
+      self.scope,
+      memberships,
+      following: false,
+      limit: 1,
+      status: :open,
+    ).present?
+  end
+
   add_to_serializer(:current_user, :include_needs_channel_retention_reminder?) do
     include_has_chat_enabled? && object.staff? &&
       !object.user_option.dismissed_channel_retention_reminder &&

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -392,7 +392,7 @@ describe "discourse-chat" do
     end
 
     fab!(:user) { Fabricate(:user) }
-    let(:serializer) { CurrentUserSerializer.new(user, scope: Guardian.new(user)).as_json }
+    let(:serializer) { CurrentUserSerializer.new(user, scope: Guardian.new(user)) }
 
     context "when no channels exist" do
       it "returns false" do

--- a/test/javascripts/acceptance/chat-channels-list-test.js
+++ b/test/javascripts/acceptance/chat-channels-list-test.js
@@ -1,0 +1,55 @@
+import {
+  acceptance,
+  exists,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import { visit } from "@ember/test-helpers";
+import fabricators from "../helpers/fabricators";
+import { directMessageChannels } from "discourse/plugins/discourse-chat/chat-fixtures";
+import { cloneJSON } from "discourse-common/lib/object";
+
+acceptance(
+  "Discourse Chat - Chat Channels list - no joinable public channels",
+  function (needs) {
+    needs.user({ has_chat_enabled: true, has_joinable_public_channels: false });
+
+    needs.settings({
+      chat_enabled: true,
+    });
+
+    needs.pretender((server, helper) => {
+      server.get("/chat/chat_channels.json", () => {
+        return helper.response({
+          public_channels: [],
+          direct_message_channels: cloneJSON(directMessageChannels).mapBy(
+            "chat_channel"
+          ),
+        });
+      });
+
+      server.get("/chat/:id/messages.json", () => {
+        return helper.response({
+          chat_messages: [],
+          meta: { can_chat: true },
+        });
+      });
+    });
+
+    test("Public chat channels section visibility", async function (assert) {
+      await visit("/chat");
+
+      assert.ok(
+        exists(".public-channels-section"),
+        "it shows the section for staff"
+      );
+
+      updateCurrentUser({ admin: false, moderator: false });
+
+      assert.notOk(
+        exists(".public-channels-section"),
+        "it doesn’t show the section for regular user"
+      );
+    });
+  }
+);

--- a/test/javascripts/acceptance/chat-channels-list-test.js
+++ b/test/javascripts/acceptance/chat-channels-list-test.js
@@ -5,7 +5,6 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
-import fabricators from "../helpers/fabricators";
 import { directMessageChannels } from "discourse/plugins/discourse-chat/chat-fixtures";
 import { cloneJSON } from "discourse-common/lib/object";
 

--- a/test/javascripts/acceptance/core-sidebar-test.js
+++ b/test/javascripts/acceptance/core-sidebar-test.js
@@ -3,6 +3,7 @@ import {
   exists,
   query,
   queryAll,
+  updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 import {
@@ -431,3 +432,69 @@ acceptance("Discourse Chat - Plugin Sidebar", function (needs) {
     assert.ok(exists(".full-page-chat .channels-list"));
   });
 });
+
+acceptance(
+  "Discourse Chat - Core Sidebar - no joinable public channels, staff",
+  function (needs) {
+    needs.user({ has_chat_enabled: true, has_joinable_public_channels: false });
+
+    needs.settings({
+      chat_enabled: true,
+      enable_experimental_sidebar_hamburger: true,
+      enable_sidebar: true,
+    });
+
+    needs.pretender((server, helper) => {
+      server.get("/chat/chat_channels.json", () => {
+        return helper.response({
+          public_channels: [],
+          direct_message_channels: [],
+        });
+      });
+    });
+
+    test("Chat channels section visibility", async function (assert) {
+      await visit("/");
+
+      assert.ok(
+        exists(".sidebar-section-chat-channels"),
+        "it shows the section for staff"
+      );
+    });
+  }
+);
+acceptance(
+  "Discourse Chat - Core Sidebar - no joinable public channels, regular user",
+  function (needs) {
+    needs.user({
+      has_chat_enabled: true,
+      has_joinable_public_channels: false,
+      moderator: false,
+      admin: false,
+    });
+
+    needs.settings({
+      chat_enabled: true,
+      enable_experimental_sidebar_hamburger: true,
+      enable_sidebar: true,
+    });
+
+    needs.pretender((server, helper) => {
+      server.get("/chat/chat_channels.json", () => {
+        return helper.response({
+          public_channels: [],
+          direct_message_channels: [],
+        });
+      });
+    });
+
+    test("Chat channels section visibility", async function (assert) {
+      await visit("/");
+
+      assert.notOk(
+        exists(".sidebar-section-chat-channels"),
+        "it doesn’t show the section for regular user"
+      );
+    });
+  }
+);

--- a/test/javascripts/acceptance/core-sidebar-test.js
+++ b/test/javascripts/acceptance/core-sidebar-test.js
@@ -3,7 +3,6 @@ import {
   exists,
   query,
   queryAll,
-  updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 import {


### PR DESCRIPTION
Unusable is defined by the following conditions:
- user is not staff
- user doesn’t have any possible public channel

Note this commit is also implementing preload of current user chat channels, preventing a /chat/channels ajax call on each first page load. This was on the roadmap and was needed in this commit to allow for clean initial state.