### PR TITLE
FIX: Do not desktop/mobile notify on muted channel

### DIFF
--- a/app/jobs/regular/chat_notify_mentioned.rb
+++ b/app/jobs/regular/chat_notify_mentioned.rb
@@ -120,7 +120,7 @@ module Jobs
     def send_notifications(membership, notification_data, os_payload)
       create_notification!(membership, notification_data)
 
-      if !membership.desktop_notifications_never?
+      if !membership.desktop_notifications_never? && !membership.muted?
         MessageBus.publish(
           "/chat/notification-alert/#{membership.user_id}",
           os_payload,
@@ -128,7 +128,7 @@ module Jobs
         )
       end
 
-      if !membership.mobile_notifications_never?
+      if !membership.mobile_notifications_never? && !membership.muted?
         PostAlerter.push_notification(membership.user, os_payload)
       end
     end

--- a/app/jobs/regular/chat_notify_watching.rb
+++ b/app/jobs/regular/chat_notify_watching.rb
@@ -68,11 +68,13 @@ module Jobs
         excerpt: @chat_message.push_notification_excerpt,
       }
 
-      if membership.desktop_notifications_always?
+      if membership.desktop_notifications_always? && !membership.muted?
         MessageBus.publish("/chat/notification-alert/#{user.id}", payload, user_ids: [user.id])
       end
 
-      PostAlerter.push_notification(user, payload) if membership.mobile_notifications_always?
+      if membership.mobile_notifications_always? && !membership.muted?
+        PostAlerter.push_notification(user, payload)
+      end
     end
 
     def online_user_ids

--- a/spec/jobs/regular/chat_notify_watching_spec.rb
+++ b/spec/jobs/regular/chat_notify_watching_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe Jobs::ChatNotifyWatching do
       )
     end
 
+    context "when the channel is muted via membership preferences" do
+      before { membership2.update!(muted: true) }
+
+      it "does not send a desktop or mobile notification" do
+        PostAlerter.expects(:push_notification).never
+        messages = notification_messages_for(user2)
+        expect(messages).to be_empty
+      end
+    end
+
     context "when mobile_notification_level is always and desktop_notification_level is none" do
       before do
         membership2.update!(
@@ -78,6 +88,16 @@ RSpec.describe Jobs::ChatNotifyWatching do
         )
         messages = notification_messages_for(user2)
         expect(messages.length).to be_zero
+      end
+
+      context "when the channel is muted via membership preferences" do
+        before { membership2.update!(muted: true) }
+
+        it "does not send a desktop or mobile notification" do
+          PostAlerter.expects(:push_notification).never
+          messages = notification_messages_for(user2)
+          expect(messages).to be_empty
+        end
       end
     end
 
@@ -162,6 +182,16 @@ RSpec.describe Jobs::ChatNotifyWatching do
       )
     end
 
+    context "when the channel is muted via membership preferences" do
+      before { membership2.update!(muted: true) }
+
+      it "does not send a desktop or mobile notification" do
+        PostAlerter.expects(:push_notification).never
+        messages = notification_messages_for(user2)
+        expect(messages).to be_empty
+      end
+    end
+
     context "when mobile_notification_level is always and desktop_notification_level is none" do
       before do
         membership2.update!(
@@ -184,6 +214,16 @@ RSpec.describe Jobs::ChatNotifyWatching do
         )
         messages = notification_messages_for(user2)
         expect(messages.length).to be_zero
+      end
+
+      context "when the channel is muted via membership preferences" do
+        before { membership2.update!(muted: true) }
+
+        it "does not send a desktop or mobile notification" do
+          PostAlerter.expects(:push_notification).never
+          messages = notification_messages_for(user2)
+          expect(messages).to be_empty
+        end
       end
     end
 
@@ -236,9 +276,7 @@ RSpec.describe Jobs::ChatNotifyWatching do
     end
 
     context "when the target user is preventing communication from the message creator" do
-      before do
-        UserCommScreener.any_instance.expects(:allowing_actor_communication).returns([])
-      end
+      before { UserCommScreener.any_instance.expects(:allowing_actor_communication).returns([]) }
 
       it "does not send a desktop notification" do
         expect(notification_messages_for(user2).count).to be_zero


### PR DESCRIPTION
The user can mute a channel they are a member of, but
still have the desktop/mobile notification levels set
to always/mention. This commit fixes the issue where the
desktop/mobile push notifications were being sent even
if the user had muted the channel.