### PR TITLE
FIX: /chat/chat_channels/:id is only for json

### DIFF
--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -75,7 +75,7 @@ class ChatChannel < ActiveRecord::Base
   end
 
   def url
-    "#{Discourse.base_url}/chat/chat_channels/#{self.id}"
+    "#{Discourse.base_url}/chat/channel/#{self.id}/-"
   end
 
   def chatable_url

--- a/assets/javascripts/lib/discourse-markdown/discourse-chat-transcript.js
+++ b/assets/javascripts/lib/discourse-markdown/discourse-chat-transcript.js
@@ -21,7 +21,7 @@ const chatTranscriptRule = {
     const channelName = tagInfo.attrs.channel;
     const channelId = tagInfo.attrs.channelId;
     const channelLink = channelId
-      ? options.getURL(`/chat/chat_channels/${channelId}`)
+      ? options.getURL(`/chat/channel/${channelId}/-`)
       : null;
 
     if (!username || !messageIdStart || !messageTimeStart) {

--- a/spec/integration/post_chat_quote_spec.rb
+++ b/spec/integration/post_chat_quote_spec.rb
@@ -34,7 +34,7 @@ describe "chat bbcode quoting in posts" do
     expect(post.cooked.chomp).to eq(<<~COOKED.chomp)
       <div class="discourse-chat-transcript" data-message-id="2321" data-username="martin" data-datetime="2022-01-25T05:40:39Z" data-channel-name="Cool Cats Club" data-channel-id="1234">
       <div class="chat-transcript-meta">
-      Originally sent in <a href="/chat/chat_channels/1234">Cool Cats Club</a>
+      Originally sent in <a href="/chat/channel/1234/-">Cool Cats Club</a>
       </div>
       <div class="chat-transcript-user">
       <div class="chat-transcript-user-avatar"></div>
@@ -65,7 +65,7 @@ describe "chat bbcode quoting in posts" do
       <div class="chat-transcript-datetime">
       <a href="/chat/message/2321" title="2022-01-25T05:40:39Z"></a>
       </div>
-      <a class="chat-transcript-channel" href="/chat/chat_channels/1234">
+      <a class="chat-transcript-channel" href="/chat/channel/1234/-">
       #Cool Cats Club</a>
       </div>
       <div class="chat-transcript-messages">
@@ -89,7 +89,7 @@ describe "chat bbcode quoting in posts" do
       <div class="chat-transcript-datetime">
       <a href="/chat/message/2321" title="2022-01-25T05:40:39Z"></a>
       </div>
-      <a class="chat-transcript-channel" href="/chat/chat_channels/1234">
+      <a class="chat-transcript-channel" href="/chat/channel/1234/-">
       #Cool Cats Club</a>
       </div>
       <div class="chat-transcript-messages">
@@ -107,7 +107,7 @@ describe "chat bbcode quoting in posts" do
     expect(post.cooked.chomp).to eq(<<~COOKED.chomp)
       <div class="discourse-chat-transcript" data-message-id="2321" data-username="martin" data-datetime="2022-01-25T05:40:39Z" data-channel-name="Cool Cats Club" data-channel-id="1234">
       <div class="chat-transcript-meta">
-      Originally sent in <a href="/chat/chat_channels/1234">Cool Cats Club</a>
+      Originally sent in <a href="/chat/channel/1234/-">Cool Cats Club</a>
       </div>
       <div class="chat-transcript-user">
       <div class="chat-transcript-user-avatar"></div>
@@ -139,7 +139,7 @@ describe "chat bbcode quoting in posts" do
       <div class="chat-transcript-datetime">
       <a href="/chat/message/2321" title="2022-01-25T05:40:39Z"></a>
       </div>
-      <a class="chat-transcript-channel" href="/chat/chat_channels/1234">
+      <a class="chat-transcript-channel" href="/chat/channel/1234/-">
       #Cool Cats Club</a>
       </div>
       <div class="chat-transcript-messages">

--- a/spec/models/chat_message_spec.rb
+++ b/spec/models/chat_message_spec.rb
@@ -128,7 +128,7 @@ describe ChatMessage do
       expect(cooked).to eq(<<~COOKED.chomp)
         <div class="discourse-chat-transcript chat-transcript-chained" data-message-id="#{msg1.id}" data-username="chatbbcodeuser" data-datetime="#{msg1.created_at.iso8601}" data-channel-name="testchannel" data-channel-id="#{chat_channel.id}">
         <div class="chat-transcript-meta">
-        Originally sent in <a href="/chat/chat_channels/#{chat_channel.id}">testchannel</a>
+        Originally sent in <a href="/chat/channel/#{chat_channel.id}/-">testchannel</a>
         </div>
         <div class="chat-transcript-user">
         <div class="chat-transcript-user-avatar">

--- a/test/javascripts/acceptance/chat-transcript-test.js
+++ b/test/javascripts/acceptance/chat-transcript-test.js
@@ -69,7 +69,7 @@ function generateTranscriptHTML(messageContent, opts) {
   if (opts.channel && opts.multiQuote) {
     let originallySent = I18n.t("chat.quote.original_channel", {
       channel: opts.channel,
-      channelLink: `/chat/chat_channels/${opts.channelId}`,
+      channelLink: `/chat/channel/${opts.channelId}/-`,
     });
     if (opts.linkTabIndex) {
       originallySent = originallySent.replace(">", tabIndexHTML + ">");
@@ -96,7 +96,7 @@ ${innerDatetimeEl}</div>`);
 
   if (opts.channel && !opts.multiQuote) {
     transcript.push(
-      `<a class=\"chat-transcript-channel\" href="/chat/chat_channels/${opts.channelId}"${tabIndexHTML}>
+      `<a class=\"chat-transcript-channel\" href="/chat/channel/${opts.channelId}/-"${tabIndexHTML}>
 #${opts.channel}</a></div>`
     );
   } else {


### PR DESCRIPTION
For human facing cases uses the direct link URL: "/chat/channel/:id/:slug"
