### PR TITLE
FIX: deletes trashed messages when hitting retention limit

### DIFF
--- a/app/jobs/scheduled/delete_old_chat_messages.rb
+++ b/app/jobs/scheduled/delete_old_chat_messages.rb
@@ -14,6 +14,7 @@ module Jobs
 
       ChatMessage
         .in_public_channel
+        .with_deleted
         .created_before(SiteSetting.chat_channel_retention_days.days.ago)
         .in_batches(of: 200)
         .each do |relation|
@@ -27,6 +28,7 @@ module Jobs
 
       ChatMessage
         .in_dm_channel
+        .with_deleted
         .created_before(SiteSetting.chat_dm_retention_days.days.ago)
         .in_batches(of: 200)
         .each do |relation|

--- a/spec/jobs/delete_old_chat_messages_spec.rb
+++ b/spec/jobs/delete_old_chat_messages_spec.rb
@@ -33,6 +33,14 @@ describe Jobs::DeleteOldChatMessages do
       created_at: base_date - 30.days - 1.second,
     )
   end
+  fab!(:public_trashed_days_old_30) do
+    Fabricate(
+      :chat_message,
+      chat_channel: public_channel,
+      message: "hi",
+      created_at: base_date - 30.days - 1.second,
+    )
+  end
 
   fab!(:dm_channel) do
     Fabricate(
@@ -67,6 +75,14 @@ describe Jobs::DeleteOldChatMessages do
       created_at: base_date - 30.days - 1.second,
     )
   end
+  fab!(:dm_trashed_days_old_30) do
+    Fabricate(
+      :chat_message,
+      chat_channel: dm_channel,
+      message: "hi",
+      created_at: base_date - 30.days - 1.second,
+    )
+  end
 
   before { freeze_time(base_date) }
 
@@ -83,8 +99,15 @@ describe Jobs::DeleteOldChatMessages do
       described_class.new.execute
       expect(public_days_old_0.deleted_at).to be_nil
       expect(public_days_old_10.deleted_at).to be_nil
-      expect { public_days_old_20 }.to raise_exception(ActiveRecord::RecordNotFound)
-      expect { public_days_old_30 }.to raise_exception(ActiveRecord::RecordNotFound)
+      expect { public_days_old_20.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      expect { public_days_old_30.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+    end
+
+    it "deletes trashed messages correctly" do
+      SiteSetting.chat_channel_retention_days = 20
+      public_trashed_days_old_30.trash!
+      described_class.new.execute
+      expect { public_trashed_days_old_30.reload }.to raise_exception(ActiveRecord::RecordNotFound)
     end
 
     it "does nothing when no messages fall in the time range" do
@@ -115,8 +138,15 @@ describe Jobs::DeleteOldChatMessages do
       described_class.new.execute
       expect(dm_days_old_0.deleted_at).to be_nil
       expect(dm_days_old_10.deleted_at).to be_nil
-      expect { dm_days_old_20 }.to raise_exception(ActiveRecord::RecordNotFound)
-      expect { dm_days_old_30 }.to raise_exception(ActiveRecord::RecordNotFound)
+      expect { dm_days_old_20.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      expect { dm_days_old_30.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+    end
+
+    it "deletes trashed messages correctly" do
+      SiteSetting.chat_dm_retention_days = 20
+      dm_trashed_days_old_30.trash!
+      described_class.new.execute
+      expect { dm_trashed_days_old_30.reload }.to raise_exception(ActiveRecord::RecordNotFound)
     end
 
     it "does nothing when no messages fall in the time range" do

--- a/spec/jobs/delete_old_chat_messages_spec.rb
+++ b/spec/jobs/delete_old_chat_messages_spec.rb
@@ -99,8 +99,8 @@ describe Jobs::DeleteOldChatMessages do
       described_class.new.execute
       expect(public_days_old_0.deleted_at).to be_nil
       expect(public_days_old_10.deleted_at).to be_nil
-      expect { public_days_old_20.reload }.to raise_exception(ActiveRecord::RecordNotFound)
-      expect { public_days_old_30.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      expect { public_days_old_20 }.to raise_exception(ActiveRecord::RecordNotFound)
+      expect { public_days_old_30 }.to raise_exception(ActiveRecord::RecordNotFound)
     end
 
     it "deletes trashed messages correctly" do
@@ -138,8 +138,8 @@ describe Jobs::DeleteOldChatMessages do
       described_class.new.execute
       expect(dm_days_old_0.deleted_at).to be_nil
       expect(dm_days_old_10.deleted_at).to be_nil
-      expect { dm_days_old_20.reload }.to raise_exception(ActiveRecord::RecordNotFound)
-      expect { dm_days_old_30.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      expect { dm_days_old_20 }.to raise_exception(ActiveRecord::RecordNotFound)
+      expect { dm_days_old_30 }.to raise_exception(ActiveRecord::RecordNotFound)
     end
 
     it "deletes trashed messages correctly" do


### PR DESCRIPTION
Prior to this fix, we would keep trashed messages in the DB forever.
