### PR TITLE
UX: Add lazy loading and dominant-color placeholder for uploads

### DIFF
--- a/assets/javascripts/discourse/components/chat-upload.js
+++ b/assets/javascripts/discourse/components/chat-upload.js
@@ -1,23 +1,43 @@
-import Component from "@ember/component";
-import discourseComputed from "discourse-common/utils/decorators";
+import Component from "@glimmer/component";
+
+import { inject as service } from "@ember/service";
 import { IMAGES_EXTENSIONS_REGEX } from "discourse/lib/uploads";
+import { action } from "@ember/object";
+import { tracked } from "@glimmer/tracking";
+import { htmlSafe } from "@ember/template";
 
-export default Component.extend({
-  IMAGE_TYPE: "image",
+export default class extends Component {
+  @service siteSettings;
 
-  @discourseComputed("upload.extension")
-  type(extension) {
-    if (IMAGES_EXTENSIONS_REGEX.test(extension)) {
+  @tracked loaded = false;
+
+  IMAGE_TYPE = "image";
+
+  get type() {
+    if (IMAGES_EXTENSIONS_REGEX.test(this.args.upload.extension)) {
       return this.IMAGE_TYPE;
     }
-  },
+  }
 
-  @discourseComputed("upload.width", "upload.height")
-  size(width, height) {
+  get size() {
+    const width = this.args.upload.width;
+    const height = this.args.upload.height;
+
     const ratio = Math.min(
       this.siteSettings.max_image_width / width,
       this.siteSettings.max_image_height / height
     );
     return { width: width * ratio, height: height * ratio };
-  },
-});
+  }
+
+  get imageStyle() {
+    if (this.args.upload.dominant_color && !this.loaded) {
+      return htmlSafe(`background-color: #${this.args.upload.dominant_color};`);
+    }
+  }
+
+  @action
+  imageLoaded() {
+    this.loaded = true;
+  }
+}

--- a/assets/javascripts/discourse/templates/components/chat-upload.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-upload.hbs
@@ -1,17 +1,20 @@
-{{#if (eq type IMAGE_TYPE)}}
+{{#if (eq this.type this.IMAGE_TYPE)}}
   <img
     class="chat-img-upload"
-    data-orig-src={{upload.short_url}}
-    height={{size.height}}
-    width={{size.width}}
-    src={{upload.url}}
+    data-orig-src={{@upload.short_url}}
+    height={{this.size.height}}
+    width={{this.size.width}}
+    src={{@upload.url}}
+    style={{this.imageStyle}}
+    loading="lazy"
+    {{on "load" this.imageLoaded}}
   >
 {{else}}
   <a
     class="chat-other-upload"
-    data-orig-href={{upload.short_url}}
-    href={{upload.url}}
+    data-orig-href={{@upload.short_url}}
+    href={{@upload.url}}
   >
-    {{upload.original_filename}}
+    {{@upload.original_filename}}
   </a>
 {{/if}}

--- a/test/javascripts/components/chat-upload-test.js
+++ b/test/javascripts/components/chat-upload-test.js
@@ -1,0 +1,83 @@
+import componentTest, {
+  setupRenderingTest,
+} from "discourse/tests/helpers/component-test";
+import { exists, query } from "discourse/tests/helpers/qunit-helpers";
+import hbs from "htmlbars-inline-precompile";
+import { module } from "qunit";
+import { settled } from "@ember/test-helpers";
+
+const IMAGE_FIXTURE = {
+  id: 290,
+  url: null, // Nulled out to avoid actually setting the img src - avoids an HTTP request
+  original_filename: "image.jpg",
+  filesize: 172214,
+  width: 1024,
+  height: 768,
+  thumbnail_width: 666,
+  thumbnail_height: 500,
+  extension: "jpeg",
+  short_url: "upload://mnCnqY5tunCFw2qMgtPnu1mu1C9.jpeg",
+  short_path: "/uploads/short-url/mnCnqY5tunCFw2qMgtPnu1mu1C9.jpeg",
+  retain_hours: null,
+  human_filesize: "168 KB",
+  dominant_color: "788370", // rgb(120, 131, 112)
+};
+
+const TXT_FIXTURE = {
+  id: 290,
+  url: "https://example.com/file.txt",
+  original_filename: "file.txt",
+  filesize: 172214,
+  extension: "txt",
+  short_url: "upload://mnCnqY5tunCFw2qMgtPnu1mu1C9.jpeg",
+  short_path: "/uploads/short-url/mnCnqY5tunCFw2qMgtPnu1mu1C9.jpeg",
+  retain_hours: null,
+  human_filesize: "168 KB",
+};
+
+module("Discourse Chat | Component | chat-upload", function (hooks) {
+  setupRenderingTest(hooks);
+
+  componentTest("with an image", {
+    template: hbs`{{chat-upload upload=upload}}`,
+
+    beforeEach() {
+      this.set("upload", IMAGE_FIXTURE);
+    },
+
+    async test(assert) {
+      assert.true(exists("img.chat-img-upload"), "displays as an image");
+      const image = query("img.chat-img-upload");
+      assert.strictEqual(image.loading, "lazy", "is lazy loading");
+
+      assert.strictEqual(
+        image.style.backgroundColor,
+        "rgb(120, 131, 112)",
+        "sets background to dominant color"
+      );
+
+      image.dispatchEvent(new Event("load")); // Fake that the image has loaded
+      await settled();
+
+      assert.strictEqual(
+        image.style.backgroundColor,
+        "",
+        "removes the background color once the image has loaded"
+      );
+    },
+  });
+
+  componentTest("non image upload", {
+    template: hbs`{{chat-upload upload=upload}}`,
+
+    beforeEach() {
+      this.set("upload", TXT_FIXTURE);
+    },
+
+    async test(assert) {
+      assert.true(exists("a.chat-other-upload"), "displays as a link");
+      const link = query("a.chat-other-upload");
+      assert.strictEqual(link.href, TXT_FIXTURE.url, "has the correct URL");
+    },
+  });
+});


### PR DESCRIPTION
Also takes the opportunity to make `chat-upload` a Glimmer Component

(requires https://github.com/discourse/discourse/pull/18248)
