### PR TITLE
FIX: minor tweaks to skeleton

### DIFF
--- a/assets/stylesheets/common/chat-skeleton.scss
+++ b/assets/stylesheets/common/chat-skeleton.scss
@@ -1,7 +1,7 @@
 $radius: 10px;
 
 .chat-skeleton {
-  height: 100vh;
+  height: auto;
 
   &__header {
     display: flex;
@@ -104,8 +104,8 @@ $radius: 10px;
       width: 60%;
     }
 
-    &.-small {
-      width: 75%;
+    &.-large {
+      width: 85%;
     }
   }
 

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -320,7 +320,7 @@ $float-height: 530px;
 
   .chat-messages-scroll {
     flex-grow: 1;
-    overflow-y: auto;
+    overflow-y: scroll;
     overflow-y: overlay;
     scrollbar-color: var(--primary-low) transparent;
     transition: scrollbar-color 0.2s ease-in-out;


### PR DESCRIPTION
- ensures we use scroll and not auto on ios
- 100vh height can be an issue on mobile where we don't have enough space to show skeleton for the resulting height
- a typo where we had two times small and not large
- a silent error where details was not defined
- apply ios scroll fix everytime for now
