### PR TITLE
FIX: reverts part of 1b30db

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -684,6 +684,14 @@ export default Component.extend({
     if (!this.showScrollToBottomBtn) {
       this.set("hasNewMessages", false);
     }
+
+    if (shouldStick !== this.stickyScroll) {
+      if (shouldStick) {
+        this._stickScrollToBottom();
+      } else {
+        this.set("stickyScroll", false);
+      }
+    }
   },
 
   @observes("floatHidden")


### PR DESCRIPTION
This was proven useful, and while the behavior is not perfect this is even worse without it.