### PR TITLE
FIX: Full page chat height on DiscourseHub iPad

### DIFF
--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -919,8 +919,7 @@ html.has-full-page-chat {
       #main-outlet-wrapper {
         // restrict the row height, including when virtual keyboard is open
         grid-template-rows: calc(
-          var(--chat-vh, 1vh) * 100 -
-            calc(var(--header-offset) + var(--footer-nav-height))
+          var(--chat-vh, 1vh) * 100 - calc(var(--header-offset))
         );
       }
     }


### PR DESCRIPTION
Removes extra space below input in DiscourseHub on iPads. 

- [x] chat-scoped -- core unaffected

### Browsers

- [x] safari

### Device

- [x] iPad DiscourseHub
- [x] iPad Safari