### PR TITLE
FIX: zoom check doesn't work with tests

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -26,6 +26,7 @@ import {
   onPresenceChange,
   removeOnPresenceChange,
 } from "discourse/lib/user-presence";
+import isZoomed from "discourse/plugins/discourse-chat/discourse/lib/zoom-check";
 
 const MAX_RECENT_MSGS = 100;
 const STICKY_SCROLL_LENIENCE = 50;
@@ -1411,7 +1412,7 @@ export default Component.extend({
     if (
       this.capabilities.isIOS &&
       document.documentElement.classList.contains("keyboard-visible") &&
-      document.documentElement.clientWidth / window.innerWidth === 1 // not zoomed
+      !isZoomed()
     ) {
       document.documentElement.scrollTo(0, 0);
     }

--- a/assets/javascripts/discourse/components/chat-message.js
+++ b/assets/javascripts/discourse/components/chat-message.js
@@ -18,6 +18,7 @@ import { clipboardCopy } from "discourse/lib/utilities";
 import { inject as service } from "@ember/service";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import discourseLater from "discourse-common/lib/later";
+import isZoomed from "discourse/plugins/discourse-chat/discourse/lib/zoom-check";
 
 let _chatMessageDecorators = [];
 
@@ -282,7 +283,7 @@ export default Component.extend({
   @action
   handleTouchStart() {
     // if zoomed don't track long press
-    if (document.documentElement.clientWidth / window.innerWidth !== 1) {
+    if (isZoomed()) {
       return;
     }
 
@@ -313,8 +314,8 @@ export default Component.extend({
 
   @action
   _handleLongPress() {
-    // if zoomed don't handle long press
-    if (document.documentElement.clientWidth / window.innerWidth !== 1) {
+    if (isZoomed()) {
+      // if zoomed don't handle long press
       return;
     }
 

--- a/assets/javascripts/discourse/components/chat-vh.js
+++ b/assets/javascripts/discourse/components/chat-vh.js
@@ -1,6 +1,7 @@
 import { bind } from "discourse-common/utils/decorators";
 import Component from "@ember/component";
 import { throttle } from "@ember/runloop";
+import isZoomed from "discourse/plugins/discourse-chat/discourse/lib/zoom-check";
 
 const CSS_VAR = "--chat-vh";
 
@@ -34,7 +35,7 @@ export default class ChatVh extends Component {
       return;
     }
 
-    if (document.documentElement.clientWidth / window.innerWidth !== 1) {
+    if (isZoomed()) {
       return;
     }
 

--- a/assets/javascripts/discourse/lib/zoom-check.js
+++ b/assets/javascripts/discourse/lib/zoom-check.js
@@ -1,0 +1,9 @@
+import { isTesting } from "discourse-common/config/environment";
+
+// return true when the browser viewport is zoomed
+export default function isZoomed() {
+  return (
+    !isTesting() &&
+    document.documentElement.clientWidth / window.innerWidth !== 1
+  );
+}


### PR DESCRIPTION
Also creates a zoom library to encapsulate this behavior, not very much testable as it doesn’t work well in tests.
