### PR TITLE
FIX: moves chat-msg-actions-mobile into live-pane

### DIFF
--- a/assets/javascripts/discourse/components/chat-message.js
+++ b/assets/javascripts/discourse/components/chat-message.js
@@ -124,6 +124,11 @@ export default Component.extend({
     );
   },
 
+  @computed
+  get chatMessageActionsMobileAnchor() {
+    return document.querySelector(".chat-message-actions-mobile-anchor");
+  },
+
   _subscribeToAppEvents() {
     if (!this.message.id || this._hasSubscribedToAppEvents) {
       return;

--- a/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-live-pane.hbs
@@ -37,6 +37,8 @@
 
 {{chat-retention-reminder chatChannel=chatChannel}}
 
+<div class="chat-message-actions-mobile-anchor"></div>
+
 <div class="chat-messages-scroll chat-messages-container">
   <div class="chat-messages-container">
     {{#if (or this.loading this.loadingMorePast)}}

--- a/assets/javascripts/discourse/templates/components/chat-message.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message.hbs
@@ -2,16 +2,17 @@
 
 {{chat-message-separator message=message}}
 
-{{! TODO: move chat-message-actions to a shared DOM node using the newly available in-element }}
-{{#if (and showActions site.mobileView)}}
-  {{chat-message-actions-mobile
-    message=message
-    emojiReactions=emojiReactions
-    secondaryButtons=secondaryButtons
-    messageActions=messageActions
-    messageCapabilities=messageCapabilities
-    onHoverMessage=onHoverMessage
-  }}
+{{#if (and showActions site.mobileView this.chatMessageActionsMobileAnchor)}}
+  {{#in-element this.chatMessageActionsMobileAnchor}}
+    {{chat-message-actions-mobile
+      message=message
+      emojiReactions=emojiReactions
+      secondaryButtons=secondaryButtons
+      messageActions=messageActions
+      messageCapabilities=messageCapabilities
+      onHoverMessage=onHoverMessage
+    }}
+  {{/in-element}}
 {{/if}}
 
 <div

--- a/assets/stylesheets/mobile/chat-message.scss
+++ b/assets/stylesheets/mobile/chat-message.scss
@@ -12,6 +12,7 @@
   @include unselectable;
 }
 
+.chat-messages-scroll .chat-messages-container,
 .chat-message,
 .chat-message-container {
   -webkit-transform: translate3d(0, 0, 0);


### PR DESCRIPTION
This move allows to apply translated3D on parent chat-messages-container (needed to avoid a case of lag rendering on iOS) without suffering from the bug of translated3D + fixed positioning (which is basically creating a different positioning context for fixed)