### PR TITLE
FIX: minot tweaks to emoji picket in chat message

### DIFF
--- a/assets/javascripts/discourse/components/chat-message.js
+++ b/assets/javascripts/discourse/components/chat-message.js
@@ -540,13 +540,6 @@ export default Component.extend({
     }
   },
 
-  @action
-  didLeaveChatMessage(event) {
-    if (parseInt(event.target.dataset?.id, 10) !== this.message.id) {
-      this.onHoverMessage(null, { desktopOnly: true });
-    }
-  },
-
   deselectReaction(emoji) {
     if (!this.canInteractWithChat) {
       return;

--- a/assets/javascripts/discourse/templates/components/chat-message.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message.hbs
@@ -18,10 +18,7 @@
 {{emoji-picker
   emojiStore=emojiReactionStore
   placement="top"
-  isActive=(or
-    (and site.desktopView isHovered emojiPickerIsActive)
-    (and site.mobileView emojiPickerIsActive)
-  )
+  isActive=emojiPickerIsActive
   isEditorFocused=true
   usePopper=true
   emojiSelected=(action "selectReaction")
@@ -33,7 +30,7 @@
   {{on "touchstart" this.handleTouchStart passive=true}}
   {{on "touchend" this.handleTouchEnd passive=true}}
   {{on "mouseenter" (fn this.onHoverMessage message (hash desktopOnly=true))}}
-  {{on "mouseleave" this.didLeaveChatMessage}}
+  {{on "mouseleave" (fn this.onHoverMessage null (hash desktopOnly=true))}}
   {{chat/track-message-visibility}}
   class={{concat-class
     "chat-message-container"

--- a/assets/javascripts/discourse/templates/components/chat-message.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message.hbs
@@ -17,7 +17,7 @@
 
 {{emoji-picker
   emojiStore=emojiReactionStore
-  placement="top"
+  placement="bottom"
   isActive=emojiPickerIsActive
   isEditorFocused=true
   usePopper=true

--- a/assets/stylesheets/common/chat-message.scss
+++ b/assets/stylesheets/common/chat-message.scss
@@ -14,11 +14,6 @@
   }
 }
 
-.emoji-picker-anchor {
-  position: absolute;
-  height: 34px;
-}
-
 @mixin chat-reaction {
   align-items: center;
   display: inline-flex;
@@ -272,6 +267,11 @@
   border-radius: 0.25em;
   background-color: var(--secondary);
   display: flex;
+
+  .emoji-picker-anchor {
+    position: absolute;
+    height: 34px;
+  }
 
   .link-to-message-btn {
     .d-icon {


### PR DESCRIPTION
- prevents specific anchor styles to leak in other parts of the app
- only checks for emojiPickerIsActive and not emojiPickerIsActive && isHovered, the later was too unforgiven for small messages
