### PR TITLE
FIX: various emoji-picker positioning issues

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-message.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message.hbs
@@ -40,10 +40,6 @@
   }}
   data-id={{or message.id message.stagedId}}
 >
-  {{#if (and site.desktopView isHovered)}}
-    <div class="emoji-picker-anchor"></div>
-  {{/if}}
-
   {{#if show}}
     {{#if selectingMessages}}
       {{input
@@ -73,6 +69,9 @@
     {{else}}
       <div class={{chatMessageClasses}}>
         {{#if (and showActions (not site.mobileView))}}
+          {{#if (and site.desktopView isHovered)}}
+            <div class="emoji-picker-anchor"></div>
+          {{/if}}
 
           {{! TODO: move chat-message-actions to a shared DOM node using the newly available in-element }}
           {{chat-message-actions-desktop

--- a/assets/stylesheets/common/chat-message.scss
+++ b/assets/stylesheets/common/chat-message.scss
@@ -14,6 +14,10 @@
   }
 }
 
+.emoji-picker-anchor {
+  position: absolute;
+}
+
 @mixin chat-reaction {
   align-items: center;
   display: inline-flex;


### PR DESCRIPTION
- enabling selecting messages was broken due to emoji-picker-anchor breaking the flow
- the anchor was sometimes too far from msg-actions making it impossible to reach without closing it
