### PR TITLE
UX: moves new channel button to browse view

### DIFF
--- a/assets/javascripts/discourse/components/channels-list.js
+++ b/assets/javascripts/discourse/components/channels-list.js
@@ -65,31 +65,6 @@ export default class ChannelsList extends Component {
     return false;
   }
 
-  @computed
-  get channelsActions() {
-    return [
-      { id: "browseChannels", name: I18n.t("chat.channels_list_popup.browse") },
-      {
-        id: "openCreateChannelModal",
-        name: I18n.t("chat.channels_list_popup.create"),
-      },
-    ];
-  }
-
-  @action
-  handleChannelAction(id) {
-    if (!this.channelsActions.map((a) => a.id).includes(id)) {
-      throw new Error(`The action ${id} is not allowed`);
-    }
-    this[id]();
-  }
-
-  @action
-  openCreateChannelModal() {
-    showModal("create-channel");
-    return false;
-  }
-
   @action
   startCreatingDmChannel() {
     if (

--- a/assets/javascripts/discourse/components/channels-list.js
+++ b/assets/javascripts/discourse/components/channels-list.js
@@ -1,11 +1,9 @@
 import { bind } from "discourse-common/utils/decorators";
 import Component from "@ember/component";
-import showModal from "discourse/lib/show-modal";
 import { action, computed } from "@ember/object";
 import { schedule } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 import { empty, reads } from "@ember/object/computed";
-import I18n from "I18n";
 import { DRAFT_CHANNEL_VIEW } from "discourse/plugins/discourse-chat/discourse/services/chat";
 
 export default class ChannelsList extends Component {

--- a/assets/javascripts/discourse/components/chat-browse-view.js
+++ b/assets/javascripts/discourse/components/chat-browse-view.js
@@ -6,6 +6,7 @@ import { inject as service } from "@ember/service";
 import ChatApi from "discourse/plugins/discourse-chat/discourse/lib/chat-api";
 import discourseDebounce from "discourse-common/lib/debounce";
 import { bind } from "discourse-common/utils/decorators";
+import showModal from "discourse/lib/show-modal";
 
 const TABS = ["all", "open", "closed", "archived"];
 const PER_PAGE = 20;
@@ -80,6 +81,11 @@ export default class ChatBrowseView extends Component {
       event.target.value,
       INPUT_DELAY
     );
+  }
+
+  @action
+  createChannel() {
+    showModal("create-channel");
   }
 
   @bind

--- a/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -181,7 +181,7 @@ export default {
               }
 
               get actions() {
-                const actions = [
+                return [
                   {
                     id: "browseChannels",
                     title: I18n.t("chat.channels_list_popup.browse"),
@@ -190,20 +190,10 @@ export default {
                     },
                   },
                 ];
-                if (this.sidebar.currentUser.staff) {
-                  actions.push({
-                    id: "openCreateChannelModal",
-                    title: I18n.t("chat.channels_list_popup.create"),
-                    action: () => {
-                      showModal("create-channel");
-                    },
-                  });
-                }
-                return actions;
               }
 
               get actionsIcon() {
-                return "cog";
+                return "pencil-alt";
               }
 
               get links() {

--- a/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -4,7 +4,6 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import I18n from "I18n";
 import { bind } from "discourse-common/utils/decorators";
 import { tracked } from "@glimmer/tracking";
-import showModal from "discourse/lib/show-modal";
 import { DRAFT_CHANNEL_VIEW } from "discourse/plugins/discourse-chat/discourse/services/chat";
 import { avatarUrl, escapeExpression } from "discourse/lib/utilities";
 import { dasherize } from "@ember/string";

--- a/assets/javascripts/discourse/templates/components/channels-list.hbs
+++ b/assets/javascripts/discourse/templates/components/channels-list.hbs
@@ -20,20 +20,11 @@
       {{/if}}
       <span class="channel-title">{{i18n "chat.chat_channels"}}</span>
 
-      {{#if currentUser.staff}}
-        {{dropdown-select-box
-          options=(hash icon="cog" placementStrategy="absolute")
-          content=channelsActions
-          onChange=(action "handleChannelAction")
-          class="edit-channels-dropdown"
-        }}
-      {{else}}
-        {{d-button
-          action=(action "browseChannels")
-          icon="pencil-alt"
-          class="btn-flat edit-channel-membership-btn title-action"
-        }}
-      {{/if}}
+      {{d-button
+        action=(action "browseChannels")
+        icon="pencil-alt"
+        class="btn-flat edit-channel-membership-btn title-action"
+      }}
     </div>
 
     <div id="public-channels" class={{publicChannelClasses}}>

--- a/assets/javascripts/discourse/templates/components/chat-browse-view.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-browse-view.hbs
@@ -11,7 +11,7 @@
       {{d-button
         action=(action "createChannel")
         icon="plus"
-        class="edit-channel-membership-btn title-action"
+        class="new-channel-btn"
         label=(if site.desktopView "chat.create_channel.title")
       }}
     {{/if}}

--- a/assets/javascripts/discourse/templates/components/chat-browse-view.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-browse-view.hbs
@@ -5,7 +5,18 @@
 {{/if}}
 
 <div class="chat-browse-view">
-  <h1 class="chat-browse-view__title">{{i18n "chat.browse.title"}}</h1>
+  <div class="chat-browse-view__header">
+    <h1 class="chat-browse-view__title">{{i18n "chat.browse.title"}}</h1>
+    {{#if currentUser.staff}}
+      {{d-button
+        action=(action "createChannel")
+        icon="plus"
+        class="edit-channel-membership-btn title-action"
+        label=(if site.desktopView "chat.create_channel.title")
+      }}
+    {{/if}}
+  </div>
+
   <div class="chat-browse-view__actions">
     <nav>
       <ul class="nav-pills chat-browse-view__filters">

--- a/assets/stylesheets/common/chat-browse.scss
+++ b/assets/stylesheets/common/chat-browse.scss
@@ -4,13 +4,19 @@
   overflow-y: scroll;
   @include chat-scrollbar(var(--secondary));
 
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
   &__title {
     box-sizing: border-box;
     margin: 1rem;
   }
 
   &__content_wrapper {
-    margin: 2rem 1rem 1rem 1rem;
+    margin: 2rem 0 1rem 1rem;
     box-sizing: border-box;
 
     @include breakpoint(tablet) {
@@ -33,7 +39,7 @@
     display: flex;
     justify-content: space-between;
     align-items: end;
-    margin: 0 1rem;
+    margin: 0 0 0 1rem;
 
     @include breakpoint(tablet) {
       flex-direction: column;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -66,7 +66,7 @@ en:
         process_started: "The process to delete the channel has started. This modal will close shortly, you will no longer see the deleted channel anywhere."
       channels_list_popup:
         browse: "Browse channels"
-        create: "Create a channel"
+        create: "New channel"
 
       click_to_join: "Click here to view available channels."
       close: "Close"
@@ -248,7 +248,7 @@ en:
         create: "Create channel"
         description: "Description (optional)"
         name: "Channel name"
-        title: "Create a channel"
+        title: "New channel"
         type: "Type"
         types:
           category: "Category"
@@ -374,7 +374,7 @@ en:
         spam: "This message is an advertisement, or vandalism. It is not useful or relevant to the current channel."
         notify_user: "I want to talk to this person directly and personally about their message."
         notify_moderators: "This message requires staff attention for another reason not listed above."
-      
+
       flagging:
         action: "Flag message"
 

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -1238,17 +1238,10 @@ acceptance(
     test("Create channel modal", async function (assert) {
       this.container.lookup("service:chat").set("chatWindowFullPage", true);
 
-      await visit("/chat/channel/11/another-category");
-      const dropdown = selectKit(".edit-channels-dropdown");
-      await dropdown.expand();
-      await dropdown.selectRowByValue("browseChannels");
-      assert.strictEqual(currentURL(), "/chat/browse/open");
+      await visit("/chat/browse");
+      await click(".new-channel-btn");
 
-      await visit("/chat/channel/11/another-category");
-      await dropdown.expand();
-      await dropdown.selectRowByValue("openCreateChannelModal");
-      assert.ok(exists(".create-channel-modal"));
-      assert.ok(query(".create-channel-modal .btn.create").disabled);
+      assert.strictEqual(currentURL(), "/chat/browse/open");
 
       let categories = selectKit(".create-channel-modal .category-chooser");
       await categories.expand();

--- a/test/javascripts/acceptance/create-channel-test.js
+++ b/test/javascripts/acceptance/create-channel-test.js
@@ -1,5 +1,5 @@
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import { visit } from "@ember/test-helpers";
+import { click, visit } from "@ember/test-helpers";
 import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 
@@ -62,6 +62,8 @@ acceptance("Discourse Chat - Create channel modal", function (needs) {
       helper.response({ id: 1, title: "something" })
     );
 
+    server.get("/chat/api/chat_channels.json", () => helper.response([]));
+
     server.get(
       "/chat/api/category-chatables/:categoryId/permissions.json",
       (request) => {
@@ -83,11 +85,8 @@ acceptance("Discourse Chat - Create channel modal", function (needs) {
   });
 
   test("links to categories and selected category's security settings", async function (assert) {
-    await visit("/chat/channel/1/cat");
-
-    const dropdown = selectKit(".edit-channels-dropdown");
-    await dropdown.expand();
-    await dropdown.selectRowByValue("openCreateChannelModal");
+    await visit("/chat/browse");
+    await click(".new-channel-btn");
 
     assert.strictEqual(
       query(".create-channel-hint a").innerText,
@@ -109,11 +108,8 @@ acceptance("Discourse Chat - Create channel modal", function (needs) {
   });
 
   test("links to selected category's security settings works with nested subcategories", async function (assert) {
-    await visit("/chat/channel/1/cat");
-
-    const dropdown = selectKit(".edit-channels-dropdown");
-    await dropdown.expand();
-    await dropdown.selectRowByValue("openCreateChannelModal");
+    await visit("/chat/browse");
+    await click(".new-channel-btn");
 
     assert.strictEqual(
       query(".create-channel-hint a").innerText,
@@ -137,11 +133,8 @@ acceptance("Discourse Chat - Create channel modal", function (needs) {
   });
 
   test("includes group names in the hint", async (assert) => {
-    await visit("/chat/channel/1/cat");
-
-    const dropdown = selectKit(".edit-channels-dropdown");
-    await dropdown.expand();
-    await dropdown.selectRowByValue("openCreateChannelModal");
+    await visit("/chat/browse");
+    await click(".new-channel-btn");
 
     assert.strictEqual(
       query(".create-channel-hint a").innerText,
@@ -160,10 +153,8 @@ acceptance("Discourse Chat - Create channel modal", function (needs) {
   });
 
   test("escapes group name/category slug in the hint", async (assert) => {
-    await visit("/chat/channel/1/cat");
-    const dropdown = selectKit(".edit-channels-dropdown");
-    await dropdown.expand();
-    await dropdown.selectRowByValue("openCreateChannelModal");
+    await visit("/chat/browse");
+    await click(".new-channel-btn");
 
     assert.strictEqual(
       query(".create-channel-hint a").innerText,


### PR DESCRIPTION
Removes the dropdown with browse/create from the sidebar. As a side effect:
- it's now a button using the pencil icon, leading to browse page
- the new channel button is at the top of browse page

It's only changing behavior for staff, regular users were already not seeing the dropdown as they can’t create channels.