### PR TITLE
UX: Hide chat image overflow

### DIFF
--- a/assets/stylesheets/common/chat-message-images.scss
+++ b/assets/stylesheets/common/chat-message-images.scss
@@ -13,6 +13,7 @@ $max_image_height: 150px;
     max-height: $max_image_height;
     max-width: 100%;
     width: unset;
+    overflow: hidden;
   }
 
   .chat-message-collapser


### PR DESCRIPTION
When there was a problem with an image the built-in frame would expand way outside the message.

Before/After
<img width="86" alt="Screenshot 2022-08-19 at 09 31 35" src="https://user-images.githubusercontent.com/66961/185638137-cc8b3ae2-2ed6-4bbd-a713-af2356025d69.png"> <img width="86" alt="Screenshot 2022-08-19 at 09 31 41" src="https://user-images.githubusercontent.com/66961/185638171-0b649538-fbc4-467a-9807-235172666111.png">

If anyone has a better solution, please come forward 😄

(originally incorrectly submitted in https://github.com/discourse/discourse/pull/18000 oops 😅)

<!-- Checklist for UI / stylesheet changes, delete if not applicable -->

- [ ] chat-scoped -- core unaffected

### View mode

- [ ] docked (windowed/drawer)

### Browsers

- [ ] safari
- [ ] chrome
- [ ] firefox

### Device

- [ ] desktop – wide screen
- [ ] mobile – `?mobile_view=1`
