### PR TITLE
FIX: tweaks to live pane scroll

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -684,14 +684,6 @@ export default Component.extend({
     if (!this.showScrollToBottomBtn) {
       this.set("hasNewMessages", false);
     }
-
-    if (shouldStick !== this.stickyScroll) {
-      if (shouldStick) {
-        this._stickScrollToBottom();
-      } else {
-        this.set("stickyScroll", false);
-      }
-    }
   },
 
   @observes("floatHidden")

--- a/assets/stylesheets/mobile/chat-message.scss
+++ b/assets/stylesheets/mobile/chat-message.scss
@@ -12,7 +12,8 @@
   @include unselectable;
 }
 
-.chat-message {
+.chat-message,
+.chat-message-container {
   -webkit-transform: translate3d(0, 0, 0);
 }
 


### PR DESCRIPTION
- removes part of the code which has a very unclear goal at the moment, if this was proven useful, the intent should be made much more clear in the code and a test should written. ATM this is causing scroll bumps when pulling at the bottom of the pane.
- fixes a possible artifact when ios rendering is lagging behind
