### PR TITLE
FIX: prefers /chat/channel/:id/:title?messageId=x link

### DIFF
--- a/assets/javascripts/lib/discourse-markdown/discourse-chat-transcript.js
+++ b/assets/javascripts/lib/discourse-markdown/discourse-chat-transcript.js
@@ -110,7 +110,9 @@ const chatTranscriptRule = {
 
     // for some cases, like archiving, we don't want the link to the
     // chat message because it will just result in a 404
-    if (noLink) {
+    // also handles the case where the quote doesn’t contain
+    // enough data to build a valid channel/message link
+    if (noLink || !channelLink) {
       let spanToken = state.push("span_open", "span", 1);
       spanToken.attrs = [["title", messageTimeStart]];
 
@@ -120,7 +122,7 @@ const chatTranscriptRule = {
     } else {
       let linkToken = state.push("link_open", "a", 1);
       linkToken.attrs = [
-        ["href", options.getURL(`/chat/message/${messageIdStart}`)],
+        ["href", `${channelLink}?messageId=${messageIdStart}`],
         ["title", messageTimeStart],
       ];
 

--- a/spec/integration/post_chat_quote_spec.rb
+++ b/spec/integration/post_chat_quote_spec.rb
@@ -16,7 +16,7 @@ describe "chat bbcode quoting in posts" do
       <div class="chat-transcript-username">
       martin</div>
       <div class="chat-transcript-datetime">
-      <a title="2022-01-25T05:40:39Z"></a>
+      <span title="2022-01-25T05:40:39Z"></span>
       </div>
       </div>
       <div class="chat-transcript-messages">
@@ -198,7 +198,7 @@ This is an inline onebox https://en.wikipedia.org/wiki/Hyperlink.
 <div class="chat-transcript-username">
 martin</div>
 <div class="chat-transcript-datetime">
-<a title="2022-01-25T05:40:39Z"></a>
+<span title="2022-01-25T05:40:39Z"></span>
 </div>
 </div>
 <div class="chat-transcript-messages">

--- a/spec/integration/post_chat_quote_spec.rb
+++ b/spec/integration/post_chat_quote_spec.rb
@@ -16,7 +16,7 @@ describe "chat bbcode quoting in posts" do
       <div class="chat-transcript-username">
       martin</div>
       <div class="chat-transcript-datetime">
-      <a href="/chat/message/2321" title="2022-01-25T05:40:39Z"></a>
+      <a title="2022-01-25T05:40:39Z"></a>
       </div>
       </div>
       <div class="chat-transcript-messages">
@@ -41,7 +41,7 @@ describe "chat bbcode quoting in posts" do
       <div class="chat-transcript-username">
       martin</div>
       <div class="chat-transcript-datetime">
-      <a href="/chat/message/2321" title="2022-01-25T05:40:39Z"></a>
+      <a href="/chat/channel/1234/-?messageId=2321" title="2022-01-25T05:40:39Z"></a>
       </div>
       </div>
       <div class="chat-transcript-messages">
@@ -63,7 +63,7 @@ describe "chat bbcode quoting in posts" do
       <div class="chat-transcript-username">
       martin</div>
       <div class="chat-transcript-datetime">
-      <a href="/chat/message/2321" title="2022-01-25T05:40:39Z"></a>
+      <a href="/chat/channel/1234/-?messageId=2321" title="2022-01-25T05:40:39Z"></a>
       </div>
       <a class="chat-transcript-channel" href="/chat/channel/1234/-">
       #Cool Cats Club</a>
@@ -87,7 +87,7 @@ describe "chat bbcode quoting in posts" do
       <div class="chat-transcript-username">
       martin</div>
       <div class="chat-transcript-datetime">
-      <a href="/chat/message/2321" title="2022-01-25T05:40:39Z"></a>
+      <a href="/chat/channel/1234/-?messageId=2321" title="2022-01-25T05:40:39Z"></a>
       </div>
       <a class="chat-transcript-channel" href="/chat/channel/1234/-">
       #Cool Cats Club</a>
@@ -137,7 +137,7 @@ describe "chat bbcode quoting in posts" do
       <div class="chat-transcript-username">
       martin</div>
       <div class="chat-transcript-datetime">
-      <a href="/chat/message/2321" title="2022-01-25T05:40:39Z"></a>
+      <a href="/chat/channel/1234/-?messageId=2321" title="2022-01-25T05:40:39Z"></a>
       </div>
       <a class="chat-transcript-channel" href="/chat/channel/1234/-">
       #Cool Cats Club</a>
@@ -198,7 +198,7 @@ This is an inline onebox https://en.wikipedia.org/wiki/Hyperlink.
 <div class="chat-transcript-username">
 martin</div>
 <div class="chat-transcript-datetime">
-<a href="/chat/message/2321" title="2022-01-25T05:40:39Z"></a>
+<a title="2022-01-25T05:40:39Z"></a>
 </div>
 </div>
 <div class="chat-transcript-messages">

--- a/spec/models/chat_message_spec.rb
+++ b/spec/models/chat_message_spec.rb
@@ -152,7 +152,7 @@ describe ChatMessage do
         <div class="chat-transcript-username">
         otherbbcodeuser</div>
         <div class="chat-transcript-datetime">
-        <a title="#{msg2.created_at.iso8601}"></a>
+        <span title="#{msg2.created_at.iso8601}"></span>
         </div>
         </div>
         <div class="chat-transcript-messages">

--- a/spec/models/chat_message_spec.rb
+++ b/spec/models/chat_message_spec.rb
@@ -137,7 +137,7 @@ describe ChatMessage do
         <div class="chat-transcript-username">
         chatbbcodeuser</div>
         <div class="chat-transcript-datetime">
-        <a href="/chat/message/#{msg1.id}" title="#{msg1.created_at.iso8601}"></a>
+        <a href="/chat/channel/#{chat_channel.id}/-?messageId=#{msg1.id}" title="#{msg1.created_at.iso8601}"></a>
         </div>
         </div>
         <div class="chat-transcript-messages">
@@ -152,7 +152,7 @@ describe ChatMessage do
         <div class="chat-transcript-username">
         otherbbcodeuser</div>
         <div class="chat-transcript-datetime">
-        <a href="/chat/message/#{msg2.id}" title="#{msg2.created_at.iso8601}"></a>
+        <a title="#{msg2.created_at.iso8601}"></a>
         </div>
         </div>
         <div class="chat-transcript-messages">

--- a/test/javascripts/acceptance/chat-transcript-test.js
+++ b/test/javascripts/acceptance/chat-transcript-test.js
@@ -84,9 +84,10 @@ ${originallySent}</div>`);
         .format(I18n.t("dates.long_no_year"))
     : "";
 
-  const innerDatetimeEl = opts.noLink
-    ? `<span title=\"${opts.datetime}\">${dateTimeText}</span>`
-    : `<a href=\"/chat/message/${opts.messageId}\" title=\"${opts.datetime}\"${tabIndexHTML}>${dateTimeText}</a>`;
+  const innerDatetimeEl =
+    opts.noLink || !opts.channelId
+      ? `<span title=\"${opts.datetime}\">${dateTimeText}</span>`
+      : `<a href=\"/chat/channel/${opts.channelId}/-?messageId=${opts.messageId}\" title=\"${opts.datetime}\"${tabIndexHTML}>${dateTimeText}</a>`;
   transcript.push(`<div class=\"chat-transcript-user\">
 <div class=\"chat-transcript-user-avatar\"></div>
 <div class=\"chat-transcript-username\">
@@ -488,7 +489,7 @@ acceptance(
       await visit("/t/-/280");
 
       assert.strictEqual(
-        query(".chat-transcript-datetime a").text.trim(),
+        query(".chat-transcript-datetime span").innerText.trim(),
         moment
           .tz("2022-01-25T05:40:39Z", "Australia/Brisbane")
           .format(I18n.t("dates.long_no_year")),


### PR DESCRIPTION
Prior to this fix we were constructing links using: `/chat/message/id` in chat transcript, which is prone to errors.
