### PR TITLE
FIX: ensures dms are sorted on new-channel event

### DIFF
--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -318,8 +318,6 @@ export default class Chat extends Service {
           )
         )
       ),
-      // We don't need to sort direct message channels, as the channel list
-      // uses a computed property to keep them ordered by `last_message_sent_at`.
       directMessageChannels: A(
         this.sortDirectMessageChannels(
           (channels.direct_message_channels || []).map((channel) =>
@@ -544,7 +542,10 @@ export default class Chat extends Service {
         chatable_type: channel.chatable_type,
       });
     this.userChatChannelTrackingStateChanged();
-    if (!channel.isDirectMessageChannel) {
+    if (channel.isDirectMessageChannel) {
+      this.reSortDirectMessageChannels();
+    }
+    if (channel.isPublicChannel) {
       this.set("publicChannels", this.sortPublicChannels(this.publicChannels));
     }
     this.appEvents.trigger("chat:refresh-channels");

--- a/test/javascripts/unit/services/chat-test.js
+++ b/test/javascripts/unit/services/chat-test.js
@@ -6,6 +6,9 @@ import {
 import { settled } from "@ember/test-helpers";
 import { test } from "qunit";
 import fabricators from "../../helpers/fabricators";
+import { directMessageChannels } from "discourse/plugins/discourse-chat/chat-fixtures";
+import { cloneJSON } from "discourse-common/lib/object";
+import ChatChannel from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
 
 acceptance("Discourse Chat | Unit | Service | chat", function (needs) {
   needs.hooks.beforeEach(function () {
@@ -49,6 +52,24 @@ acceptance("Discourse Chat | Unit | Service | chat", function (needs) {
       })
     );
   }
+
+  test("#startTrackingChannel - sorts dm channels", async function (assert) {
+    setupMockPresenceChannel(this.chatService);
+    const fixtures = cloneJSON(directMessageChannels).mapBy("chat_channel");
+    const channel1 = ChatChannel.create(fixtures[0]);
+    const channel2 = ChatChannel.create(fixtures[1]);
+    await this.chatService.startTrackingChannel(channel1);
+    this.currentUser.set(
+      `chat_channel_tracking_state.${channel1.id}.unread_count`,
+      0
+    );
+    await this.chatService.startTrackingChannel(channel2);
+
+    assert.strictEqual(
+      this.chatService.directMessageChannels.firstObject.title,
+      channel2.title
+    );
+  });
 
   test("#refreshTrackingState", async function (assert) {
     this.currentUser.set("chat_channel_tracking_state", {});


### PR DESCRIPTION
Prior to this fix a new dm would not force a resort of the list to push channels with highest unread_count at the top.
