### PR TITLE
FIX: Arrow Up should edit last non staged message

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -188,7 +188,7 @@ export default Component.extend(TextareaTextManipulation, {
     }
 
     if (
-      event.code === "ArrowUp" &&
+      event.key === "ArrowUp" &&
       this._messageIsEmpty() &&
       !this.editingMessage
     ) {

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1161,7 +1161,11 @@ export default Component.extend({
       messageIndex--
     ) {
       let message = this.messages[messageIndex];
-      if (message.user.id === this.currentUser.id && !message.error) {
+      if (
+        !message.staged &&
+        message.user.id === this.currentUser.id &&
+        !message.error
+      ) {
         lastUserMessage = message;
         break;
       }

--- a/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
+++ b/test/javascripts/acceptance/chat-keyboard-shortcuts-test.js
@@ -38,6 +38,12 @@ acceptance("Discourse Chat - Keyboard shortcuts", function (needs) {
   });
 
   needs.pretender((server, helper) => {
+    // allows to create a staged message
+    server.post("/chat/:id.json", () =>
+      helper.response({
+        errors: [""],
+      })
+    );
     server.get("/chat/chat_channels.json", () => helper.response(chatChannels));
     server.get("/chat/:chatChannelId/messages.json", () =>
       helper.response(generateChatView(loggedInUser()))
@@ -217,6 +223,22 @@ acceptance("Discourse Chat - Keyboard shortcuts", function (needs) {
       composerInput.value,
       "`test text`",
       "selection should get the code markdown"
+    );
+  });
+
+  test("editing last non staged message", async function (assert) {
+    const stagedMessageText = "This is a test";
+    await visit("/latest");
+
+    this.chatService.set("sidebarActive", false);
+    await click(".header-dropdown-toggle.open-chat");
+    await fillIn(".chat-composer-input", stagedMessageText);
+    await click(".chat-composer-inline-button");
+    await triggerKeyEvent(".chat-composer-input", "keydown", "ArrowUp");
+
+    assert.notEqual(
+      query(".chat-composer-input").value.trim(),
+      stagedMessageText
     );
   });
 


### PR DESCRIPTION
We can't edit staged messages as they haven't been  propagated on the server yet.
