### PR TITLE
UX: Add title for the chat notifications tab in the user menu

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -433,3 +433,9 @@ en:
       allowed_pm_users_instructions: "Only allow personal messages or chat direct messages from these users."
       allow_private_messages_from_specific_users: "Only allow specific users to send me personal messages or chat direct messages"
       ignored_users_instructions: "Suppress all posts, messages, notifications, personal messages, and chat direct messages from these users."
+    user_menu:
+      tabs:
+        chat_notifications: "Chat notifications"
+        chat_notifications_with_unread:
+          one: "Chat notifications - %{count} unread notification"
+          other: "Chat notifications - %{count} unread notifications"


### PR DESCRIPTION
As of https://github.com/discourse/discourse/commit/496f910f03dfbc0a8021561fa7795a68894ef0e4, core automatically adds title to user menu tabs if an i18n string exists at the key `user_menu.tabs.${tab_id}`. This PR adds a string in the right place so core picks it up and uses it for the chat notifications tab.