### PR TITLE
FIX: Dev populate still breaks with missing admin user

### DIFF
--- a/lib/discourse_dev/direct_channel.rb
+++ b/lib/discourse_dev/direct_channel.rb
@@ -11,8 +11,13 @@ module DiscourseDev
 
     def data
       if Faker::Boolean.boolean(true_ratio: 0.5)
-        admin_username = DiscourseDev::Config.new.config[:admin][:username]
-        admin_user = ::User.find_by(username: admin_username)
+        admin_username =
+          begin
+            DiscourseDev::Config.new.config[:admin][:username]
+          rescue StandardError
+            nil
+          end
+        admin_user = ::User.find_by(username: admin_username) if admin_username
       end
 
       [User.new.create!, admin_user || User.new.create!]


### PR DESCRIPTION
This addresses the same type of issue that was covered in https://github.com/discourse/discourse-chat/pull/912

>When running dev:populate you might not have the admin user specified in
your config yaml file so we should ignore that instead of throwing an
error.

Output before:

```
# ALLOW_DEV_POPULATE=1 rake dev:populate
I did no detect a custom `config/dev.yml` file, creating one for you where you can amend defaults.
There are 9 group records. Creating 6 more.
......
There are 3 user records. Creating 27 more.
...........................
There are 4 category records. Creating 26 more.
..........................
discourse-solved enabled on category 'Travelling' (10).
Creating 30 sample tag records
..............................
There are 6 topic records. Creating 24 more.
........................
There are 1 chatchannel records. Creating 4 more.
....
Creating 5 sample directmessagechannel records
rake aborted!
NoMethodError: undefined method `[]' for nil:NilClass
/var/www/discourse/plugins/discourse-chat/lib/discourse_dev/direct_channel.rb:14:in `data'
/var/www/discourse/plugins/discourse-chat/lib/discourse_dev/direct_channel.rb:22:in `create!'
/var/www/discourse/lib/discourse_dev/record.rb:59:in `block in populate!'
/var/www/discourse/lib/discourse_dev/record.rb:58:in `times'
/var/www/discourse/lib/discourse_dev/record.rb:58:in `populate!'
/var/www/discourse/lib/discourse_dev/record.rb:73:in `populate!'
/var/www/discourse/plugins/discourse-chat/lib/tasks/chat.rake:8:in `block in <main>'
/usr/local/bin/bundle:26:in `load'
/usr/local/bin/bundle:26:in `<main>'
Tasks: TOP => dev:populate
(See full trace by running task with --trace)
```

Output after:

```
# ALLOW_DEV_POPULATE=1 rake dev:populate
There are 9 group records. Creating 6 more.
......
There are 3 user records. Creating 27 more.
...........................
There are 4 category records. Creating 26 more.
..........................
discourse-solved enabled on category 'Docs' (26).
Creating 30 sample tag records
..............................
There are 6 topic records. Creating 24 more.
........................
There are 1 chatchannel records. Creating 4 more.
....
Creating 5 sample directmessagechannel records
.....
Creating 200 sample chatmessage records
........................................................................................................................................................................................................
```