### PR TITLE
FIX: Tighten flagging restrictions for chat messages.

### DIFF
--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -429,13 +429,17 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
   end
 
   def flag
+    RateLimiter.new(current_user, "flag_chat_message", 4, 1.minutes).performed!
+
     permitted_params =
       params.permit(
         %i[chat_message_id flag_type_id message is_warning take_action queue_for_review],
       )
 
     chat_message =
-      ChatMessage.includes(:chat_channel).find_by(id: permitted_params[:chat_message_id])
+      ChatMessage.includes(:chat_channel, :revisions).find_by(
+        id: permitted_params[:chat_message_id],
+      )
     raise Discourse::InvalidParameters.new(:chat_message_id) if !chat_message
 
     flag_type_id = permitted_params[:flag_type_id].to_i

--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -77,10 +77,6 @@ class ChatMessage < ActiveRecord::Base
     Emoji.gsub_emoji_to_unicode(message).truncate(400)
   end
 
-  def reviewable_score_for(user)
-    ReviewableScore.joins(:reviewable).where(reviewable: { target: self }).where(user: user)
-  end
-
   def to_markdown
     markdown = []
 

--- a/lib/chat_review_queue.rb
+++ b/lib/chat_review_queue.rb
@@ -15,6 +15,13 @@ class DiscourseChat::ChatReviewQueue
     guardian.ensure_can_flag_chat_message!(chat_message)
     guardian.ensure_can_flag_message_as!(chat_message, flag_type_id, opts)
 
+    existing_reviewable = Reviewable.includes(:reviewable_scores).find_by(target: chat_message)
+
+    if !can_flag_again?(existing_reviewable, chat_message, guardian.user, flag_type_id)
+      result[:errors] << I18n.t("reviewables.already_handled")
+      return result
+    end
+
     if opts[:message].present? &&
          ReviewableScore.types.slice(:notify_user, :notify_moderators).values.include?(flag_type_id)
       creator = companion_pm_creator(chat_message, guardian.user, flag_type_id, opts)
@@ -116,5 +123,30 @@ class DiscourseChat::ChatReviewQueue
     end
 
     PostCreator.new(flagger, create_args)
+  end
+
+  def can_flag_again?(reviewable, message, flagger, flag_type_id)
+    return true if reviewable.blank?
+
+    flagger_has_no_pending_flags =
+      reviewable.reviewable_scores.none? { |rs| rs.user == flagger && rs.pending? }
+
+    if flagger_has_no_pending_flags && flag_type_id == PostActionType.types[:notify_moderators]
+      return true
+    end
+
+    flag_not_used =
+      reviewable.reviewable_scores.none? do |rs|
+        rs.reviewable_score_type == flag_type_id && rs.pending?
+      end
+    not_handled_recently =
+      reviewable.pending? ||
+        reviewable.updated_at < SiteSetting.cooldown_hours_until_reflag.to_i.hours.ago
+
+    latest_revision = message.revisions.last
+    edited_since_last_review = latest_revision && latest_revision.updated_at > reviewable.updated_at
+
+    flag_not_used && flagger_has_no_pending_flags &&
+      (not_handled_recently || edited_since_last_review)
   end
 end

--- a/lib/guardian_extensions.rb
+++ b/lib/guardian_extensions.rb
@@ -100,7 +100,7 @@ module DiscourseChat::GuardianExtensions
 
   def can_flag_in_chat_channel?(chat_channel)
     return false if !can_modify_channel_message?(chat_channel)
-    !chat_channel.direct_message_channel?
+    !chat_channel.direct_message_channel? && can_see_chat_channel?(chat_channel)
   end
 
   def can_flag_chat_message?(chat_message)


### PR DESCRIPTION
For all messages, make sure the user can see the channel to flag and limit the number of flags a user can create, which is the same we do for post actions.

For each message, prevent multiple users from flagging the same message for the same reason following the post action creator guidelines:

* A reviewable can only have one pending flag of each type, except for notify_moderators.
* Users can only flag a message once until it gets reviewed by staff.
* Enforce a cooldown window after review unless the poster edits the message.
