### PR TITLE
FIX: use grouped_unread_notifications

### DIFF
--- a/test/javascripts/acceptance/chat-user-menu-notifications-test.js
+++ b/test/javascripts/acceptance/chat-user-menu-notifications-test.js
@@ -47,7 +47,7 @@ acceptance(
 
     test("chat notifications tab", async function (assert) {
       updateCurrentUser({
-        grouped_unread_high_priority_notifications: {
+        grouped_unread_notifications: {
           29: 3, // chat_mention notification type
           31: 1, // chat_invitation notification type
         },


### PR DESCRIPTION
Use `grouped_unread_notifications` instead of `grouped_unread_high_priority_notifications`

Related PR: https://github.com/discourse/discourse/pull/18132