### PR TITLE
UX: Add help text for webhook URL and remove from index page

### DIFF
--- a/assets/javascripts/discourse/templates/admin-plugins-chat.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-chat.hbs
@@ -92,6 +92,9 @@
     <div class="control-group">
       <label class="control-label">{{i18n "chat.incoming_webhooks.url"}}</label>
       <label>{{selectedWebhook.url}}</label>
+      <div class="control-instructions">
+        {{i18n "chat.incoming_webhooks.url_instructions"}}
+      </div>
     </div>
 
     {{d-button
@@ -163,7 +166,6 @@
 
             <div>{{chat-channel-title channel=webhook.chat_channel}}</div>
             <div>{{webhook.description}}</div>
-            <div>{{webhook.url}}</div>
           </div>
 
           <div class="incoming-chat-webhooks--row--controls">

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -326,6 +326,7 @@ en:
         system: "system"
         title: "Incoming webhooks"
         url: "URL"
+        url_instructions: "This URL contains a secret value - keep it safe."
         username: "Username"
         username_instructions: "Username of bot that posts to channel. Defaults to 'system' when left blank."
 


### PR DESCRIPTION
<img width="485" alt="Screenshot 2022-09-19 at 13 00 15" src="https://user-images.githubusercontent.com/6270921/191012507-3367d2a9-ee95-4152-b32e-6d7ce817f25e.png">
