### PR TITLE
Update "automatically add users" copy

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -232,7 +232,7 @@ en:
 
       create_channel:
         auto_join_users:
-          public_category_warning: "%{category} is a public category. Automatically add every user to this channel?"
+          public_category_warning: "%{category} is a public category. Automatically add all recently active users to this channel?"
           warning_groups:
             one: Automatically add %{members_count} users from %{group_1}?
             other: Automatically add %{members_count} users from %{group_1} and %{group_2}?
@@ -280,8 +280,8 @@ en:
         always: "For all activity"
 
       settings:
-        enable_auto_join_users: "Automatically add all new and existing users"
-        disable_auto_join_users: "Stop automatically adding new users"
+        enable_auto_join_users: "Automatically add all recently active users"
+        disable_auto_join_users: "Stop automatically adding users"
         auto_join_users_warning: "Every user who isn't a member of this channel and has access to the %{category} category will join. Are you sure?"
         desktop_notification_level: "Desktop notifications"
         follow: "Join"


### PR DESCRIPTION
We only add users who are active and have been seen in the last 3 months

This hint is intended to help avoid some of the confusion that has
surfaced around the current logic.

Copy for channels only available to certain groups may benefit from similar
improvements, but logic to calculate the user count would need to be changed
at the same time, so skipping that for now.

Related:
* https://meta.discourse.org/t/introducing-default-chat-channels-automatically-add-users/233141/31
* https://github.com/discourse/discourse-chat/blob/07f9cb4618465a5f2288fffa0a708d01db2ce175/spec/jobs/regular/auto_manage_channel_memberships_spec.rb#L28-L32
