### PR TITLE
FIX: Prevent deleting a category that has channels

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -170,3 +170,7 @@ en:
       select_title: "Set chat summary emails frequency to:"
       never: Never
       when_away: Only when away
+
+  category:
+    cannot_delete:
+      has_chat_channels: "Can't delete this category because it has chat channels."

--- a/lib/extensions/category_extension.rb
+++ b/lib/extensions/category_extension.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module DiscourseChat::CategoryExtension
+  extend ActiveSupport::Concern
+
+  prepended do
+    has_one :chat_channel, as: :chatable
+  end
+
+  def cannot_delete_reason
+    return I18n.t('category.cannot_delete.has_chat_channels') if chat_channel
+    super
+  end
+end

--- a/lib/guardian_extensions.rb
+++ b/lib/guardian_extensions.rb
@@ -160,4 +160,8 @@ module DiscourseChat::GuardianExtensions
   def can_react?
     can_create_chat_message?
   end
+
+  def can_delete_category?(category)
+    super && !category.chat_channel
+  end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -164,6 +164,7 @@ after_initialize do
   load File.expand_path("../lib/extensions/user_option_extension.rb", __FILE__)
   load File.expand_path("../lib/extensions/user_notifications_extension.rb", __FILE__)
   load File.expand_path("../lib/extensions/user_email_extension.rb", __FILE__)
+  load File.expand_path("../lib/extensions/category_extension.rb", __FILE__)
   load File.expand_path("../lib/slack_compatibility.rb", __FILE__)
   load File.expand_path("../lib/post_notification_handler.rb", __FILE__)
   load File.expand_path("../lib/secure_media_compatibility.rb", __FILE__)
@@ -216,16 +217,16 @@ after_initialize do
       limited_pretty_text_markdown_rules: ChatMessage::MARKDOWN_IT_RULES,
     }
 
-    Guardian.class_eval { include DiscourseChat::GuardianExtensions }
-    UserNotifications.class_eval { prepend DiscourseChat::UserNotificationsExtension }
-    UserOption.class_eval { prepend DiscourseChat::UserOptionExtension }
-    Category.class_eval { has_one :chat_channel, as: :chatable }
+    Guardian.prepend DiscourseChat::GuardianExtensions
+    UserNotifications.prepend DiscourseChat::UserNotificationsExtension
+    UserOption.prepend DiscourseChat::UserOptionExtension
+    Category.prepend DiscourseChat::CategoryExtension
     User.class_eval do
       has_many :user_chat_channel_memberships, dependent: :destroy
       has_many :chat_message_reactions, dependent: :destroy
       has_many :chat_mentions
     end
-    Jobs::UserEmail.class_eval { prepend DiscourseChat::UserEmailExtension }
+    Jobs::UserEmail.prepend DiscourseChat::UserEmailExtension
 
     Bookmark.register_bookmarkable(ChatMessageBookmarkable)
   end

--- a/spec/lib/guardian_extensions_spec.rb
+++ b/spec/lib/guardian_extensions_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe DiscourseChat::GuardianExtensions do
+RSpec.describe DiscourseChat::GuardianExtensions do
   fab!(:user) { Fabricate(:user) }
   fab!(:staff) { Fabricate(:user, admin: true) }
   fab!(:guardian) { Guardian.new(user) }
@@ -240,6 +240,29 @@ describe DiscourseChat::GuardianExtensions do
           it "allows owner to restore" do
             expect(guardian.can_restore_chat?(message, chatable)).to eq(true)
           end
+        end
+      end
+    end
+
+    describe "#can_delete_category?" do
+      alias_matcher :be_able_to_delete_category, :be_can_delete_category
+
+      let(:category) { channel.chatable }
+
+      context "when category has no channel" do
+        before do
+          category.chat_channel.destroy
+          category.reload
+        end
+
+        it "allows to delete the category" do
+          expect(staff_guardian).to be_able_to_delete_category(category)
+        end
+      end
+
+      context "when category has a channel" do
+        it "does not allow to delete the category" do
+          expect(staff_guardian).not_to be_able_to_delete_category(category)
         end
       end
     end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Category do
+  it { is_expected.to have_one(:chat_channel) }
+
+  describe "#cannot_delete_reason" do
+    subject(:reason) { category.cannot_delete_reason }
+
+    context "when a chat channel is present" do
+      let(:channel) { Fabricate(:chat_channel) }
+      let(:category) { channel.chatable }
+
+      it "returns a message" do
+        expect(reason).to match I18n.t("category.cannot_delete.has_chat_channels")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently nothing prevents from deleting a category which has chat enabled on it. This already led to a bug (see commit 07f9cb4).

This PR addresses this issue by not allowing the deletion of a category if a channel is linked to it. This is the same approach we already have for not deleting a category when topics or sub-categories are present.