### PR TITLE
DEV: Refactor user_count calculation and chat membership management

### DIFF
--- a/app/controllers/api/chat_channels_controller.rb
+++ b/app/controllers/api/chat_channels_controller.rb
@@ -74,6 +74,7 @@ class DiscourseChat::Api::ChatChannelsController < DiscourseChat::Api
         user: current_user,
         channel_id: params.require(:chat_channel_id),
       )
+    raise Discourse::NotFound if membership.blank?
     guardian.ensure_can_see_chat_channel!(membership.chat_channel)
     membership
   end

--- a/app/controllers/api/chat_channels_controller.rb
+++ b/app/controllers/api/chat_channels_controller.rb
@@ -48,7 +48,7 @@ class DiscourseChat::Api::ChatChannelsController < DiscourseChat::Api
 
     if chat_channel.category_channel? && chat_channel.auto_join_users
       DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(
-        channel_id: chat_channel.id,
+        channel: chat_channel,
       )
     end
 

--- a/app/controllers/api/chat_channels_controller.rb
+++ b/app/controllers/api/chat_channels_controller.rb
@@ -47,9 +47,9 @@ class DiscourseChat::Api::ChatChannelsController < DiscourseChat::Api
     ChatPublisher.publish_chat_channel_edit(chat_channel, current_user)
 
     if chat_channel.category_channel? && chat_channel.auto_join_users
-      DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(
+      DiscourseChat::ChatChannelMembershipManager.new(
         chat_channel,
-      )
+      ).enforce_automatic_channel_memberships
     end
 
     render_serialized(
@@ -69,13 +69,10 @@ class DiscourseChat::Api::ChatChannelsController < DiscourseChat::Api
   end
 
   def find_membership
+    chat_channel = find_chat_channel
     membership =
-      DiscourseChat::ChatChannelMembershipManager.find_for_user(
-        user: current_user,
-        channel_id: params.require(:chat_channel_id),
-      )
+      DiscourseChat::ChatChannelMembershipManager.new(chat_channel).find_for_user(current_user)
     raise Discourse::NotFound if membership.blank?
-    guardian.ensure_can_see_chat_channel!(membership.chat_channel)
     membership
   end
 

--- a/app/controllers/api/chat_channels_controller.rb
+++ b/app/controllers/api/chat_channels_controller.rb
@@ -48,7 +48,7 @@ class DiscourseChat::Api::ChatChannelsController < DiscourseChat::Api
 
     if chat_channel.category_channel? && chat_channel.auto_join_users
       DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(
-        channel: chat_channel,
+        chat_channel,
       )
     end
 

--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -13,7 +13,7 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
       @chat_channel,
       ChatChannelSerializer,
       membership: @chat_channel.membership_for(current_user),
-      root: false
+      root: false,
     )
   end
 
@@ -24,7 +24,7 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
       @chat_channel,
       ChatChannelSerializer,
       membership: @chat_channel.membership_for(current_user),
-      root: false
+      root: false,
     )
   end
 
@@ -35,7 +35,7 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
       @chat_channel,
       ChatChannelSerializer,
       membership: @chat_channel.membership_for(current_user),
-      root: false
+      root: false,
     )
   end
 
@@ -68,7 +68,9 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
     chat_channel.user_chat_channel_memberships.create!(user: current_user, following: true)
 
     if chat_channel.auto_join_users
-      UserChatChannelMembership.enforce_automatic_channel_memberships(chat_channel)
+      DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(
+        chat_channel,
+      )
     end
 
     render_serialized(
@@ -102,7 +104,7 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
   def search
     params.require(:filter)
     filter = params[:filter]&.downcase
-    memberships = UserChatChannelMembership.where(user: current_user)
+    memberships = DiscourseChat::ChatChannelMembershipManager.all_for_user(current_user)
     public_channels =
       DiscourseChat::ChatChannelFetcher.secured_public_channels(
         guardian,

--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -59,7 +59,7 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
 
     if chat_channel.auto_join_users
       DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(
-        channel: chat_channel,
+        chat_channel,
       )
     end
 

--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -23,7 +23,7 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
     render_serialized(
       @chat_channel,
       ChatChannelSerializer,
-      membership: @chat_channel.membership_for(current_user),
+      membership: membership,
       root: false,
     )
   end
@@ -34,7 +34,7 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
     render_serialized(
       @chat_channel,
       ChatChannelSerializer,
-      membership: @chat_channel.membership_for(current_user),
+      membership: membership,
       root: false,
     )
   end
@@ -69,7 +69,7 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
 
     if chat_channel.auto_join_users
       DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(
-        chat_channel,
+        channel: chat_channel,
       )
     end
 

--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -20,23 +20,13 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
   def follow
     membership = @chat_channel.add(current_user)
 
-    render_serialized(
-      @chat_channel,
-      ChatChannelSerializer,
-      membership: membership,
-      root: false,
-    )
+    render_serialized(@chat_channel, ChatChannelSerializer, membership: membership, root: false)
   end
 
   def unfollow
     membership = @chat_channel.remove(current_user)
 
-    render_serialized(
-      @chat_channel,
-      ChatChannelSerializer,
-      membership: membership,
-      root: false,
-    )
+    render_serialized(@chat_channel, ChatChannelSerializer, membership: membership, root: false)
   end
 
   def create

--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -58,9 +58,9 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
     chat_channel.user_chat_channel_memberships.create!(user: current_user, following: true)
 
     if chat_channel.auto_join_users
-      DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(
+      DiscourseChat::ChatChannelMembershipManager.new(
         chat_channel,
-      )
+      ).enforce_automatic_channel_memberships
     end
 
     render_serialized(

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -50,13 +50,7 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
     end
 
     if success
-      membership =
-        UserChatChannelMembership.find_or_initialize_by(
-          chat_channel: chat_channel,
-          user: current_user,
-        )
-      membership.following = true
-      membership.save!
+      membership = DiscourseChat::ChatChannelMembershipManager.follow_channel(user: user, channel: channel)
       render_serialized(chat_channel, ChatChannelSerializer, membership: membership)
     else
       render_json_error(chat_channel)
@@ -86,9 +80,9 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
     DiscourseChat::ChatMessageRateLimiter.run!(current_user)
 
     @user_chat_channel_membership =
-      UserChatChannelMembership.find_by(
-        chat_channel: @chat_channel,
+      DiscourseChat::ChatChannelMembershipManager.find_for_user(
         user: current_user,
+        chat_channel: @chat_channel,
         following: true,
       )
     raise Discourse::InvalidAccess unless @user_chat_channel_membership
@@ -117,21 +111,23 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
     @user_chat_channel_membership.update(last_read_message_id: chat_message_creator.chat_message.id)
 
     if @chat_channel.direct_message_channel?
-
       # If any of the channel users is ignoring, muting, or preventing DMs from
       # the current user then we shold not auto-follow the channel once again or
       # publish the new channel.
-      user_ids_allowing_communication = UserCommScreener.new(
-        acting_user: current_user,
-        target_user_ids: @chat_channel.user_chat_channel_memberships.pluck(:user_id)
-      ).allowing_actor_communication
+      user_ids_allowing_communication =
+        UserCommScreener.new(
+          acting_user: current_user,
+          target_user_ids: @chat_channel.user_chat_channel_memberships.pluck(:user_id),
+        ).allowing_actor_communication
 
       if user_ids_allowing_communication.any?
-        @chat_channel.user_chat_channel_memberships.where(
-          user_id: user_ids_allowing_communication
-        ).update_all(following: true)
+        @chat_channel
+          .user_chat_channel_memberships
+          .where(user_id: user_ids_allowing_communication)
+          .update_all(following: true)
         ChatPublisher.publish_new_channel(
-          @chat_channel, @chat_channel.chatable.users.where(id: user_ids_allowing_communication)
+          @chat_channel,
+          @chat_channel.chatable.users.where(id: user_ids_allowing_communication),
         )
       end
     end
@@ -160,7 +156,7 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
 
   def update_user_last_read
     membership =
-      UserChatChannelMembership.find_by(
+      DiscourseChat::ChatChannelMembershipManager.find_for_user(
         user: current_user,
         chat_channel: @chat_channel,
         following: true,

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -50,7 +50,8 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
     end
 
     if success
-      membership = DiscourseChat::ChatChannelMembershipManager.follow_channel(user: user, channel: channel)
+      membership =
+        DiscourseChat::ChatChannelMembershipManager.follow_channel(user: user, channel: channel)
       render_serialized(chat_channel, ChatChannelSerializer, membership: membership)
     else
       render_json_error(chat_channel)

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -82,7 +82,7 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
     @user_chat_channel_membership =
       DiscourseChat::ChatChannelMembershipManager.find_for_user(
         user: current_user,
-        chat_channel: @chat_channel,
+        channel: @chat_channel,
         following: true,
       )
     raise Discourse::InvalidAccess unless @user_chat_channel_membership
@@ -158,7 +158,7 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
     membership =
       DiscourseChat::ChatChannelMembershipManager.find_for_user(
         user: current_user,
-        chat_channel: @chat_channel,
+        channel: @chat_channel,
         following: true,
       )
     raise Discourse::NotFound if membership.nil?

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -50,12 +50,13 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
     end
 
     if success
-      membership =
-        DiscourseChat::ChatChannelMembershipManager.follow_channel(user: user, channel: channel)
+      membership = DiscourseChat::ChatChannelMembershipManager.new(channel).follow(user)
       render_serialized(chat_channel, ChatChannelSerializer, membership: membership)
     else
       render_json_error(chat_channel)
     end
+
+    DiscourseChat::ChatChannelMembershipManager.new(channel).follow(user)
   end
 
   def disable_chat
@@ -81,9 +82,8 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
     DiscourseChat::ChatMessageRateLimiter.run!(current_user)
 
     @user_chat_channel_membership =
-      DiscourseChat::ChatChannelMembershipManager.find_for_user(
-        user: current_user,
-        channel: @chat_channel,
+      DiscourseChat::ChatChannelMembershipManager.new(@chat_channel).find_for_user(
+        current_user,
         following: true,
       )
     raise Discourse::InvalidAccess unless @user_chat_channel_membership
@@ -157,9 +157,8 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
 
   def update_user_last_read
     membership =
-      DiscourseChat::ChatChannelMembershipManager.find_for_user(
-        user: current_user,
-        channel: @chat_channel,
+      DiscourseChat::ChatChannelMembershipManager.new(@chat_channel).find_for_user(
+        current_user,
         following: true,
       )
     raise Discourse::NotFound if membership.nil?

--- a/app/jobs/regular/auto_join_channel_batch.rb
+++ b/app/jobs/regular/auto_join_channel_batch.rb
@@ -4,7 +4,10 @@ module Jobs
   class AutoJoinChannelBatch < ::Jobs::Base
     def execute(args)
       return "starts_at or ends_at missing" if args[:starts_at].blank? || args[:ends_at].blank?
-      return "End is higher than start" if args[:ends_at] < args[:starts_at]
+      start_user_id = args[:starts_at].to_i
+      end_user_id = args[:ends_at].to_i
+
+      return "End is higher than start" if end_user_id < start_user_id
 
       channel =
         ChatChannel.find_by(
@@ -20,8 +23,8 @@ module Jobs
 
       query_args = {
         chat_channel_id: channel.id,
-        start: args[:starts_at],
-        end: args[:ends_at],
+        start: start_user_id,
+        end: end_user_id,
         suspended_until: Time.zone.now,
         last_seen_at: 3.months.ago,
         channel_category: channel.chatable_id,
@@ -33,7 +36,7 @@ module Jobs
       # Only do this if we are running auto-join for a single user, if we
       # are doing it for many then we should do it after all batches are
       # complete for the channel in Jobs::AutoManageChannelMemberships
-      if args[:starts_at] == args[:ends_at]
+      if start_user_id == end_user_id
         DiscourseChat::ChatChannelMembershipManager.recalculate_user_count!(channel.id)
       end
 

--- a/app/jobs/regular/auto_join_channel_batch.rb
+++ b/app/jobs/regular/auto_join_channel_batch.rb
@@ -37,7 +37,7 @@ module Jobs
       # are doing it for many then we should do it after all batches are
       # complete for the channel in Jobs::AutoManageChannelMemberships
       if start_user_id == end_user_id
-        DiscourseChat::ChatChannelMembershipManager.recalculate_user_count(channel)
+        DiscourseChat::ChatChannelMembershipManager.new(channel).recalculate_user_count
       end
 
       ChatPublisher.publish_new_channel(channel.reload, User.where(id: new_member_ids))

--- a/app/jobs/regular/auto_join_channel_batch.rb
+++ b/app/jobs/regular/auto_join_channel_batch.rb
@@ -37,7 +37,7 @@ module Jobs
       # are doing it for many then we should do it after all batches are
       # complete for the channel in Jobs::AutoManageChannelMemberships
       if start_user_id == end_user_id
-        DiscourseChat::ChatChannelMembershipManager.recalculate_user_count!(channel.id)
+        DiscourseChat::ChatChannelMembershipManager.recalculate_user_count(channel)
       end
 
       ChatPublisher.publish_new_channel(channel.reload, User.where(id: new_member_ids))

--- a/app/jobs/regular/auto_manage_channel_memberships.rb
+++ b/app/jobs/regular/auto_manage_channel_memberships.rb
@@ -38,7 +38,7 @@ module Jobs
       # The Jobs::AutoJoinChannelBatch job will only do this recalculation
       # if it's operating on one user, so we need to make sure we do it for
       # the channel here once this job is complete.
-      DiscourseChat::ChatChannelMembershipManager.recalculate_user_count!(channel.id)
+      DiscourseChat::ChatChannelMembershipManager.recalculate_user_count(channel)
     end
 
     private

--- a/app/jobs/regular/auto_manage_channel_memberships.rb
+++ b/app/jobs/regular/auto_manage_channel_memberships.rb
@@ -38,7 +38,7 @@ module Jobs
       # The Jobs::AutoJoinChannelBatch job will only do this recalculation
       # if it's operating on one user, so we need to make sure we do it for
       # the channel here once this job is complete.
-      DiscourseChat::ChatChannelMembershipManager.recalculate_user_count(channel)
+      DiscourseChat::ChatChannelMembershipManager.new(channel).recalculate_user_count
     end
 
     private

--- a/app/jobs/regular/auto_manage_channel_memberships.rb
+++ b/app/jobs/regular/auto_manage_channel_memberships.rb
@@ -34,6 +34,11 @@ module Jobs
 
         processed += batch.size
       end
+
+      # The Jobs::AutoJoinChannelBatch job will only do this recalculation
+      # if it's operating on one user, so we need to make sure we do it for
+      # the channel here once this job is complete.
+      DiscourseChat::ChatChannelMembershipManager.recalculate_user_count!(channel.id)
     end
 
     private

--- a/app/jobs/regular/update_channel_user_count.rb
+++ b/app/jobs/regular/update_channel_user_count.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Jobs
+  class UpdateChannelUserCount < Jobs::Base
+    def execute(args = {})
+      channel = ChatChannel.find(args[:chat_channel_id])
+      return if channel.blank?
+      return if !channel.user_count_stale
+
+      channel.update!(
+        user_count: ChatChannelMembershipsQuery.call(channel, count_only: true),
+        user_count_stale: false,
+      )
+
+      ChatPublisher.publish_chat_channel_metadata(channel)
+    end
+  end
+end

--- a/app/jobs/regular/update_channel_user_count.rb
+++ b/app/jobs/regular/update_channel_user_count.rb
@@ -8,7 +8,7 @@ module Jobs
       return if !channel.user_count_stale
 
       channel.update!(
-        user_count: ChatChannelMembershipsQuery.call(channel, count_only: true),
+        user_count: ChatChannelMembershipsQuery.count(channel),
         user_count_stale: false,
       )
 

--- a/app/jobs/regular/update_channel_user_count.rb
+++ b/app/jobs/regular/update_channel_user_count.rb
@@ -3,7 +3,7 @@
 module Jobs
   class UpdateChannelUserCount < Jobs::Base
     def execute(args = {})
-      channel = ChatChannel.find(args[:chat_channel_id])
+      channel = ChatChannel.find_by(id: args[:chat_channel_id])
       return if channel.blank?
       return if !channel.user_count_stale
 

--- a/app/jobs/scheduled/auto_join_users.rb
+++ b/app/jobs/scheduled/auto_join_users.rb
@@ -8,9 +8,7 @@ module Jobs
       ChatChannel
         .where(auto_join_users: true)
         .each do |channel|
-          DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(
-            channel: channel,
-          )
+          DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(channel)
         end
     end
   end

--- a/app/jobs/scheduled/auto_join_users.rb
+++ b/app/jobs/scheduled/auto_join_users.rb
@@ -7,7 +7,11 @@ module Jobs
     def execute(_args)
       ChatChannel
         .where(auto_join_users: true)
-        .each { |channel| UserChatChannelMembership.enforce_automatic_channel_memberships(channel) }
+        .each do |channel|
+          DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(
+            channel: channel,
+          )
+        end
     end
   end
 end

--- a/app/jobs/scheduled/auto_join_users.rb
+++ b/app/jobs/scheduled/auto_join_users.rb
@@ -8,7 +8,9 @@ module Jobs
       ChatChannel
         .where(auto_join_users: true)
         .each do |channel|
-          DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(channel)
+          DiscourseChat::ChatChannelMembershipManager.new(
+            channel,
+          ).enforce_automatic_channel_memberships
         end
     end
   end

--- a/app/jobs/scheduled/update_user_counts_for_chat_channels.rb
+++ b/app/jobs/scheduled/update_user_counts_for_chat_channels.rb
@@ -2,25 +2,25 @@
 
 module Jobs
   class UpdateUserCountsForChatChannels < ::Jobs::Scheduled
-    every 2.hours
+    every 1.hour
 
+    # FIXME: This could become huge as the amount of channels grows, we
+    # need a different approach here. Perhaps we should only bother for
+    # channels updated or with new messages in the past N days? Perhaps
+    # we could update all the counts in a single query as well?
     def execute(args = {})
-      ChatChannel.find_each { |chat_channel| set_user_count(chat_channel) }
+      ChatChannel
+        .where(status: %i[open closed])
+        .find_each { |chat_channel| set_user_count(chat_channel) }
     end
 
     def set_user_count(chat_channel)
       current_count = chat_channel.user_count || 0
-      new_count =
-        chat_channel
-          .user_chat_channel_memberships
-          .joins(:user)
-          .where(following: true)
-          .merge(User.activated.not_suspended.not_staged)
-          .count
-
+      new_count = ChatChannelMembershipsQuery.call(chat_channel, count_only: true)
       return if current_count == new_count
 
-      chat_channel.update(user_count: new_count)
+      chat_channel.update(user_count: new_count, user_count_stale: false)
+      ChatPublisher.publish_chat_channel_metadata(chat_channel)
     end
   end
 end

--- a/app/jobs/scheduled/update_user_counts_for_chat_channels.rb
+++ b/app/jobs/scheduled/update_user_counts_for_chat_channels.rb
@@ -16,7 +16,7 @@ module Jobs
 
     def set_user_count(chat_channel)
       current_count = chat_channel.user_count || 0
-      new_count = ChatChannelMembershipsQuery.call(chat_channel, count_only: true)
+      new_count = ChatChannelMembershipsQuery.count(chat_channel)
       return if current_count == new_count
 
       chat_channel.update(user_count: new_count, user_count_stale: false)

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -50,11 +50,11 @@ class ChatChannel < ActiveRecord::Base
   end
 
   def add(user)
-    DiscourseChat::ChatChannelMembershipManager.follow_channel(user: user, channel: self)
+    DiscourseChat::ChatChannelMembershipManager.new(self).follow(user)
   end
 
   def remove(user)
-    DiscourseChat::ChatChannelMembershipManager.unfollow_channel(user: user, channel: self)
+    DiscourseChat::ChatChannelMembershipManager.new(self).unfollow(user)
   end
 
   def status_name

--- a/app/models/user_chat_channel_membership.rb
+++ b/app/models/user_chat_channel_membership.rb
@@ -13,21 +13,6 @@ class UserChatChannelMembership < ActiveRecord::Base
 
   attribute :unread_count, default: 0
   attribute :unread_mentions, default: 0
-
-  class << self
-    def enforce_automatic_channel_memberships(channel)
-      Jobs.enqueue(:auto_manage_channel_memberships, chat_channel_id: channel.id)
-    end
-
-    def enforce_automatic_user_membership(channel, user)
-      Jobs.enqueue(
-        :auto_join_channel_batch,
-        chat_channel_id: channel.id,
-        starts_at: user.id,
-        ends_at: user.id,
-      )
-    end
-  end
 end
 
 # == Schema Information

--- a/app/queries/chat_channel_memberships_query.rb
+++ b/app/queries/chat_channel_memberships_query.rb
@@ -40,4 +40,8 @@ class ChatChannelMembershipsQuery
 
     query.offset(offset).limit(limit)
   end
+
+  def self.count(channel)
+    call(channel, count_only: true)
+  end
 end

--- a/app/queries/chat_channel_memberships_query.rb
+++ b/app/queries/chat_channel_memberships_query.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
-# TODO (martin) Move to MembershipManager
 class ChatChannelMembershipsQuery
-  def self.call(channel, limit: 50, offset: 0, username: nil)
+  def self.call(channel, limit: 50, offset: 0, username: nil, count_only: false)
     query =
       UserChatChannelMembership
         .joins(:user)
         .includes(:user)
         .where(user: User.activated.not_suspended.not_staged)
         .where(chat_channel: channel, following: true)
+
+    return query.count if count_only
 
     if channel.category_channel? && channel.read_restricted? && channel.allowed_group_ids
       query =

--- a/app/queries/chat_channel_memberships_query.rb
+++ b/app/queries/chat_channel_memberships_query.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# TODO (martin) Move to MembershipManager
 class ChatChannelMembershipsQuery
   def self.call(channel, limit: 50, offset: 0, username: nil)
     query =

--- a/app/services/chat_publisher.rb
+++ b/app/services/chat_publisher.rb
@@ -143,7 +143,7 @@ module ChatPublisher
           chat_channel,
           scope: Guardian.new(user), # We need a guardian here for direct messages
           root: :chat_channel,
-          membership: chat_channel.membership_for(user)
+          membership: chat_channel.membership_for(user),
         ).as_json
       MessageBus.publish("/chat/new-channel", serialized_channel, user_ids: [user.id])
     end
@@ -191,6 +191,14 @@ module ChatPublisher
     MessageBus.publish(
       "/chat/channel-status",
       { chat_channel_id: chat_channel.id, status: chat_channel.status },
+      permissions(chat_channel),
+    )
+  end
+
+  def self.publish_chat_channel_metadata(chat_channel)
+    MessageBus.publish(
+      "/chat/channel-metadata",
+      { chat_channel_id: chat_channel.id, memberships_count: chat_channel.user_count },
       permissions(chat_channel),
     )
   end

--- a/assets/javascripts/discourse/components/chat-channel-members-view.js
+++ b/assets/javascripts/discourse/components/chat-channel-members-view.js
@@ -30,6 +30,13 @@ export default class ChatChannelMembersView extends Component {
     this._focusSearch();
     this.set("members", []);
     this.fetchMembers();
+
+    this.appEvents.on("chat:refresh-channel-members", this, "onFilterMembers");
+  }
+
+  willDestroyElement() {
+    this._super(...arguments);
+    this.appEvents.off("chat:refresh-channel-members", this, "onFilterMembers");
   }
 
   get chatProgressBarContainer() {

--- a/assets/javascripts/discourse/lib/chat-api.js
+++ b/assets/javascripts/discourse/lib/chat-api.js
@@ -59,7 +59,6 @@ export default class ChatApi {
       }
     ).then((updatedChannel) => {
       channel.updateMembership(updatedChannel.current_user_membership);
-      channel.set("memberships_count", updatedChannel.memberships_count);
       return channel;
     });
   }
@@ -72,7 +71,6 @@ export default class ChatApi {
       }
     ).then((updatedChannel) => {
       channel.updateMembership(updatedChannel.current_user_membership);
-      channel.set("memberships_count", updatedChannel.memberships_count);
       return channel;
     });
   }

--- a/assets/javascripts/discourse/lib/chat-api.js
+++ b/assets/javascripts/discourse/lib/chat-api.js
@@ -59,6 +59,10 @@ export default class ChatApi {
       }
     ).then((updatedChannel) => {
       channel.updateMembership(updatedChannel.current_user_membership);
+
+      // doesn't matter if this is inaccurate, it will be eventually consistent
+      // via the channel-metadata MessageBus channel
+      channel.set("memberships_count", channel.memberships_count - 1);
       return channel;
     });
   }
@@ -71,6 +75,10 @@ export default class ChatApi {
       }
     ).then((updatedChannel) => {
       channel.updateMembership(updatedChannel.current_user_membership);
+
+      // doesn't matter if this is inaccurate, it will be eventually consistent
+      // via the channel-metadata MessageBus channel
+      channel.set("memberships_count", channel.memberships_count + 1);
       return channel;
     });
   }

--- a/assets/javascripts/discourse/models/chat-channel.js
+++ b/assets/javascripts/discourse/models/chat-channel.js
@@ -103,6 +103,7 @@ export default class ChatChannel extends RestModel {
     "chatable.users.length"
   )
   get membershipsCount() {
+    // TODO (martin) can we just use user_count/memberships_count here too??
     if (this.isDirectMessageChannel) {
       return (this.chatable.users?.length || 0) + 1;
     }

--- a/assets/javascripts/discourse/models/chat-channel.js
+++ b/assets/javascripts/discourse/models/chat-channel.js
@@ -97,17 +97,8 @@ export default class ChatChannel extends RestModel {
     return this.isOpen && !this.isArchived;
   }
 
-  @computed(
-    "isDirectMessageChannel",
-    "memberships_count",
-    "chatable.users.length"
-  )
+  @computed("memberships_count")
   get membershipsCount() {
-    // TODO (martin) can we just use user_count/memberships_count here too??
-    if (this.isDirectMessageChannel) {
-      return (this.chatable.users?.length || 0) + 1;
-    }
-
     return this.memberships_count;
   }
 

--- a/assets/javascripts/discourse/services/chat.js
+++ b/assets/javascripts/discourse/services/chat.js
@@ -68,6 +68,7 @@ export default class Chat extends Service {
       this._subscribeToNewChannelUpdates();
       this._subscribeToUserTrackingChannel();
       this._subscribeToChannelEdits();
+      this._subscribeToChannelMetadata();
       this._subscribeToChannelStatusChange();
       this.presenceChannel = this.presence.getChannel("/chat/online");
       this.draftStore = {};
@@ -115,6 +116,7 @@ export default class Chat extends Service {
       this._unsubscribeFromNewDmChannelUpdates();
       this._unsubscribeFromUserTrackingChannel();
       this._unsubscribeFromChannelEdits();
+      this._unsubscribeFromChannelMetadata();
       this._unsubscribeFromChannelStatusChange();
       this._unsubscribeFromAllChatChannels();
     }
@@ -588,6 +590,19 @@ export default class Chat extends Service {
     });
   }
 
+  _subscribeToChannelMetadata() {
+    this.messageBus.subscribe("/chat/channel-metadata", (busData) => {
+      this.getChannelBy("id", busData.chat_channel_id).then((channel) => {
+        if (channel) {
+          channel.setProperties({
+            memberships_count: busData.memberships_count,
+          });
+          this.appEvents.trigger("chat:refresh-channel-members");
+        }
+      });
+    });
+  }
+
   _subscribeToChannelEdits() {
     this.messageBus.subscribe("/chat/channel-edits", (busData) => {
       this.getChannelBy("id", busData.chat_channel_id).then((channel) => {
@@ -634,6 +649,10 @@ export default class Chat extends Service {
 
   _unsubscribeFromChannelEdits() {
     this.messageBus.unsubscribe("/chat/channel-edits");
+  }
+
+  _unsubscribeFromChannelMetadata() {
+    this.messageBus.unsubscribe("/chat/channel-metadata");
   }
 
   _subscribeToNewChannelUpdates() {

--- a/db/migrate/20220901034107_add_user_count_stale_to_channel.rb
+++ b/db/migrate/20220901034107_add_user_count_stale_to_channel.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUserCountStaleToChannel < ActiveRecord::Migration[7.0]
+  def change
+    add_column :chat_channels, :user_count_stale, :boolean, default: false, null: false
+  end
+end

--- a/lib/chat_channel_archive_service.rb
+++ b/lib/chat_channel_archive_service.rb
@@ -242,6 +242,6 @@ class DiscourseChat::ChatChannelArchiveService
   end
 
   def kick_all_users
-    DiscourseChat::ChatChannelMembershipManager.unfollow_all_for_channel(chat_channel)
+    DiscourseChat::ChatChannelMembershipManager.new(chat_channel).unfollow_all_users
   end
 end

--- a/lib/chat_channel_archive_service.rb
+++ b/lib/chat_channel_archive_service.rb
@@ -242,6 +242,7 @@ class DiscourseChat::ChatChannelArchiveService
   end
 
   def kick_all_users
+    # TODO (martin) Move to MembershipManager
     UserChatChannelMembership.where(chat_channel: chat_channel).update_all(
       following: false,
       last_read_message_id: chat_channel.chat_messages.last&.id,

--- a/lib/chat_channel_archive_service.rb
+++ b/lib/chat_channel_archive_service.rb
@@ -242,10 +242,6 @@ class DiscourseChat::ChatChannelArchiveService
   end
 
   def kick_all_users
-    # TODO (martin) Move to MembershipManager
-    UserChatChannelMembership.where(chat_channel: chat_channel).update_all(
-      following: false,
-      last_read_message_id: chat_channel.chat_messages.last&.id,
-    )
+    DiscourseChat::ChatChannelMembershipManager.unfollow_all_for_channel(chat_channel)
   end
 end

--- a/lib/chat_channel_fetcher.rb
+++ b/lib/chat_channel_fetcher.rb
@@ -4,7 +4,7 @@ module DiscourseChat::ChatChannelFetcher
   MAX_PUBLIC_CHANNEL_RESULTS = 50
 
   def self.structured(guardian)
-    memberships = UserChatChannelMembership.where(user_id: guardian.user.id)
+    memberships = UserChatChannelMembership.all_for_user(guardian.user)
     {
       public_channels:
         secured_public_channels(guardian, memberships, status: :open, following: true),

--- a/lib/chat_channel_fetcher.rb
+++ b/lib/chat_channel_fetcher.rb
@@ -4,7 +4,7 @@ module DiscourseChat::ChatChannelFetcher
   MAX_PUBLIC_CHANNEL_RESULTS = 50
 
   def self.structured(guardian)
-    memberships = UserChatChannelMembership.all_for_user(guardian.user)
+    memberships = DiscourseChat::ChatChannelMembershipManager.all_for_user(guardian.user)
     {
       public_channels:
         secured_public_channels(guardian, memberships, status: :open, following: true),

--- a/lib/chat_channel_membership_manager.rb
+++ b/lib/chat_channel_membership_manager.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class DiscourseChat::ChatChannelMembershipManager
+  def self.all_for_user(user)
+    UserChatChannelMembership.where(user: user)
+  end
+
+  def self.find_for_user(user:, channel_id: nil, channel: nil, following: nil, initialize: false)
+    ensure_channel_or_id_provided!(channel_id, channel)
+    params = { user: user, chat_channel_id: channel_id || channel.id }
+    params[:following] = following if following.present?
+
+    if initialize
+      UserChatChannelMembership.find_or_initialize_by(params)
+    else
+      UserChatChannelMembership.includes(:user, :chat_channel).find(params)
+    end
+  end
+
+  def self.follow_channel(user:, channel_id: nil, channel: nil)
+    ensure_channel_or_id_provided!(channel_id, channel)
+  end
+
+  def self.unfollow_channel(user:, channel_id: nil, channel: nil)
+    ensure_channel_or_id_provided!(channel_id, channel)
+  end
+
+  def self.enforce_automatic_channel_memberships(channel_id: nil, channel: nil)
+    ensure_channel_or_id_provided!(channel_id, channel)
+    Jobs.enqueue(:auto_manage_channel_memberships, chat_channel_id: channel_id || channel.id)
+  end
+
+  def self.enforce_automatic_user_membership(channel, user)
+    Jobs.enqueue(
+      :auto_join_channel_batch,
+      chat_channel_id: channel.id,
+      starts_at: user.id,
+      ends_at: user.id,
+    )
+  end
+
+  def self.ensure_channel_or_id_provided!(channel_id, channel)
+    raise ArgumentError if channel_id.blank? && channel.blank?
+  end
+end

--- a/lib/chat_channel_membership_manager.rb
+++ b/lib/chat_channel_membership_manager.rb
@@ -7,22 +7,60 @@ class DiscourseChat::ChatChannelMembershipManager
 
   def self.find_for_user(user:, channel_id: nil, channel: nil, following: nil, initialize: false)
     ensure_channel_or_id_provided!(channel_id, channel)
-    params = { user: user, chat_channel_id: channel_id || channel.id }
+    params = { user_id: user.id, chat_channel_id: channel_id || channel.id }
     params[:following] = following if following.present?
 
     if initialize
       UserChatChannelMembership.find_or_initialize_by(params)
     else
-      UserChatChannelMembership.includes(:user, :chat_channel).find(params)
+      UserChatChannelMembership.includes(:user, :chat_channel).find_by(params)
     end
   end
 
   def self.follow_channel(user:, channel_id: nil, channel: nil)
     ensure_channel_or_id_provided!(channel_id, channel)
+    membership =
+      find_for_user(user: user, channel_id: channel_id, channel: channel, initialize: true)
+
+    ActiveRecord::Base.transaction do
+      if !membership.following
+        membership.following = true
+        membership.save!
+        recalculate_user_count!(channel_id || channel.id)
+      end
+    end
+
+    membership
   end
 
   def self.unfollow_channel(user:, channel_id: nil, channel: nil)
     ensure_channel_or_id_provided!(channel_id, channel)
+
+    membership = find_for_user(user: user, channel_id: channel_id, channel: channel)
+
+    return if membership.blank?
+
+    ActiveRecord::Base.transaction do
+      if membership.following
+        membership.update!(following: false)
+        recalculate_user_count!(channel_id || channel.id)
+      end
+    end
+
+    membership
+  end
+
+  def self.recalculate_user_count!(channel_id)
+    return if ChatChannel.exists?(id: channel_id, user_count_stale: true)
+    ChatChannel.update!(channel_id, user_count_stale: true)
+    Jobs.enqueue_in(3.seconds, :update_channel_user_count, chat_channel_id: channel_id)
+  end
+
+  def self.unfollow_all_for_channel(channel)
+    UserChatChannelMembership.where(chat_channel: channel).update_all(
+      following: false,
+      last_read_message_id: channel.chat_messages.last&.id,
+    )
   end
 
   def self.enforce_automatic_channel_memberships(channel_id: nil, channel: nil)

--- a/lib/chat_channel_membership_manager.rb
+++ b/lib/chat_channel_membership_manager.rb
@@ -5,64 +5,70 @@ class DiscourseChat::ChatChannelMembershipManager
     UserChatChannelMembership.where(user: user)
   end
 
-  def self.find_for_user(user:, channel:, following: nil)
+  attr_reader :channel
+
+  def initialize(channel)
+    @channel = channel
+  end
+
+  def find_for_user(user, following: nil)
     params = { user_id: user.id, chat_channel_id: channel.id }
     params[:following] = following if following.present?
 
     UserChatChannelMembership.includes(:user, :chat_channel).find_by(params)
   end
 
-  def self.follow_channel(user:, channel:)
+  def follow(user)
     membership =
-      find_for_user(user: user, channel: channel) ||
+      find_for_user(user) ||
         UserChatChannelMembership.new(user: user, chat_channel: channel, following: true)
 
     ActiveRecord::Base.transaction do
       if membership.new_record?
         membership.save!
-        recalculate_user_count(channel)
+        recalculate_user_count
       elsif !membership.following
         membership.update!(following: true)
-        recalculate_user_count(channel)
+        recalculate_user_count
       end
     end
 
     membership
   end
 
-  def self.unfollow_channel(user:, channel:)
-    membership = find_for_user(user: user, channel: channel)
+  def unfollow(user)
+    membership = find_for_user(user)
 
     return if membership.blank?
 
     ActiveRecord::Base.transaction do
       if membership.following
         membership.update!(following: false)
-        recalculate_user_count(channel)
+        recalculate_user_count
       end
     end
 
     membership
   end
 
-  def self.recalculate_user_count(channel)
+  def recalculate_user_count
     return if ChatChannel.exists?(id: channel.id, user_count_stale: true)
     channel.update!(user_count_stale: true)
     Jobs.enqueue_in(3.seconds, :update_channel_user_count, chat_channel_id: channel.id)
   end
 
-  def self.unfollow_all_for_channel(channel)
+  def unfollow_all_users
     UserChatChannelMembership.where(chat_channel: channel).update_all(
       following: false,
       last_read_message_id: channel.chat_messages.last&.id,
     )
   end
 
-  def self.enforce_automatic_channel_memberships(channel)
+  def enforce_automatic_channel_memberships
     Jobs.enqueue(:auto_manage_channel_memberships, chat_channel_id: channel.id)
   end
 
-  def self.enforce_automatic_user_membership(channel, user)
+  def enforce_automatic_user_membership(user)
     Jobs.enqueue(
       :auto_join_channel_batch,
       chat_channel_id: channel.id,

--- a/lib/chat_message_reactor.rb
+++ b/lib/chat_message_reactor.rb
@@ -45,7 +45,7 @@ class DiscourseChat::ChatMessageReactor
 
   def enforce_channel_membership!
     DiscourseChat::ChatChannelMembershipManager.follow_channel(
-      chat_channel: @chat_channel,
+      channel: @chat_channel,
       user: @user,
     )
   end

--- a/lib/chat_message_reactor.rb
+++ b/lib/chat_message_reactor.rb
@@ -44,7 +44,7 @@ class DiscourseChat::ChatMessageReactor
   end
 
   def enforce_channel_membership!
-    DiscourseChat::ChatChannelMembershipManager.follow_channel(channel: @chat_channel, user: @user)
+    DiscourseChat::ChatChannelMembershipManager.new(@chat_channel).follow(@user)
   end
 
   def validate_channel_status!

--- a/lib/chat_message_reactor.rb
+++ b/lib/chat_message_reactor.rb
@@ -44,17 +44,10 @@ class DiscourseChat::ChatMessageReactor
   end
 
   def enforce_channel_membership!
-    existing_membership =
-      DiscourseChat::ChatChannelMembershipManager.find_for_user(
-        chat_channel: @chat_channel,
-        user: @user,
-        initialize: true,
-      )
-
-    unless existing_membership&.following
-      existing_membership.following = true
-      existing_membership.save!
-    end
+    DiscourseChat::ChatChannelMembershipManager.follow_channel(
+      chat_channel: @chat_channel,
+      user: @user,
+    )
   end
 
   def validate_channel_status!

--- a/lib/chat_message_reactor.rb
+++ b/lib/chat_message_reactor.rb
@@ -45,7 +45,11 @@ class DiscourseChat::ChatMessageReactor
 
   def enforce_channel_membership!
     existing_membership =
-      UserChatChannelMembership.find_or_initialize_by(chat_channel: @chat_channel, user: @user)
+      DiscourseChat::ChatChannelMembershipManager.find_for_user(
+        chat_channel: @chat_channel,
+        user: @user,
+        initialize: true,
+      )
 
     unless existing_membership&.following
       existing_membership.following = true

--- a/lib/chat_message_reactor.rb
+++ b/lib/chat_message_reactor.rb
@@ -44,10 +44,7 @@ class DiscourseChat::ChatMessageReactor
   end
 
   def enforce_channel_membership!
-    DiscourseChat::ChatChannelMembershipManager.follow_channel(
-      channel: @chat_channel,
-      user: @user,
-    )
+    DiscourseChat::ChatChannelMembershipManager.follow_channel(channel: @chat_channel, user: @user)
   end
 
   def validate_channel_status!

--- a/lib/chat_seeder.rb
+++ b/lib/chat_seeder.rb
@@ -28,7 +28,7 @@ class ChatSeeder
     chat_channel = ChatChannel.create!(chatable: category, auto_join_users: true, name: name)
     category.custom_fields[DiscourseChat::HAS_CHAT_ENABLED] = true
     category.save!
-    UserChatChannelMembership.enforce_automatic_channel_memberships(chat_channel)
+    DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(chat_channel)
     chat_channel
   end
 end

--- a/lib/chat_seeder.rb
+++ b/lib/chat_seeder.rb
@@ -28,7 +28,9 @@ class ChatSeeder
     chat_channel = ChatChannel.create!(chatable: category, auto_join_users: true, name: name)
     category.custom_fields[DiscourseChat::HAS_CHAT_ENABLED] = true
     category.save!
-    DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(channel: chat_channel)
+    DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(
+      channel: chat_channel,
+    )
     chat_channel
   end
 end

--- a/lib/chat_seeder.rb
+++ b/lib/chat_seeder.rb
@@ -28,7 +28,9 @@ class ChatSeeder
     chat_channel = ChatChannel.create!(chatable: category, auto_join_users: true, name: name)
     category.custom_fields[DiscourseChat::HAS_CHAT_ENABLED] = true
     category.save!
-    DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(chat_channel)
+    DiscourseChat::ChatChannelMembershipManager.new(
+      chat_channel,
+    ).enforce_automatic_channel_memberships
     chat_channel
   end
 end

--- a/lib/chat_seeder.rb
+++ b/lib/chat_seeder.rb
@@ -28,7 +28,7 @@ class ChatSeeder
     chat_channel = ChatChannel.create!(chatable: category, auto_join_users: true, name: name)
     category.custom_fields[DiscourseChat::HAS_CHAT_ENABLED] = true
     category.save!
-    DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(chat_channel)
+    DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(channel: chat_channel)
     chat_channel
   end
 end

--- a/lib/chat_seeder.rb
+++ b/lib/chat_seeder.rb
@@ -28,9 +28,7 @@ class ChatSeeder
     chat_channel = ChatChannel.create!(chatable: category, auto_join_users: true, name: name)
     category.custom_fields[DiscourseChat::HAS_CHAT_ENABLED] = true
     category.save!
-    DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(
-      channel: chat_channel,
-    )
+    DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(chat_channel)
     chat_channel
   end
 end

--- a/lib/direct_message_channel_creator.rb
+++ b/lib/direct_message_channel_creator.rb
@@ -24,6 +24,7 @@ module DiscourseChat::DirectMessageChannelCreator
   private
 
   def self.update_memberships(acting_user, target_users, chat_channel_id)
+    # TODO (martin) Move this to MembershipManager
     sql_params = {
       acting_user_id: acting_user.id,
       user_ids: target_users.map(&:id),

--- a/lib/direct_message_channel_creator.rb
+++ b/lib/direct_message_channel_creator.rb
@@ -24,7 +24,6 @@ module DiscourseChat::DirectMessageChannelCreator
   private
 
   def self.update_memberships(acting_user, target_users, chat_channel_id)
-    # TODO (martin) Move this to MembershipManager
     sql_params = {
       acting_user_id: acting_user.id,
       user_ids: target_users.map(&:id),

--- a/lib/discourse_dev/public_channel.rb
+++ b/lib/discourse_dev/public_channel.rb
@@ -38,7 +38,7 @@ module DiscourseDev
 
             DiscourseChat::ChatChannelMembershipManager.follow_channel(
               user: admin_user || User.new.create!,
-              chat_channel: channel,
+              channel: channel,
             )
           end
       end

--- a/lib/discourse_dev/public_channel.rb
+++ b/lib/discourse_dev/public_channel.rb
@@ -36,11 +36,13 @@ module DiscourseDev
               admin_user = ::User.find_by(username: admin_username) if admin_username
             end
 
-            ::UserChatChannelMembership.find_or_create_by!(
+            membership = DiscourseChat::ChatChannelMembershipManager.find_for_user(
               user: admin_user || User.new.create!,
               chat_channel: channel,
               following: true,
+              initialize: true
             )
+            membership.save!
           end
       end
     end

--- a/lib/discourse_dev/public_channel.rb
+++ b/lib/discourse_dev/public_channel.rb
@@ -36,9 +36,8 @@ module DiscourseDev
               admin_user = ::User.find_by(username: admin_username) if admin_username
             end
 
-            DiscourseChat::ChatChannelMembershipManager.follow_channel(
-              user: admin_user || User.new.create!,
-              channel: channel,
+            DiscourseChat::ChatChannelMembershipManager.new(channel).follow(
+              admin_user || User.new.create!,
             )
           end
       end

--- a/lib/discourse_dev/public_channel.rb
+++ b/lib/discourse_dev/public_channel.rb
@@ -36,13 +36,10 @@ module DiscourseDev
               admin_user = ::User.find_by(username: admin_username) if admin_username
             end
 
-            membership = DiscourseChat::ChatChannelMembershipManager.find_for_user(
+            DiscourseChat::ChatChannelMembershipManager.follow_channel(
               user: admin_user || User.new.create!,
               chat_channel: channel,
-              following: true,
-              initialize: true
             )
-            membership.save!
           end
       end
     end

--- a/plugin.rb
+++ b/plugin.rb
@@ -178,6 +178,7 @@ after_initialize do
   load File.expand_path("../app/jobs/regular/chat_channel_delete.rb", __FILE__)
   load File.expand_path("../app/jobs/regular/chat_notify_mentioned.rb", __FILE__)
   load File.expand_path("../app/jobs/regular/chat_notify_watching.rb", __FILE__)
+  load File.expand_path("../app/jobs/regular/update_channel_user_count.rb", __FILE__)
   load File.expand_path("../app/jobs/scheduled/delete_old_chat_messages.rb", __FILE__)
   load File.expand_path("../app/jobs/scheduled/update_user_counts_for_chat_channels.rb", __FILE__)
   load File.expand_path("../app/jobs/scheduled/email_chat_notifications.rb", __FILE__)

--- a/plugin.rb
+++ b/plugin.rb
@@ -159,6 +159,7 @@ after_initialize do
   load File.expand_path("../lib/chat_transcript_service.rb", __FILE__)
   load File.expand_path("../lib/duplicate_message_validator.rb", __FILE__)
   load File.expand_path("../lib/message_mover.rb", __FILE__)
+  load File.expand_path("../lib/chat_channel_membership_manager.rb", __FILE__)
   load File.expand_path("../lib/chat_message_bookmarkable.rb", __FILE__)
   load File.expand_path("../lib/chat_channel_archive_service.rb", __FILE__)
   load File.expand_path("../lib/direct_message_channel_creator.rb", __FILE__)
@@ -400,10 +401,9 @@ after_initialize do
   add_to_serializer(:current_user, :needs_dm_retention_reminder) { true }
 
   add_to_serializer(:current_user, :has_joinable_public_channels) do
-    memberships = UserChatChannelMembership.where(user_id: self.scope.user.id)
     DiscourseChat::ChatChannelFetcher.secured_public_channels(
       self.scope,
-      memberships,
+      DiscourseChat::ChatChannelMembershipManager.all_for_user(self.scope.user),
       following: false,
       limit: 1,
       status: :open,

--- a/plugin.rb
+++ b/plugin.rb
@@ -523,7 +523,7 @@ after_initialize do
       ChatChannel
         .where(auto_join_users: true)
         .each do |channel|
-          UserChatChannelMembership.enforce_automatic_user_membership(channel, user)
+          DiscourseChat::ChatChannelMembershipManager.enforce_automatic_user_membership(channel, user)
         end
     end
   end
@@ -533,7 +533,7 @@ after_initialize do
       ChatChannel
         .where(auto_join_users: true)
         .each do |channel|
-          UserChatChannelMembership.enforce_automatic_user_membership(channel, user)
+          DiscourseChat::ChatChannelMembershipManager.enforce_automatic_user_membership(channel, user)
         end
     end
   end
@@ -549,7 +549,7 @@ after_initialize do
         .where(category_groups: { group_id: group.id })
 
     channels_to_add.each do |channel|
-      UserChatChannelMembership.enforce_automatic_user_membership(channel, user)
+      DiscourseChat::ChatChannelMembershipManager.enforce_automatic_user_membership(channel, user)
     end
   end
 
@@ -560,7 +560,7 @@ after_initialize do
     category_channel = ChatChannel.find_by(auto_join_users: true, chatable: category)
 
     if category_channel
-      UserChatChannelMembership.enforce_automatic_channel_memberships(category_channel)
+      DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(channel: category_channel)
     end
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -523,7 +523,10 @@ after_initialize do
       ChatChannel
         .where(auto_join_users: true)
         .each do |channel|
-          DiscourseChat::ChatChannelMembershipManager.enforce_automatic_user_membership(channel, user)
+          DiscourseChat::ChatChannelMembershipManager.enforce_automatic_user_membership(
+            channel,
+            user,
+          )
         end
     end
   end
@@ -533,7 +536,10 @@ after_initialize do
       ChatChannel
         .where(auto_join_users: true)
         .each do |channel|
-          DiscourseChat::ChatChannelMembershipManager.enforce_automatic_user_membership(channel, user)
+          DiscourseChat::ChatChannelMembershipManager.enforce_automatic_user_membership(
+            channel,
+            user,
+          )
         end
     end
   end
@@ -560,7 +566,9 @@ after_initialize do
     category_channel = ChatChannel.find_by(auto_join_users: true, chatable: category)
 
     if category_channel
-      DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(channel: category_channel)
+      DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(
+        channel: category_channel,
+      )
     end
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -523,10 +523,9 @@ after_initialize do
       ChatChannel
         .where(auto_join_users: true)
         .each do |channel|
-          DiscourseChat::ChatChannelMembershipManager.enforce_automatic_user_membership(
+          DiscourseChat::ChatChannelMembershipManager.new(
             channel,
-            user,
-          )
+          ).enforce_automatic_user_membership(user)
         end
     end
   end
@@ -536,10 +535,9 @@ after_initialize do
       ChatChannel
         .where(auto_join_users: true)
         .each do |channel|
-          DiscourseChat::ChatChannelMembershipManager.enforce_automatic_user_membership(
+          DiscourseChat::ChatChannelMembershipManager.new(
             channel,
-            user,
-          )
+          ).enforce_automatic_user_membership(user)
         end
     end
   end
@@ -555,7 +553,9 @@ after_initialize do
         .where(category_groups: { group_id: group.id })
 
     channels_to_add.each do |channel|
-      DiscourseChat::ChatChannelMembershipManager.enforce_automatic_user_membership(channel, user)
+      DiscourseChat::ChatChannelMembershipManager.new(channel).enforce_automatic_user_membership(
+        user,
+      )
     end
   end
 
@@ -566,9 +566,9 @@ after_initialize do
     category_channel = ChatChannel.find_by(auto_join_users: true, chatable: category)
 
     if category_channel
-      DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(
+      DiscourseChat::ChatChannelMembershipManager.new(
         category_channel,
-      )
+      ).enforce_automatic_channel_memberships
     end
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -567,7 +567,7 @@ after_initialize do
 
     if category_channel
       DiscourseChat::ChatChannelMembershipManager.enforce_automatic_channel_memberships(
-        channel: category_channel,
+        category_channel,
       )
     end
   end

--- a/spec/jobs/regular/update_channel_user_count_spec.rb
+++ b/spec/jobs/regular/update_channel_user_count_spec.rb
@@ -6,9 +6,15 @@ RSpec.describe Jobs::UpdateChannelUserCount do
   fab!(:user2) { Fabricate(:user) }
   fab!(:user3) { Fabricate(:user) }
   fab!(:user4) { Fabricate(:user) }
-  fab!(:membership1) { Fabricate(:user_chat_channel_membership, chat_channel: channel, user: user1) }
-  fab!(:membership2) { Fabricate(:user_chat_channel_membership, chat_channel: channel, user: user2) }
-  fab!(:membership3) { Fabricate(:user_chat_channel_membership, chat_channel: channel, user: user3) }
+  fab!(:membership1) do
+    Fabricate(:user_chat_channel_membership, chat_channel: channel, user: user1)
+  end
+  fab!(:membership2) do
+    Fabricate(:user_chat_channel_membership, chat_channel: channel, user: user2)
+  end
+  fab!(:membership3) do
+    Fabricate(:user_chat_channel_membership, chat_channel: channel, user: user3)
+  end
 
   it "does nothing if the channel does not exist" do
     channel.destroy

--- a/spec/jobs/regular/update_channel_user_count_spec.rb
+++ b/spec/jobs/regular/update_channel_user_count_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::UpdateChannelUserCount do
+  fab!(:channel) { Fabricate(:chat_channel, user_count: 0, user_count_stale: true) }
+  fab!(:user1) { Fabricate(:user) }
+  fab!(:user2) { Fabricate(:user) }
+  fab!(:user3) { Fabricate(:user) }
+  fab!(:user4) { Fabricate(:user) }
+  fab!(:membership1) { Fabricate(:user_chat_channel_membership, chat_channel: channel, user: user1) }
+  fab!(:membership2) { Fabricate(:user_chat_channel_membership, chat_channel: channel, user: user2) }
+  fab!(:membership3) { Fabricate(:user_chat_channel_membership, chat_channel: channel, user: user3) }
+
+  it "does nothing if the channel does not exist" do
+    channel.destroy
+    ChatPublisher.expects(:publish_chat_channel_metadata).never
+    expect(described_class.new.execute(chat_channel_id: channel.id)).to eq(nil)
+  end
+
+  it "does nothing if the user count has not been marked stale" do
+    channel.update!(user_count_stale: false)
+    ChatPublisher.expects(:publish_chat_channel_metadata).never
+    expect(described_class.new.execute(chat_channel_id: channel.id)).to eq(nil)
+  end
+
+  it "updates the channel user_count and sets user_count_stale back to false" do
+    ChatPublisher.expects(:publish_chat_channel_metadata).with(channel)
+    described_class.new.execute(chat_channel_id: channel.id)
+    channel.reload
+    expect(channel.user_count).to eq(3)
+    expect(channel.user_count_stale).to eq(false)
+  end
+end

--- a/spec/lib/chat_channel_membership_manager_spec.rb
+++ b/spec/lib/chat_channel_membership_manager_spec.rb
@@ -6,49 +6,26 @@ RSpec.describe DiscourseChat::ChatChannelMembershipManager do
   fab!(:channel2) { Fabricate(:chat_channel) }
 
   describe ".find_for_user" do
-    context "when initialize is true" do
-      it "returns a new membership record for the user, channel, and following params" do
-        membership =
-          described_class.find_for_user(
-            user: user,
-            channel: channel1,
-            following: true,
-            initialize: true,
-          )
-        expect(membership.new_record?).to eq(true)
-        expect(membership.chat_channel_id).to eq(channel1.id)
-        expect(membership.user_id).to eq(user.id)
-        expect(membership.following).to eq(true)
-      end
+    let!(:membership) do
+      Fabricate(:user_chat_channel_membership, user: user, chat_channel: channel1, following: true)
     end
 
-    context "when initialize is false" do
-      let!(:membership) do
-        Fabricate(
-          :user_chat_channel_membership,
-          user: user,
-          chat_channel: channel1,
-          following: true,
-        )
-      end
+    it "returns nil if it cannot find a membership for the user and channel" do
+      expect(described_class.find_for_user(user: user, channel: channel2)).to be_blank
+    end
 
-      it "returns nil if it cannot find a membership for the user and channel" do
-        expect(described_class.find_for_user(user: user, channel: channel2)).to be_blank
-      end
+    it "returns the membership for the channel and user" do
+      membership = described_class.find_for_user(user: user, channel: channel1)
+      expect(membership.chat_channel_id).to eq(channel1.id)
+      expect(membership.user_id).to eq(user.id)
+      expect(membership.following).to eq(true)
+    end
 
-      it "returns the membership for the channel and user" do
-        membership = described_class.find_for_user(user: user, channel: channel1)
-        expect(membership.chat_channel_id).to eq(channel1.id)
-        expect(membership.user_id).to eq(user.id)
-        expect(membership.following).to eq(true)
-      end
-
-      it "scopes by following and returns nil if it does not match the scope" do
-        membership.update!(following: false)
-        expect(
-          described_class.find_for_user(user: user, channel: channel1, following: true),
-        ).to be_blank
-      end
+    it "scopes by following and returns nil if it does not match the scope" do
+      membership.update!(following: false)
+      expect(
+        described_class.find_for_user(user: user, channel: channel1, following: true),
+      ).to be_blank
     end
   end
 

--- a/spec/lib/chat_channel_membership_manager_spec.rb
+++ b/spec/lib/chat_channel_membership_manager_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseChat::ChatChannelMembershipManager do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:channel1) { Fabricate(:chat_channel) }
+  fab!(:channel2) { Fabricate(:chat_channel) }
+
+  describe ".find_for_user" do
+    context "when initialize is true" do
+      it "returns a new membership record for the user, channel, and following params" do
+        membership =
+          described_class.find_for_user(
+            user: user,
+            channel: channel1,
+            following: true,
+            initialize: true,
+          )
+        expect(membership.new_record?).to eq(true)
+        expect(membership.chat_channel_id).to eq(channel1.id)
+        expect(membership.user_id).to eq(user.id)
+        expect(membership.following).to eq(true)
+      end
+    end
+
+    context "when initialize is false" do
+      let!(:membership) do
+        Fabricate(
+          :user_chat_channel_membership,
+          user: user,
+          chat_channel: channel1,
+          following: true,
+        )
+      end
+
+      it "returns nil if it cannot find a membership for the user and channel" do
+        expect(described_class.find_for_user(user: user, channel: channel2)).to be_blank
+      end
+
+      it "returns the membership for the channel and user" do
+        membership = described_class.find_for_user(user: user, channel: channel1)
+        expect(membership.chat_channel_id).to eq(channel1.id)
+        expect(membership.user_id).to eq(user.id)
+        expect(membership.following).to eq(true)
+      end
+
+      it "scopes by following and returns nil if it does not match the scope" do
+        membership.update!(following: false)
+        expect(
+          described_class.find_for_user(user: user, channel: channel1, following: true),
+        ).to be_blank
+      end
+    end
+  end
+
+  describe ".follow_channel" do
+    it "creates a membership if one does not exist for the user and channel already" do
+      membership = nil
+      expect {
+        membership = described_class.follow_channel(user: user, channel: channel1)
+      }.to change { UserChatChannelMembership.count }.by(1)
+      expect(membership.following).to eq(true)
+      expect(membership.chat_channel).to eq(channel1)
+      expect(membership.user).to eq(user)
+    end
+
+    it "enqueues user_count recalculation and marks user_count_stale as true" do
+      described_class.follow_channel(user: user, channel: channel1)
+      expect(channel1.reload.user_count_stale).to eq(true)
+      expect_job_enqueued(job: :update_channel_user_count, args: { chat_channel_id: channel1.id })
+    end
+
+    it "updates the membership to following if it already existed" do
+      membership =
+        Fabricate(
+          :user_chat_channel_membership,
+          user: user,
+          chat_channel: channel1,
+          following: false,
+        )
+      expect {
+        membership = described_class.follow_channel(user: user, channel: channel1)
+      }.not_to change { UserChatChannelMembership.count }
+      expect(membership.reload.following).to eq(true)
+    end
+  end
+
+  describe ".unfollow_channel" do
+    it "does nothing if the user is not following the channel" do
+      expect(described_class.unfollow_channel(user: user, channel: channel2)).to be_blank
+    end
+
+    it "updates following for the membership to false and recalculates the user count" do
+      membership =
+        Fabricate(
+          :user_chat_channel_membership,
+          user: user,
+          chat_channel: channel1,
+          following: true,
+        )
+      described_class.unfollow_channel(user: user, channel: channel1)
+      membership.reload
+      expect(membership.following).to eq(false)
+      expect(channel1.reload.user_count_stale).to eq(true)
+      expect_job_enqueued(job: :update_channel_user_count, args: { chat_channel_id: channel1.id })
+    end
+
+    it "does not recalculate user count if the user was already not following the channel" do
+      membership =
+        Fabricate(
+          :user_chat_channel_membership,
+          user: user,
+          chat_channel: channel1,
+          following: false,
+        )
+      expect_not_enqueued_with(
+        job: :update_channel_user_count,
+        args: {
+          chat_channel_id: channel1.id,
+        },
+      ) { described_class.unfollow_channel(user: user, channel: channel1) }
+      expect(channel1.reload.user_count_stale).to eq(false)
+    end
+  end
+end

--- a/spec/models/chat_channel_spec.rb
+++ b/spec/models/chat_channel_spec.rb
@@ -284,7 +284,12 @@ describe ChatChannel do
       expect(membership.user).to eq(user1)
       expect(membership.chat_channel).to eq(private_category_channel)
       expect(private_category_channel.user_count_stale).to eq(true)
-      expect_job_enqueued(job: :update_channel_user_count, args: { chat_channel_id: private_category_channel.id })
+      expect_job_enqueued(
+        job: :update_channel_user_count,
+        args: {
+          chat_channel_id: private_category_channel.id,
+        },
+      )
     end
 
     it "updates an existing membership for the user and enqueues a job to update the count" do
@@ -300,7 +305,12 @@ describe ChatChannel do
 
       expect(membership.reload.following).to eq(true)
       expect(private_category_channel.user_count_stale).to eq(true)
-      expect_job_enqueued(job: :update_channel_user_count, args: { chat_channel_id: private_category_channel.id })
+      expect_job_enqueued(
+        job: :update_channel_user_count,
+        args: {
+          chat_channel_id: private_category_channel.id,
+        },
+      )
     end
 
     it "does nothing if the user is already a member" do
@@ -312,16 +322,22 @@ describe ChatChannel do
         )
 
       expect(private_category_channel.user_count_stale).to eq(false)
-      expect_not_enqueued_with(job: :update_channel_user_count, args: { chat_channel_id: private_category_channel.id }) do
-        private_category_channel.add(user1)
-      end
+      expect_not_enqueued_with(
+        job: :update_channel_user_count,
+        args: {
+          chat_channel_id: private_category_channel.id,
+        },
+      ) { private_category_channel.add(user1) }
     end
 
     it "does not recalculate user count if it's already been marked as stale" do
       private_category_channel.update!(user_count_stale: true)
-      expect_not_enqueued_with(job: :update_channel_user_count, args: { chat_channel_id: private_category_channel.id }) do
-        private_category_channel.add(user1)
-      end
+      expect_not_enqueued_with(
+        job: :update_channel_user_count,
+        args: {
+          chat_channel_id: private_category_channel.id,
+        },
+      ) { private_category_channel.add(user1) }
     end
   end
 
@@ -339,7 +355,12 @@ describe ChatChannel do
 
       expect(@membership.reload.following).to eq(false)
       expect(private_category_channel.user_count_stale).to eq(true)
-      expect_job_enqueued(job: :update_channel_user_count, args: { chat_channel_id: private_category_channel.id })
+      expect_job_enqueued(
+        job: :update_channel_user_count,
+        args: {
+          chat_channel_id: private_category_channel.id,
+        },
+      )
     end
 
     it "returns nil if the user doesn't have a membership" do
@@ -353,14 +374,22 @@ describe ChatChannel do
       private_category_channel.reload
 
       expect(private_category_channel.user_count_stale).to eq(false)
-      expect_job_enqueued(job: :update_channel_user_count, args: { chat_channel_id: private_category_channel.id })
+      expect_job_enqueued(
+        job: :update_channel_user_count,
+        args: {
+          chat_channel_id: private_category_channel.id,
+        },
+      )
     end
 
     it "does not recalculate user count if it's already been marked as stale" do
       private_category_channel.update!(user_count_stale: true)
-      expect_not_enqueued_with(job: :update_channel_user_count, args: { chat_channel_id: private_category_channel.id }) do
-        private_category_channel.remove(user1)
-      end
+      expect_not_enqueued_with(
+        job: :update_channel_user_count,
+        args: {
+          chat_channel_id: private_category_channel.id,
+        },
+      ) { private_category_channel.remove(user1) }
     end
   end
 end

--- a/spec/models/chat_channel_spec.rb
+++ b/spec/models/chat_channel_spec.rb
@@ -269,22 +269,23 @@ describe ChatChannel do
     expect(channel).to be_valid
   end
 
-  describe "#join" do
+  describe "#add" do
     before { group.add(user1) }
 
-    it "creates a membership for the user and updates the count" do
+    it "creates a membership for the user and enqueues a job to update the count" do
       initial_count = private_category_channel.user_count
 
       membership = private_category_channel.add(user1)
+      private_category_channel.reload
 
       expect(membership.following).to eq(true)
       expect(membership.user).to eq(user1)
       expect(membership.chat_channel).to eq(private_category_channel)
-      expect(private_category_channel.reload.user_count).to eq(initial_count + 1)
+      expect(private_category_channel.user_count_stale).to eq(true)
+      expect_job_enqueued(job: :update_channel_user_count, args: { chat_channel_id: private_category_channel.id })
     end
 
-    it "updates an existing membership for the user and updates the count" do
-      initial_count = private_category_channel.user_count
+    it "updates an existing membership for the user and enqueues a job to update the count" do
       membership =
         UserChatChannelMembership.create!(
           chat_channel: private_category_channel,
@@ -293,13 +294,14 @@ describe ChatChannel do
         )
 
       private_category_channel.add(user1)
+      private_category_channel.reload
 
       expect(membership.reload.following).to eq(true)
-      expect(private_category_channel.reload.user_count).to eq(initial_count + 1)
+      expect(private_category_channel.user_count_stale).to eq(true)
+      expect_job_enqueued(job: :update_channel_user_count, args: { chat_channel_id: private_category_channel.id })
     end
 
     it "does nothing if the user is already a member" do
-      initial_count = private_category_channel.user_count
       membership =
         UserChatChannelMembership.create!(
           chat_channel: private_category_channel,
@@ -307,9 +309,17 @@ describe ChatChannel do
           following: true,
         )
 
-      private_category_channel.add(user1)
+      expect(private_category_channel.user_count_stale).to eq(false)
+      expect_not_enqueued_with(job: :update_channel_user_count, args: { chat_channel_id: private_category_channel.id }) do
+        private_category_channel.add(user1)
+      end
+    end
 
-      expect(private_category_channel.reload.user_count).to eq(initial_count)
+    it "does not recalculate user count if it's already been marked as stale" do
+      private_category_channel.update!(user_count_stale: true)
+      expect_not_enqueued_with(job: :update_channel_user_count, args: { chat_channel_id: private_category_channel.id }) do
+        private_category_channel.add(user1)
+      end
     end
   end
 
@@ -318,28 +328,37 @@ describe ChatChannel do
       group.add(user1)
       @membership = private_category_channel.add(user1)
       private_category_channel.reload
+      private_category_channel.update!(user_count_stale: false)
     end
 
     it "updates the membership for the user and decreases the count" do
-      initial_count = private_category_channel.user_count
-
       membership = private_category_channel.remove(user1)
+      private_category_channel.reload
 
       expect(@membership.reload.following).to eq(false)
-      expect(private_category_channel.reload.user_count).to eq(initial_count - 1)
+      expect(private_category_channel.user_count_stale).to eq(true)
+      expect_job_enqueued(job: :update_channel_user_count, args: { chat_channel_id: private_category_channel.id })
     end
 
-    it "fails if the user doesn't have a membership" do
-      expect { private_category_channel.remove(user2) }.to raise_error(ActiveRecord::RecordNotFound)
+    it "returns nil if the user doesn't have a membership" do
+      expect(private_category_channel.remove(user2)).to eq(nil)
     end
 
     it "does nothing if the user is not following the channel" do
-      initial_count = private_category_channel.user_count
       @membership.update!(following: false)
 
       private_category_channel.remove(user1)
+      private_category_channel.reload
 
-      expect(private_category_channel.reload.user_count).to eq(initial_count)
+      expect(private_category_channel.user_count_stale).to eq(false)
+      expect_job_enqueued(job: :update_channel_user_count, args: { chat_channel_id: private_category_channel.id })
+    end
+
+    it "does not recalculate user count if it's already been marked as stale" do
+      private_category_channel.update!(user_count_stale: true)
+      expect_not_enqueued_with(job: :update_channel_user_count, args: { chat_channel_id: private_category_channel.id }) do
+        private_category_channel.remove(user1)
+      end
     end
   end
 end

--- a/spec/requests/chat_channel_controller_spec.rb
+++ b/spec/requests/chat_channel_controller_spec.rb
@@ -233,7 +233,6 @@ RSpec.describe DiscourseChat::ChatChannelsController do
         membership_record.reload.following
       }.to(true).from(false)
       expect(response.status).to eq(200)
-      expect(response.parsed_body["memberships_count"]).to eq(1)
       expect(response.parsed_body["current_user_membership"]["following"]).to eq(true)
       expect(response.parsed_body["current_user_membership"]["chat_channel_id"]).to eq(
         chat_channel.id,
@@ -255,7 +254,6 @@ RSpec.describe DiscourseChat::ChatChannelsController do
         membership_record.reload.following
       }.to(false).from(true)
       expect(response.status).to eq(200)
-      expect(response.parsed_body["memberships_count"]).to eq(0)
       expect(response.parsed_body["current_user_membership"]["following"]).to eq(false)
       expect(response.parsed_body["current_user_membership"]["chat_channel_id"]).to eq(
         chat_channel.id,

--- a/spec/support/api/schemas/category_chat_channel.json
+++ b/spec/support/api/schemas/category_chat_channel.json
@@ -11,7 +11,6 @@
     "chatable_id": { "type": "number" },
     "last_message_sent_at": { "type": "string" },
     "status": { "type": "string" },
-    "memberships_count": { "type": "number" },
     "chatable": {
       "type": "object",
       "required": ["id", "name", "slug", "color"]


### PR DESCRIPTION
This commit intends to refactor and unify updates to chat channel
membership into a single `DiscourseChat::ChatChannelMembershipManager` class,
as well as making the `user_count` updates of the `ChatChannel` table
more consistent, as previously they happened in many places and it was
not always happening.

The `user_count` update is moved into a job, along with adding a new
`user_count_stale` column to the `ChatChannel` table. Whenever someone
is added/removed from the membership table, we update `user_count_stale`
to true _if it is not already_ and then enqueue a job in 3 seconds to update
the user count, which then sets `user_count_stale` back to false. This way
the query to count all the members, which can be expensive, is done out
of band, and the updates are throttled so we don't thrash the count unnecessarily.

We then send a MessageBus message to the client about the channel
metadata change, and if the user is on the member list for the channel
we update the count and reload the list of members.