### PR TITLE
DEV: Add `tabindex` to emoji markup

### DIFF
--- a/spec/integration/post_chat_quote_spec.rb
+++ b/spec/integration/post_chat_quote_spec.rb
@@ -146,9 +146,9 @@ describe "chat bbcode quoting in posts" do
       <p>This is a chat message.</p>
       <div class="chat-transcript-reactions">
       <div class="chat-transcript-reaction">
-      <img width="20" height="20" src="/images/emoji/twitter/+1.png?v=12" title="+1" loading="lazy" alt="+1" class="emoji"> 1</div>
+      <img width="20" height="20" src="/images/emoji/twitter/+1.png?v=12" title="+1" loading="lazy" alt="+1" class="emoji" tabindex="0"> 1</div>
       <div class="chat-transcript-reaction">
-      <img width="20" height="20" src="/images/emoji/twitter/heart.png?v=12" title="heart" loading="lazy" alt="heart" class="emoji"> 2</div>
+      <img width="20" height="20" src="/images/emoji/twitter/heart.png?v=12" title="heart" loading="lazy" alt="heart" class="emoji" tabindex="0"> 2</div>
       </div>
       </div>
       </div>

--- a/spec/models/chat_message_spec.rb
+++ b/spec/models/chat_message_spec.rb
@@ -331,7 +331,7 @@ describe ChatMessage do
     it "supports emoji shortcuts" do
       cooked = ChatMessage.cook("this is a replace test :P :|")
       expect(cooked).to eq(<<~HTML.chomp)
-        <p>this is a replace test <img src="/images/emoji/twitter/stuck_out_tongue.png?v=12" title=":stuck_out_tongue:" class="emoji" alt=":stuck_out_tongue:" loading=\"lazy\" width=\"20\" height=\"20\"> <img src="/images/emoji/twitter/expressionless.png?v=12" title=":expressionless:" class="emoji" alt=":expressionless:" loading=\"lazy\" width=\"20\" height=\"20\"></p>
+        <p>this is a replace test <img src="/images/emoji/twitter/stuck_out_tongue.png?v=12" title=":stuck_out_tongue:" alt=":stuck_out_tongue:" loading=\"lazy\" width=\"20\" height=\"20\" class="emoji" tabindex="0"> <img src="/images/emoji/twitter/expressionless.png?v=12" title=":expressionless:" alt=":expressionless:" loading=\"lazy\" width=\"20\" height=\"20\" class="emoji" tabindex="0"></p>
       HTML
     end
 


### PR DESCRIPTION
This PR adds the `tabindex="0"` attribute to the emoji markup used in certain tests. This PR should only be merged in after the PR in core is merged (https://github.com/discourse/discourse/pull/18163) which is responsible for adding keyboard accessibility to the emoji picker.

The update to the markup is important to ensure tests will pass.