### PR TITLE
FIX: Deleting old messages should also clear flags.

### DIFF
--- a/app/jobs/scheduled/delete_old_chat_messages.rb
+++ b/app/jobs/scheduled/delete_old_chat_messages.rb
@@ -20,6 +20,7 @@ module Jobs
         .each do |relation|
           destroyed_ids = relation.destroy_all.pluck(:id)
           reset_last_read_message_id(destroyed_ids)
+          delete_flags(destroyed_ids)
         end
     end
 
@@ -45,6 +46,10 @@ module Jobs
       UserChatChannelMembership.where(last_read_message_id: ids).update_all(
         last_read_message_id: nil,
       )
+    end
+
+    def delete_flags(message_ids)
+      ReviewableChatMessage.where(target_id: message_ids).destroy_all
     end
   end
 end

--- a/db/post_migrate/20221004122254_delete_reviewables_targetting_deleted_chat_messages.rb
+++ b/db/post_migrate/20221004122254_delete_reviewables_targetting_deleted_chat_messages.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class DeleteReviewablesTargettingDeletedChatMessages < ActiveRecord::Migration[7.0]
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def up
+    deleted_ids = DB.query_single <<~SQL
+      DELETE FROM reviewables r
+      WHERE r.type = 'ReviewableChatMessage'
+      AND r.id IN (
+        SELECT raux.id
+        FROM reviewables raux
+        LEFT OUTER JOIN chat_messages cm ON cm.id = raux.target_id
+        WHERE raux.type = 'ReviewableChatMessage' AND cm.id IS NULL
+      )
+      RETURNING r.id
+    SQL
+
+    if deleted_ids
+      DB.exec(<<~SQL, deleted_ids: deleted_ids)
+        DELETE FROM reviewable_scores rs
+        WHERE rs.reviewable_id IN (:deleted_ids)
+      SQL
+
+      DB.exec(<<~SQL, deleted_ids: deleted_ids)
+        DELETE FROM reviewable_histories rh
+        WHERE rh.reviewable_id IN (:deleted_ids)
+      SQL
+    end
+  end
+end


### PR DESCRIPTION
Since the job permanently deletes messages instead of trashing them, it makes sense to delete associated flags too.
