### PR TITLE
FEATURE: Improve chat messages flagging.

### DIFF
--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -77,13 +77,6 @@ class ChatMessage < ActiveRecord::Base
     Emoji.gsub_emoji_to_unicode(message).truncate(400)
   end
 
-  def add_flag(user)
-    reviewable = ReviewableChatMessage.needs_review!(created_by: user, target: self)
-    reviewable.update(target_created_by: self.user)
-    reviewable.add_score(user, ReviewableScore.types[:needs_review], force_review: true)
-    reviewable
-  end
-
   def reviewable_score_for(user)
     ReviewableScore.joins(:reviewable).where(reviewable: { target: self }).where(user: user)
   end

--- a/app/models/deleted_chat_user.rb
+++ b/app/models/deleted_chat_user.rb
@@ -8,4 +8,8 @@ class DeletedChatUser < User
   def avatar_template
     "/plugins/discourse-chat/images/deleted-chat-user-avatar.png"
   end
+
+  def bot?
+    false
+  end
 end

--- a/app/models/reviewable_chat_message.rb
+++ b/app/models/reviewable_chat_message.rb
@@ -3,25 +3,6 @@
 require_dependency "reviewable"
 
 class ReviewableChatMessage < Reviewable
-  def self.on_score_updated(reviewable)
-    # Silence user if new score is over the `score_to_silence_user`
-    return if reviewable.type != self.name
-
-    auto_silence_duration = SiteSetting.chat_auto_silence_from_flags_duration
-    return if auto_silence_duration.zero?
-    return if reviewable.score <= self.score_to_silence_user
-
-    user = reviewable&.target&.user
-    return unless user
-
-    UserSilencer.silence(
-      user,
-      Discourse.system_user,
-      silenced_till: auto_silence_duration.minutes.from_now,
-      reason: I18n.t("chat.errors.auto_silence_from_flags"),
-    )
-  end
-
   def self.action_aliases
     {
       agree_and_keep_hidden: :agree_and_delete,

--- a/app/serializers/chat_message_serializer.rb
+++ b/app/serializers/chat_message_serializer.rb
@@ -12,7 +12,8 @@ class ChatMessageSerializer < ApplicationSerializer
              :user_flag_status,
              :edited,
              :reactions,
-             :bookmark
+             :bookmark,
+             :available_flags
 
   has_one :user, serializer: BasicUserWithStatusSerializer, embed: :objects
   has_one :chat_webhook_event, serializer: ChatWebhookEventSerializer, embed: :objects
@@ -119,5 +120,22 @@ class ChatMessageSerializer < ApplicationSerializer
 
   def include_user_flag_status?
     user_flag_status.present?
+  end
+
+  def available_flags
+    return [] if !scope.can_flag_chat_message?(object)
+    return [] if reviewable_id.present?
+
+    PostActionType.flag_types.map do |sym, id|
+      if sym == :notify_user &&
+           (
+             scope.current_user == user || user.bot? ||
+               !scope.current_user.in_any_groups?(SiteSetting.personal_message_enabled_groups_map)
+           )
+        next
+      end
+
+      sym
+    end
   end
 end

--- a/app/services/chat_publisher.rb
+++ b/app/services/chat_publisher.rb
@@ -100,13 +100,13 @@ module ChatPublisher
     MessageBus.publish("/chat/#{chat_channel.id}", content.as_json, permissions(chat_channel))
   end
 
-  def self.publish_flag!(chat_message, user, reviewable)
+  def self.publish_flag!(chat_message, user, reviewable, score)
     # Publish to user who created flag
     MessageBus.publish(
       "/chat/#{chat_message.chat_channel_id}",
       {
         type: "self_flagged",
-        user_flag_status: ReviewableScore.statuses[:pending],
+        user_flag_status: score.status_for_database,
         chat_message_id: chat_message.id,
       }.as_json,
       user_ids: [user.id],

--- a/assets/javascripts/discourse/lib/chat-message-flag.js
+++ b/assets/javascripts/discourse/lib/chat-message-flag.js
@@ -1,0 +1,87 @@
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import I18n from "I18n";
+
+export default class ChatMessageFlag {
+  title() {
+    return "flagging.title";
+  }
+
+  customSubmitLabel() {
+    return "flagging.notify_action";
+  }
+
+  submitLabel() {
+    return "chat.flagging.action";
+  }
+
+  targetsTopic() {
+    return false;
+  }
+
+  editable() {
+    return false;
+  }
+
+  _rewriteFlagDescriptions(flags) {
+    return flags.map((flag) => {
+      flag.set("description", I18n.t(`chat.flags.${flag.name_key}`));
+      return flag;
+    });
+  }
+
+  flagsAvailable(_controller, site, model) {
+    let flagsAvailable = site.flagTypes;
+
+    flagsAvailable = flagsAvailable.filter((flag) => {
+      return model.available_flags.includes(flag.name_key);
+    });
+
+    // "message user" option should be at the top
+    const notifyUserIndex = flagsAvailable.indexOf(
+      flagsAvailable.filterBy("name_key", "notify_user")[0]
+    );
+
+    if (notifyUserIndex !== -1) {
+      const notifyUser = flagsAvailable[notifyUserIndex];
+      flagsAvailable.splice(notifyUserIndex, 1);
+      flagsAvailable.splice(0, 0, notifyUser);
+    }
+
+    return this._rewriteFlagDescriptions(flagsAvailable);
+  }
+
+  create(controller, opts) {
+    controller.send("hideModal");
+
+    return ajax("/chat/flag", {
+      method: "PUT",
+      data: {
+        chat_message_id: controller.get("model.id"),
+        flag_type_id: controller.get("selected.id"),
+        message: opts.message,
+        is_warning: opts.isWarning,
+        take_action: opts.takeAction,
+        queue_for_review: opts.queue_for_review,
+      },
+    })
+      .then(() => {
+        if (controller.isDestroying || controller.isDestroyed) {
+          return;
+        }
+
+        if (!opts.skipClose) {
+          controller.send("closeModal");
+        }
+        if (opts.message) {
+          controller.set("message", "");
+        }
+      })
+      .catch((error) => {
+        if (!controller.isDestroying && !controller.isDestroyed) {
+          controller.send("closeModal");
+        }
+        popupAjaxError(error);
+      });
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -368,6 +368,16 @@ en:
 
       topic_button_title: "Chat"
 
+      flags:
+        off_topic: "This message is not relevant to the current discussion as defined by the channel title, and should probably be moved elsewhere."
+        inappropriate: "This message contains content that a reasonable person would consider offensive, abusive, or a violation of <a href=\"/guidelines\">our community guidelines</a>."
+        spam: "This message is an advertisement, or vandalism. It is not useful or relevant to the current channel."
+        notify_user: "I want to talk to this person directly and personally about their message."
+        notify_moderators: "This message requires staff attention for another reason not listed above."
+      
+      flagging:
+        action: "Flag message"
+
     notifications:
       chat_invitation: "invited you to join a chat channel"
       chat_invitation_html: "<span>%{username}</span> <span>invited you to join a chat channel</span>"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -15,6 +15,7 @@ en:
     chat_allow_uploads: "Allow uploads in public chat channels."
     chat_archive_destination_topic_status: "The status that the destination topic should be once a channel archive is completed. This only applies when the destination topic is a new topic, not an existing one."
     default_emoji_reactions: "Default emoji reactions for chat messages. Add up to 5 emojis for quick reaction."
+    min_trust_to_flag_chat_messages: "The minimum trust level required to flag chat messages."
     errors:
       chat_default_channel: "The default chat channel must be a public channel."
       chat_upload_not_allowed_secure_media: "Chat uploads are not allowed when secure media site setting is enabled."
@@ -138,7 +139,16 @@ en:
   reviewable_score_types:
     needs_review:
       title: "Needs Review"
-
+    notify_user:
+      chat_pm_title: 'Your chat message in "%{channel_name}"'
+      chat_pm_body: "%{link}\n\n%{message}"
+    notify_moderators:
+      chat_pm_title: 'A chat message in "%{channel_name}" requires staff attention'
+      chat_pm_body: "%{link}\n\n%{message}"
+  
+  reviewables:
+    reasons:
+      chat_message_queued_by_staff: "A staff member thinks this chat message needs review."
   user_notifications:
     chat_summary:
       deleted_user: "Deleted user"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -80,3 +80,8 @@ plugins:
     default: 10000
     hidden: true
     client: true
+  chat_message_flag_allowed_groups:
+    default: "11" # auto group trust_level_1
+    type: group_list
+    client: true
+    allow_any: false

--- a/lib/chat_review_queue.rb
+++ b/lib/chat_review_queue.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+# Acceptable options:
+#   - message: Used when the flag type is notify_user or notify_moderators and we have to create
+#     a separate PM.
+#   - is_warning: Staff can send warnings when using the notify_user flag.
+#   - take_action: Automatically approves the created reviewable and deletes the chat message.
+#   - queue_for_review: Adds a special reason to the reviwable score and creates the reviewable using
+#     the force_review option.
+
+class DiscourseChat::ChatReviewQueue
+  def flag_message(chat_message, guardian, flag_type_id, opts = {})
+    result = { success: false, errors: [] }
+
+    guardian.ensure_can_flag_chat_message!(chat_message)
+    guardian.ensure_can_flag_message_as!(chat_message, flag_type_id, opts)
+
+    if opts[:message].present? &&
+         ReviewableScore.types.slice(:notify_user, :notify_moderators).values.include?(flag_type_id)
+      creator = companion_pm_creator(chat_message, guardian.user, flag_type_id, opts)
+      post = creator.create
+
+      if creator.errors.present?
+        creator.errors.full_messages.each { |msg| result[:errors] << msg }
+        return result
+      end
+    end
+
+    queued_for_review = !!ActiveRecord::Type::Boolean.new.deserialize(opts[:queue_for_review])
+
+    reviewable =
+      ReviewableChatMessage.needs_review!(
+        created_by: guardian.user,
+        target: chat_message,
+        reviewable_by_moderator: true,
+        potential_spam: flag_type_id == ReviewableScore.types[:spam],
+      )
+    reviewable.update(target_created_by: chat_message.user)
+    score =
+      reviewable.add_score(
+        guardian.user,
+        flag_type_id,
+        meta_topic_id: post&.topic_id,
+        take_action: opts[:take_action],
+        reason: queued_for_review ? "chat_message_queued_by_staff" : nil,
+        force_review: queued_for_review,
+      )
+
+    if opts[:take_action]
+      reviewable.perform(guardian.user, :agree_and_delete)
+      ChatPublisher.publish_delete!(chat_message.chat_channel, chat_message)
+    else
+      enforce_auto_silence_threshold(reviewable)
+      ChatPublisher.publish_flag!(chat_message, guardian.user, reviewable, score)
+    end
+
+    result.tap do |r|
+      r[:success] = true
+      r[:reviewable] = reviewable
+    end
+  end
+
+  private
+
+  def enforce_auto_silence_threshold(reviewable)
+    auto_silence_duration = SiteSetting.chat_auto_silence_from_flags_duration
+    return if auto_silence_duration.zero?
+    return if reviewable.score <= ReviewableChatMessage.score_to_silence_user
+
+    user = reviewable.target_created_by
+    return unless user
+    return if user.silenced?
+
+    UserSilencer.silence(
+      user,
+      Discourse.system_user,
+      silenced_till: auto_silence_duration.minutes.from_now,
+      reason: I18n.t("chat.errors.auto_silence_from_flags"),
+    )
+  end
+
+  def companion_pm_creator(chat_message, flagger, flag_type_id, opts)
+    notifying_user = flag_type_id == ReviewableScore.types[:notify_user]
+
+    i18n_key = notifying_user ? "notify_user" : "notify_moderators"
+
+    title =
+      I18n.t(
+        "reviewable_score_types.#{i18n_key}.chat_pm_title",
+        channel_name: chat_message.chat_channel.title(flagger),
+        locale: SiteSetting.default_locale,
+      )
+
+    body =
+      I18n.t(
+        "reviewable_score_types.#{i18n_key}.chat_pm_body",
+        message: opts[:message],
+        link: chat_message.full_url,
+        locale: SiteSetting.default_locale,
+      )
+
+    create_args = {
+      archetype: Archetype.private_message,
+      title: title.truncate(SiteSetting.max_topic_title_length, separator: /\s/),
+      raw: body,
+    }
+
+    if notifying_user
+      create_args[:subtype] = TopicSubtype.notify_user
+      create_args[:target_usernames] = chat_message.user.username
+
+      create_args[:is_warning] = opts[:is_warning] if flagger.staff?
+    else
+      create_args[:subtype] = TopicSubtype.notify_moderators
+      create_args[:target_group_names] = [Group[:moderators].name]
+    end
+
+    PostCreator.new(flagger, create_args)
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -162,6 +162,7 @@ after_initialize do
   load File.expand_path("../lib/chat_channel_membership_manager.rb", __FILE__)
   load File.expand_path("../lib/chat_message_bookmarkable.rb", __FILE__)
   load File.expand_path("../lib/chat_channel_archive_service.rb", __FILE__)
+  load File.expand_path("../lib/chat_review_queue.rb", __FILE__)
   load File.expand_path("../lib/direct_message_channel_creator.rb", __FILE__)
   load File.expand_path("../lib/guardian_extensions.rb", __FILE__)
   load File.expand_path("../lib/extensions/user_option_extension.rb", __FILE__)
@@ -515,8 +516,6 @@ after_initialize do
       true
     end
   end
-
-  on(:reviewable_score_updated) { |reviewable| ReviewableChatMessage.on_score_updated(reviewable) }
 
   on(:user_seen) do |user|
     if user.last_seen_at == user.first_seen_at

--- a/spec/lib/chat_review_queue_spec.rb
+++ b/spec/lib/chat_review_queue_spec.rb
@@ -1,0 +1,301 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe DiscourseChat::ChatReviewQueue do
+  fab!(:message_poster) { Fabricate(:user) }
+  fab!(:flagger) { Fabricate(:user) }
+  fab!(:chat_channel) { Fabricate(:chat_channel) }
+  fab!(:message) { Fabricate(:chat_message, user: message_poster, chat_channel: chat_channel) }
+
+  fab!(:admin) { Fabricate(:admin) }
+  let(:guardian) { Guardian.new(flagger) }
+  let(:admin_guardian) { Guardian.new(admin) }
+
+  before do
+    chat_channel.add(message_poster)
+    chat_channel.add(flagger)
+    Group.refresh_automatic_groups!
+  end
+
+  describe "#flag_message" do
+    it "raises an error when the user is not allowed to flag" do
+      UserSilencer.new(flagger).silence
+
+      expect {
+        subject.flag_message(message, guardian, ReviewableScore.types[:spam])
+      }.to raise_error(Discourse::InvalidAccess)
+    end
+
+    it "creates a new reviewable with an associated score" do
+      subject.flag_message(message, guardian, ReviewableScore.types[:spam])
+
+      new_reviewable = ReviewableChatMessage.find_by(target: message)
+
+      expect(new_reviewable).to be_present
+      expect(new_reviewable.target_created_by).to eq(message_poster)
+      expect(new_reviewable.created_by).to eq(flagger)
+      expect(new_reviewable.pending?).to eq(true)
+
+      scores = new_reviewable.reviewable_scores
+      expect(scores.size).to eq(1)
+      expect(scores.first.reviewable_score_type).to eq(ReviewableScore.types[:spam])
+      expect(scores.first.pending?).to eq(true)
+    end
+
+    it "appends a new score if the reviewable already exists" do
+      subject.flag_message(message, guardian, ReviewableScore.types[:spam])
+
+      second_flagger = Fabricate(:user)
+      chat_channel.add(second_flagger)
+      guardian_2 = Guardian.new(second_flagger)
+      Group.find(Group::AUTO_GROUPS[:trust_level_1]).add(second_flagger)
+
+      subject.flag_message(message, guardian_2, ReviewableScore.types[:off_topic])
+
+      reviewable = ReviewableChatMessage.find_by(target: message)
+      scores = reviewable.reviewable_scores
+
+      expect(scores.size).to eq(2)
+      expect(scores.map(&:reviewable_score_type)).to contain_exactly(
+        *ReviewableScore.types.slice(:off_topic, :spam).values,
+      )
+    end
+
+    it "publishes a message to the flagger" do
+      messages =
+        MessageBus
+          .track_publish { subject.flag_message(message, guardian, ReviewableScore.types[:spam]) }
+          .map(&:data)
+
+      self_flag_msg = messages.detect { |m| m["type"] == "self_flagged" }
+
+      expect(self_flag_msg["user_flag_status"]).to eq(ReviewableScore.statuses[:pending])
+      expect(self_flag_msg["chat_message_id"]).to eq(message.id)
+    end
+
+    it "publishes a message to tell staff there is a new reviewable" do
+      messages =
+        MessageBus
+          .track_publish { subject.flag_message(message, guardian, ReviewableScore.types[:spam]) }
+          .map(&:data)
+
+      flag_msg = messages.detect { |m| m["type"] == "flag" }
+      new_reviewable = ReviewableChatMessage.find_by(target: message)
+
+      expect(flag_msg["chat_message_id"]).to eq(message.id)
+      expect(flag_msg["reviewable_id"]).to eq(new_reviewable.id)
+    end
+
+    let(:flag_message) { "I just flagged your chat message..." }
+
+    context "when creating a notify_user flag" do
+      it "creates a companion PM" do
+        subject.flag_message(
+          message,
+          guardian,
+          ReviewableScore.types[:notify_user],
+          message: flag_message,
+        )
+
+        pm_topic =
+          Topic.includes(:posts).find_by(user: guardian.user, archetype: Archetype.private_message)
+        pm_post = pm_topic.first_post
+
+        expect(pm_topic.allowed_users).to include(message.user)
+        expect(pm_topic.subtype).to eq(TopicSubtype.notify_user)
+        expect(pm_post.raw).to include(flag_message)
+        expect(pm_topic.title).to eq("Your chat message in \"#{chat_channel.title(message.user)}\"")
+      end
+
+      it "doesn't create a PM if there is no message" do
+        subject.flag_message(message, guardian, ReviewableScore.types[:notify_user])
+
+        pm_topic =
+          Topic.includes(:posts).find_by(user: guardian.user, archetype: Archetype.private_message)
+
+        expect(pm_topic).to be_nil
+      end
+
+      it "allow staff to tag PM as a warning" do
+        subject.flag_message(
+          message,
+          admin_guardian,
+          ReviewableScore.types[:notify_user],
+          message: flag_message,
+          is_warning: true,
+        )
+
+        expect(UserWarning.exists?(user: message.user)).to eq(true)
+      end
+
+      it "only allows staff members to send warnings" do
+        expect do
+          subject.flag_message(
+            message,
+            guardian,
+            ReviewableScore.types[:notify_user],
+            message: flag_message,
+            is_warning: true,
+          )
+        end.to raise_error(Discourse::InvalidAccess)
+      end
+    end
+
+    context "when creating a notify_moderators flag" do
+      it "creates a companion PM and gives moderators access to it" do
+        subject.flag_message(
+          message,
+          guardian,
+          ReviewableScore.types[:notify_moderators],
+          message: flag_message,
+        )
+
+        pm_topic =
+          Topic.includes(:posts).find_by(user: guardian.user, archetype: Archetype.private_message)
+        pm_post = pm_topic.first_post
+
+        expect(pm_topic.allowed_groups).to contain_exactly(Group[:moderators])
+        expect(pm_topic.subtype).to eq(TopicSubtype.notify_moderators)
+        expect(pm_post.raw).to include(flag_message)
+        expect(pm_topic.title).to eq(
+          "A chat message in \"#{chat_channel.title(message.user)}\" requires staff attention",
+        )
+      end
+
+      it "ignores the is_warning flag when notifying moderators" do
+        subject.flag_message(
+          message,
+          guardian,
+          ReviewableScore.types[:notify_moderators],
+          message: flag_message,
+          is_warning: true,
+        )
+
+        expect(UserWarning.exists?(user: message.user)).to eq(false)
+      end
+    end
+
+    context "when immediately taking action" do
+      it "agrees with the flag and deletes the chat message" do
+        subject.flag_message(
+          message,
+          admin_guardian,
+          ReviewableScore.types[:off_topic],
+          take_action: true,
+        )
+
+        reviewable = ReviewableChatMessage.find_by(target: message)
+
+        expect(reviewable.approved?).to eq(true)
+        expect(message.reload.trashed?).to eq(true)
+      end
+
+      it "publishes an when deleting the message" do
+        messages =
+          MessageBus
+            .track_publish do
+              subject.flag_message(
+                message,
+                admin_guardian,
+                ReviewableScore.types[:off_topic],
+                take_action: true,
+              )
+            end
+            .map(&:data)
+
+        delete_msg = messages.detect { |m| m[:type] == "delete" }
+
+        expect(delete_msg[:deleted_id]).to eq(message.id)
+      end
+
+      it "agrees with other flags on the same message" do
+        subject.flag_message(message, guardian, ReviewableScore.types[:off_topic])
+
+        reviewable = ReviewableChatMessage.includes(:reviewable_scores).find_by(target: message)
+        scores = reviewable.reviewable_scores
+
+        expect(scores.size).to eq(1)
+        expect(scores.all?(&:pending?)).to eq(true)
+
+        subject.flag_message(
+          message,
+          admin_guardian,
+          ReviewableScore.types[:off_topic],
+          take_action: true,
+        )
+
+        scores = reviewable.reload.reviewable_scores
+
+        expect(scores.size).to eq(2)
+        expect(scores.all?(&:agreed?)).to eq(true)
+      end
+
+      it "raises an exception if the user is not a staff member" do
+        expect do
+          subject.flag_message(
+            message,
+            guardian,
+            ReviewableScore.types[:off_topic],
+            take_action: true,
+          )
+        end.to raise_error(Discourse::InvalidAccess)
+      end
+    end
+
+    context "when queueing for review" do
+      it "sets a reason on the score" do
+        subject.flag_message(
+          message,
+          admin_guardian,
+          ReviewableScore.types[:off_topic],
+          queue_for_review: true,
+        )
+
+        reviewable = ReviewableChatMessage.includes(:reviewable_scores).find_by(target: message)
+        score = reviewable.reviewable_scores.first
+
+        expect(score.reason).to eq("chat_message_queued_by_staff")
+      end
+
+      it "only allows staff members to queue for review" do
+        expect do
+          subject.flag_message(
+            message,
+            guardian,
+            ReviewableScore.types[:off_topic],
+            queue_for_review: true,
+          )
+        end.to raise_error(Discourse::InvalidAccess)
+      end
+    end
+
+    context "when the auto silence threshold is met" do
+      it "silences the user" do
+        SiteSetting.chat_auto_silence_from_flags_duration = 1
+        flagger.update!(trust_level: TrustLevel[4]) # Increase Score due to TL Bonus.
+
+        subject.flag_message(message, guardian, ReviewableScore.types[:off_topic])
+
+        expect(message_poster.reload.silenced?).to eq(true)
+      end
+
+      it "does nothing if the new score is less than the auto-silence threshold" do
+        SiteSetting.chat_auto_silence_from_flags_duration = 50
+
+        subject.flag_message(message, guardian, ReviewableScore.types[:off_topic])
+
+        expect(message_poster.reload.silenced?).to eq(false)
+      end
+
+      it "does nothing if the silence duration is set to 0" do
+        SiteSetting.chat_auto_silence_from_flags_duration = 0
+        flagger.update!(trust_level: TrustLevel[4]) # Increase Score due to TL Bonus.
+
+        subject.flag_message(message, guardian, ReviewableScore.types[:off_topic])
+
+        expect(message_poster.reload.silenced?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/models/reviewable_chat_message_spec.rb
+++ b/spec/models/reviewable_chat_message_spec.rb
@@ -55,30 +55,4 @@ RSpec.describe ReviewableChatMessage, type: :model do
     expect(reviewable).to be_ignored
     expect(chat_message.reload.deleted_at).not_to be_present
   end
-
-  describe ".on_score_updated" do
-    it "silences the user for the correct time when the threshold is met" do
-      SiteSetting.chat_auto_silence_from_flags_duration = 3
-      reviewable.update!(score: ReviewableChatMessage.score_to_silence_user + 1)
-      expect { ReviewableChatMessage.on_score_updated(reviewable) }.to change {
-        user.reload.silenced?
-      }.to be true
-    end
-
-    it "does nothing if the new score is less than the score to auto-silence" do
-      SiteSetting.chat_auto_silence_from_flags_duration = 3
-      reviewable.update!(score: ReviewableChatMessage.score_to_silence_user - 1)
-      expect { ReviewableChatMessage.on_score_updated(reviewable) }.not_to change {
-        user.reload.silenced?
-      }
-    end
-
-    it "does nothing if the silence duration is set to 0" do
-      SiteSetting.chat_auto_silence_from_flags_duration = 0
-      reviewable.update!(score: ReviewableChatMessage.score_to_silence_user + 1)
-      expect { ReviewableChatMessage.on_score_updated(reviewable) }.not_to change {
-        user.reload.silenced?
-      }
-    end
-  end
 end

--- a/spec/serializer/chat_message_serializer_spec.rb
+++ b/spec/serializer/chat_message_serializer_spec.rb
@@ -57,4 +57,87 @@ describe ChatMessageSerializer do
       end
     end
   end
+
+  describe "#available_flags" do
+    it "returns an empty list if the user already flagged the message" do
+      reviewable = Fabricate(:reviewable_chat_message, target: message_1)
+
+      serialized =
+        described_class.new(
+          message_1,
+          scope: guardian,
+          root: nil,
+          reviewable_ids: {
+            message_1.id => reviewable.id,
+          },
+        ).as_json
+
+      expect(serialized[:available_flags]).to be_empty
+    end
+
+    it "doesn't include notify_user for self-flags" do
+      guardian_1 = Guardian.new(message_1.user)
+
+      serialized = described_class.new(message_1, scope: guardian_1, root: nil).as_json
+
+      expect(serialized[:available_flags]).not_to include(:notify_user)
+    end
+
+    it "doesn't include the notify_user flag for bot messages" do
+      message_1.update!(user: Discourse.system_user)
+
+      serialized = described_class.new(message_1, scope: guardian, root: nil).as_json
+
+      expect(serialized[:available_flags]).not_to include(:notify_user)
+    end
+
+    it "returns an empty list for anons" do
+      serialized = described_class.new(message_1, scope: Guardian.new, root: nil).as_json
+
+      expect(serialized[:available_flags]).to be_empty
+    end
+
+    it "returns an empty list for silenced users" do
+      guardian.user.update!(silenced_till: 1.month.from_now)
+
+      serialized = described_class.new(message_1, scope: guardian, root: nil).as_json
+
+      expect(serialized[:available_flags]).to be_empty
+    end
+
+    it "returns an empty list if the message was deleted" do
+      message_1.trash!
+
+      serialized = described_class.new(message_1, scope: guardian, root: nil).as_json
+
+      expect(serialized[:available_flags]).to be_empty
+    end
+
+    it "doesn't include notify_user if PMs are disabled" do
+      SiteSetting.enable_personal_messages = false
+
+      serialized = described_class.new(message_1, scope: guardian, root: nil).as_json
+
+      expect(serialized[:available_flags]).not_to include(:notify_user)
+    end
+
+    it "doesn't include notify_user if flagged TL is not high enough" do
+      guardian.user.update!(trust_level: TrustLevel[2])
+      SiteSetting.min_trust_to_send_messages = TrustLevel[3]
+
+      serialized = described_class.new(message_1, scope: guardian, root: nil).as_json
+
+      expect(serialized[:available_flags]).not_to include(:notify_user)
+    end
+
+    it "returns an empty list if the user needs a higher TL to flag" do
+      guardian.user.update!(trust_level: TrustLevel[2])
+      SiteSetting.chat_message_flag_allowed_groups = Group::AUTO_GROUPS[:trust_level_3]
+      Group.refresh_automatic_groups!
+
+      serialized = described_class.new(message_1, scope: guardian, root: nil).as_json
+
+      expect(serialized[:available_flags]).to be_empty
+    end
+  end
 end

--- a/test/javascripts/acceptance/chat-flagging-test.js
+++ b/test/javascripts/acceptance/chat-flagging-test.js
@@ -60,9 +60,10 @@ acceptance("Discourse Chat - Flagging test", function (needs) {
     assert.ok(content.find((row) => row.id === "flag"));
 
     await moreButtons.selectRowByValue("flag");
-    assert.ok(exists(".bootbox.in"));
 
-    await click(".bootbox.in .btn-primary");
+    await click(".controls.spam input");
+    await click(".modal-footer button");
+
     await publishToMessageBus("/chat/75", {
       type: "self_flagged",
       chat_message_id: defaultChatView.chat_messages[0].id,

--- a/test/javascripts/chat-fixtures.js
+++ b/test/javascripts/chat-fixtures.js
@@ -213,6 +213,7 @@ const message0 = {
     name: null,
     avatar_template: "/letter_avatar_proxy/v4/letter/m/48db29/{size}.png",
   },
+  available_flags: ["spam"],
 };
 
 const message1 = {
@@ -246,6 +247,7 @@ const message1 = {
       width: null,
     },
   ],
+  available_flags: ["spam"],
 };
 
 const message2 = {
@@ -296,6 +298,7 @@ const message2 = {
       users: [],
     },
   },
+  available_flags: ["spam"],
 };
 
 const message3 = {
@@ -313,6 +316,7 @@ const message3 = {
     name: null,
     avatar_template: "/letter_avatar_proxy/v4/letter/m/48db29/{size}.png",
   },
+  available_flags: ["spam"],
 };
 
 export function generateChatView(loggedInUser, metaOverrides = {}) {


### PR DESCRIPTION
This PR re-uses core's flag modal so users can select a flag type and send PMs when selecting notify_user or notify_moderators. It also lets staff take actions, or queue chat messages for review.

One difference is that we don't have the concept of "hiding" as we do for posts, so we have to delete messages instead on those scenarios.