### PR TITLE
DEV: Skip a test temporarily

### DIFF
--- a/test/javascripts/acceptance/chat-live-pane-test.js
+++ b/test/javascripts/acceptance/chat-live-pane-test.js
@@ -5,7 +5,7 @@ import {
   publishToMessageBus,
   query,
 } from "discourse/tests/helpers/qunit-helpers";
-import { test } from "qunit";
+import { skip, test } from "qunit";
 
 function buildMessage(messageId) {
   return {
@@ -214,7 +214,7 @@ acceptance(
       });
     });
 
-    test("Handles 429 errors by displaying an alert", async function (assert) {
+    skip("Handles 429 errors by displaying an alert", async function (assert) {
       await visit("/chat/channel/1/cat");
 
       assert.ok(exists(`.bootbox`), "We displayed a 429 error");


### PR DESCRIPTION
This test relies on a dialog in core that is about to change in https://github.com/discourse/discourse/pull/18292. So, to get stuff passing in CI and builds, I'm following this process: 

- skipping the tests (this PR)
- getting the core PR to ✅ in CI
- merging core PR
- reverting the skip and adjusting the test in discourse-chat