### PR TITLE
DEV: Fix upload test by adding settled

### DIFF
--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -1478,7 +1478,8 @@ acceptance("Discourse Chat - image uploads", function (needs) {
     const done = assert.async();
     await fillIn(".d-editor-input", "The image:\n");
 
-    appEvents.on("composer:all-uploads-complete", () => {
+    appEvents.on("composer:all-uploads-complete", async () => {
+      await settled();
       assert.strictEqual(
         query(".d-editor-input").value,
         "The image:\n![avatar.PNG|690x320](upload://yoj8pf9DdIeHRRULyw7i57GAYdz.jpeg)\n",


### PR DESCRIPTION
Follow up to core PR
https://github.com/discourse/discourse/commit/9daa6328b525069556de8e9a293f197fbf62fe7f which made some changes to uppy completion
events, which requires us to wait for the composer to be settled before checking the placeholders
