### PR TITLE
FIX: enforces chat_channel_id when present

### DIFF
--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -498,7 +498,7 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
   end
 
   def find_chat_message
-    @message = ChatMessage.unscoped.includes(chat_channel: :chatable)
+    @message = preloaded_chat_message_query.with_deleted
     @message = @message.where(chat_channel_id: params[:chat_channel_id]) if params[:chat_channel_id]
     @message = @message.find_by(id: params[:message_id])
     raise Discourse::NotFound unless @message

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -498,9 +498,9 @@ class DiscourseChat::ChatController < DiscourseChat::ChatBaseController
   end
 
   def find_chat_message
-    @message =
-      ChatMessage.unscoped.includes(chat_channel: :chatable).find_by(id: params[:message_id])
-
+    @message = ChatMessage.unscoped.includes(chat_channel: :chatable)
+    @message = @message.where(chat_channel_id: params[:chat_channel_id]) if params[:chat_channel_id]
+    @message = @message.find_by(id: params[:message_id])
     raise Discourse::NotFound unless @message
   end
 end

--- a/assets/javascripts/discourse/adapters/chat-message.js
+++ b/assets/javascripts/discourse/adapters/chat-message.js
@@ -3,7 +3,7 @@ import RESTAdapter from "discourse/adapters/rest";
 export default class ChatMessage extends RESTAdapter {
   pathFor(store, type, findArgs) {
     if (findArgs.targetMessageId) {
-      return `/chat/lookup/${findArgs.targetMessageId}.json`;
+      return `/chat/lookup/${findArgs.targetMessageId}.json?chat_channel_id=${findArgs.channelId}`;
     }
 
     let path = `/chat/${findArgs.channelId}/messages.json?page_size=${findArgs.pageSize}`;

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -246,7 +246,7 @@ export default Component.extend({
           }
           this.setMessageProps(messages, fetchingFromLastRead);
         })
-        .catch(this._handle429Errors)
+        .catch(this._handleErrors)
         .finally(() => {
           if (this._selfDeleted || this.chatChannel.id !== channel.id) {
             return;
@@ -322,7 +322,7 @@ export default Component.extend({
 
         return messages;
       })
-      .catch(this._handle429Errors)
+      .catch(this._handleErrors)
       .finally(() => {
         if (this._selfDeleted) {
           return;
@@ -1431,8 +1431,10 @@ export default Component.extend({
     });
   },
 
-  _handle429Errors(error) {
+  _handleErrors(error) {
     if (error?.jqXHR?.status === 429) {
+      popupAjaxError(error);
+    } else if (error?.jqXHR?.status === 404) {
       popupAjaxError(error);
     } else {
       throw error;

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1436,7 +1436,7 @@ export default Component.extend({
       case 429:
       case 404:
         popupAjaxError(error);
-        return;
+        break;
       default:
         throw error;
     }

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1432,12 +1432,12 @@ export default Component.extend({
   },
 
   _handleErrors(error) {
-    if (error?.jqXHR?.status === 429) {
-      popupAjaxError(error);
-    } else if (error?.jqXHR?.status === 404) {
-      popupAjaxError(error);
-    } else {
-      throw error;
+    switch (error?.jqXHR?.status) {
+      case 429:
+      case 404:
+        popupAjaxError(error);
+      default:
+        throw error;
     }
   },
 });

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1436,6 +1436,7 @@ export default Component.extend({
       case 429:
       case 404:
         popupAjaxError(error);
+        return;
       default:
         throw error;
     }

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -1293,25 +1293,35 @@ RSpec.describe DiscourseChat::ChatController do
 
     it "ensures message's channel can be seen" do
       Guardian.any_instance.expects(:can_see_chat_channel?).with(channel)
-      get "/chat/lookup/#{message.id}.json"
+      get "/chat/lookup/#{message.id}.json", { params: { chat_channel_id: channel.id } }
+    end
+
+    context "when the message doesn’t belong to the channel" do
+      let!(:message) { Fabricate(:chat_message) }
+
+      it "returns a 404" do
+        get "/chat/lookup/#{message.id}.json", { params: { chat_channel_id: channel.id } }
+
+        expect(response.status).to eq(404)
+      end
     end
 
     context "when the chat channel is for a category" do
       let!(:chatable) { Fabricate(:category) }
 
       it "ensures the user can access that category" do
-        get "/chat/lookup/#{message.id}.json"
+        get "/chat/lookup/#{message.id}.json", { params: { chat_channel_id: channel.id } }
         expect(response.status).to eq(200)
         expect(response.parsed_body["chat_messages"][0]["id"]).to eq(message.id)
 
         group = Fabricate(:group)
         chatable.update!(read_restricted: true)
         Fabricate(:category_group, group: group, category: chatable)
-        get "/chat/lookup/#{message.id}.json"
+        get "/chat/lookup/#{message.id}.json", { params: { chat_channel_id: channel.id } }
         expect(response.status).to eq(403)
 
         GroupUser.create!(user: user, group: group)
-        get "/chat/lookup/#{message.id}.json"
+        get "/chat/lookup/#{message.id}.json", { params: { chat_channel_id: channel.id } }
         expect(response.status).to eq(200)
         expect(response.parsed_body["chat_messages"][0]["id"]).to eq(message.id)
       end
@@ -1321,11 +1331,11 @@ RSpec.describe DiscourseChat::ChatController do
       let!(:chatable) { Fabricate(:direct_message_channel) }
 
       it "ensures the user can access that direct message channel" do
-        get "/chat/lookup/#{message.id}.json"
+        get "/chat/lookup/#{message.id}.json", { params: { chat_channel_id: channel.id } }
         expect(response.status).to eq(403)
 
         DirectMessageUser.create!(user: user, direct_message_channel: chatable)
-        get "/chat/lookup/#{message.id}.json"
+        get "/chat/lookup/#{message.id}.json", { params: { chat_channel_id: channel.id } }
         expect(response.status).to eq(200)
         expect(response.parsed_body["chat_messages"][0]["id"]).to eq(message.id)
       end

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -561,7 +561,7 @@ RSpec.describe DiscourseChat::ChatController do
       sign_in(other_user)
       UserSilencer.new(other_user).silence
 
-      delete "/chat/#{chat_channel.id}/#{other_user_message.id}.json"
+      delete "/chat/#{other_user_message.chat_channel.id}/#{other_user_message.id}.json"
       expect(response.status).to eq(403)
     end
 

--- a/test/javascripts/acceptance/chat-live-pane-test.js
+++ b/test/javascripts/acceptance/chat-live-pane-test.js
@@ -222,3 +222,40 @@ acceptance(
     });
   }
 );
+
+acceptance(
+  "Discourse Chat - Chat live pane - handling 404 errors",
+  function (needs) {
+    needs.user({
+      username: "eviltrout",
+      id: 1,
+      has_chat_enabled: true,
+    });
+
+    needs.settings({ chat_enabled: true });
+
+    needs.pretender((server, helper) => {
+      server.get("/chat/:chatChannelId/messages.json", () => {
+        return helper.response(404);
+      });
+
+      server.get("/chat/chat_channels.json", () =>
+        helper.response({
+          public_channels: [],
+          direct_message_channels: [],
+        })
+      );
+
+      server.get("/chat/chat_channels/:chatChannelId", () =>
+        helper.response({ id: 1, title: "something" })
+      );
+    });
+
+    test("Handles 404 errors by displaying an alert", async function (assert) {
+      await visit("/chat/channel/1/cat");
+
+      assert.ok(exists(".dialog-content"), "it displays a 404 error");
+      await click(".dialog-footer .btn-primary");
+    });
+  }
+);


### PR DESCRIPTION
This will deserve an heavier refactoring in the future, and more importantly moving all this logic under something like `/chat/chat_channels/:id/messages?target_message_id=865` to enforce message being a child from the channel.

This commit however prevents the issue for now and ensures this case is tracked for future refactoring with a test.
