### PR TITLE
FIX: Make the scrollbar visible on iOS

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -326,6 +326,7 @@ $float-height: 530px;
     transition: scrollbar-color 0.2s ease-in-out;
     display: flex;
     flex-direction: column-reverse;
+    z-index: 1;
 
     &::-webkit-scrollbar {
       width: 15px;


### PR DESCRIPTION
It was mostly hidden under the message elements