### PR TITLE
UX: Tweak padding on mobile

### DIFF
--- a/assets/stylesheets/common/chat-composer.scss
+++ b/assets/stylesheets/common/chat-composer.scss
@@ -1,8 +1,6 @@
 .chat-composer-container {
   display: flex;
   flex-direction: column;
-  margin-bottom: 1px;
-  margin-top: auto;
 
   #chat-full-page-uploader,
   #chat-widget-uploader {

--- a/assets/stylesheets/common/chat-replying-indicator.scss
+++ b/assets/stylesheets/common/chat-replying-indicator.scss
@@ -4,9 +4,9 @@
 
 .chat-replying-indicator {
   color: var(--primary-medium);
-  padding-bottom: 0.5em;
-  font-size: var(--font-down-2);
   display: inline-flex;
+  font-size: var(--font-down-2);
+  padding-bottom: unquote("max(0px, 0.5rem - env(safe-area-inset-bottom, 0))");
 
   &:before {
     // unicode zero width space character

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -890,6 +890,7 @@ html.has-full-page-chat {
       .full-page-chat {
         height: 100%;
         min-height: 0;
+        padding-bottom: env(safe-area-inset-bottom);
       }
 
       #main-chat-outlet {

--- a/assets/stylesheets/mobile/chat-composer.scss
+++ b/assets/stylesheets/mobile/chat-composer.scss
@@ -1,7 +1,3 @@
 .chat-composer-container {
   padding: 0;
 }
-
-.chat-composer {
-  margin: 0.5rem 0.5rem 0 0.5rem;
-}

--- a/assets/stylesheets/mobile/mobile.scss
+++ b/assets/stylesheets/mobile/mobile.scss
@@ -1,9 +1,10 @@
-.chat-message:not(.user-info-hidden) {
-  padding: 0.75em 1em 0.1em;
+.chat-message {
+  // 1px to account for .is-online box-shadow
+  padding: 0.1em 1px;
 }
 
-.chat-message.user-info-hidden {
-  padding: 0.1em 1em;
+.chat-message:not(.user-info-hidden) {
+  padding-top: 0.75em;
 }
 
 body.has-full-page-chat {
@@ -115,4 +116,8 @@ html.has-full-page-chat body {
     // restricts the height of the page
     grid-template-rows: calc(var(--chat-vh, 1vh) * 100 - var(--header-offset));
   }
+}
+
+.chat-message-separator {
+  margin-left: 0;
 }


### PR DESCRIPTION
Before / After

<img width="340" alt="Screenshot 2022-09-14 at 22 06 48" src="https://user-images.githubusercontent.com/66961/190252903-33b72862-89c6-4416-bd03-ab33efbb2417.png"> <img width="340" alt="Screenshot 2022-09-14 at 22 05 59" src="https://user-images.githubusercontent.com/66961/190252915-d792ce3d-526e-415d-b747-a014dca33b5a.png">

(actually, the composer is now about 6px lower than shown in "After" but I didn't want to retake the screenshot 😛 you can see the final position below)

How our message composer compares now to other apps:

![inputs](https://user-images.githubusercontent.com/66961/190414284-0c6508a3-4287-4d48-b135-51177e75058b.png)
