### PR TITLE
DEV: Make specs compatible with AR enums

### DIFF
--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe DiscourseChat::ChatController do
 
       get "/chat/#{chat_channel.id}/messages.json", params: { page_size: page_size }
       expect(response.parsed_body["chat_messages"].last["user_flag_status"]).to eq(
-        reviewable_score.status,
+        reviewable_score.status_for_database,
       )
       expect(response.parsed_body["chat_messages"].second_to_last["user_flag_status"]).to be_nil
     end


### PR DESCRIPTION
Reviewable models from core are going to use `ActiveRecord` enums and this change breaks one of our specs from this plugin. (see https://github.com/discourse/discourse/pull/15330)

This issue is addressed by using `#status_for_database` which returns the value stored in the DB. This small change makes the specs compatible with the current version of core and with the version that will use `ActiveRecord` enums.