### PR TITLE
Revert "DEV: Temporarily skip reactions tests (#1254)"

### DIFF
--- a/spec/integration/post_chat_quote_spec.rb
+++ b/spec/integration/post_chat_quote_spec.rb
@@ -146,9 +146,9 @@ describe "chat bbcode quoting in posts" do
       <p>This is a chat message.</p>
       <div class="chat-transcript-reactions">
       <div class="chat-transcript-reaction">
-      <img width="20" height="20" src="/images/emoji/twitter/+1.png?v=12" title="+1" loading="lazy" alt="+1" class="emoji" tabindex="0"> 1</div>
+      <img width="20" height="20" src="/images/emoji/twitter/+1.png?v=12" title="+1" loading="lazy" alt="+1" class="emoji"> 1</div>
       <div class="chat-transcript-reaction">
-      <img width="20" height="20" src="/images/emoji/twitter/heart.png?v=12" title="heart" loading="lazy" alt="heart" class="emoji" tabindex="0"> 2</div>
+      <img width="20" height="20" src="/images/emoji/twitter/heart.png?v=12" title="heart" loading="lazy" alt="heart" class="emoji"> 2</div>
       </div>
       </div>
       </div>

--- a/spec/integration/post_chat_quote_spec.rb
+++ b/spec/integration/post_chat_quote_spec.rb
@@ -124,7 +124,7 @@ describe "chat bbcode quoting in posts" do
     COOKED
   end
 
-  xit "renders with the reactions attribute" do
+  it "renders with the reactions attribute" do
     reactions_attr = "+1:martin;heart:martin,eviltrout"
     post.update!(
       raw:

--- a/spec/models/chat_message_spec.rb
+++ b/spec/models/chat_message_spec.rb
@@ -331,7 +331,7 @@ describe ChatMessage do
     it "supports emoji shortcuts" do
       cooked = ChatMessage.cook("this is a replace test :P :|")
       expect(cooked).to eq(<<~HTML.chomp)
-        <p>this is a replace test <img src="/images/emoji/twitter/stuck_out_tongue.png?v=12" title=":stuck_out_tongue:" alt=":stuck_out_tongue:" loading=\"lazy\" width=\"20\" height=\"20\" class="emoji" tabindex="0"> <img src="/images/emoji/twitter/expressionless.png?v=12" title=":expressionless:" alt=":expressionless:" loading=\"lazy\" width=\"20\" height=\"20\" class="emoji" tabindex="0"></p>
+        <p>this is a replace test <img src="/images/emoji/twitter/stuck_out_tongue.png?v=12" title=":stuck_out_tongue:" class="emoji" alt=":stuck_out_tongue:" loading=\"lazy\" width=\"20\" height=\"20\"> <img src="/images/emoji/twitter/expressionless.png?v=12" title=":expressionless:" class="emoji" alt=":expressionless:" loading=\"lazy\" width=\"20\" height=\"20\"></p>
       HTML
     end
 

--- a/spec/models/chat_message_spec.rb
+++ b/spec/models/chat_message_spec.rb
@@ -219,7 +219,7 @@ describe ChatMessage do
       )
     end
 
-    xit "supports emoji plugin" do
+    it "supports emoji plugin" do
       cooked = ChatMessage.cook(":grin:")
 
       expect(cooked).to eq(
@@ -321,14 +321,14 @@ describe ChatMessage do
       HTML
     end
 
-    xit "supports inline emoji" do
+    it "supports inline emoji" do
       cooked = ChatMessage.cook(":D")
       expect(cooked).to eq(<<~HTML.chomp)
       <p><img src="/images/emoji/twitter/smiley.png?v=12" title=":smiley:" class="emoji only-emoji" alt=":smiley:" loading=\"lazy\" width=\"20\" height=\"20\"></p>
       HTML
     end
 
-    xit "supports emoji shortcuts" do
+    it "supports emoji shortcuts" do
       cooked = ChatMessage.cook("this is a replace test :P :|")
       expect(cooked).to eq(<<~HTML.chomp)
         <p>this is a replace test <img src="/images/emoji/twitter/stuck_out_tongue.png?v=12" title=":stuck_out_tongue:" alt=":stuck_out_tongue:" loading=\"lazy\" width=\"20\" height=\"20\" class="emoji" tabindex="0"> <img src="/images/emoji/twitter/expressionless.png?v=12" title=":expressionless:" alt=":expressionless:" loading=\"lazy\" width=\"20\" height=\"20\" class="emoji" tabindex="0"></p>

--- a/test/javascripts/acceptance/chat-transcript-test.js
+++ b/test/javascripts/acceptance/chat-transcript-test.js
@@ -267,7 +267,7 @@ acceptance("Discourse Chat | discourse-chat-transcript", function (needs) {
     );
   });
 
-  test.skip("renders with the reactions attribute", function (assert) {
+  test("renders with the reactions attribute", function (assert) {
     const reactionsAttr = "+1:martin;heart:martin,eviltrout";
     assert.cookedChatTranscript(
       `[chat quote="martin;2321;2022-01-25T05:40:39Z" channel="Cool Cats Club" channelId="1234" reactions="${reactionsAttr}"]\nThis is a chat message.\n[/chat]`,


### PR DESCRIPTION
Core is now passing, and we can revert the skipping of tests.