### PR TITLE
FIX: closing button not  visible on chat index page

### DIFF
--- a/assets/stylesheets/common/chat-channel-title.scss
+++ b/assets/stylesheets/common/chat-channel-title.scss
@@ -3,9 +3,9 @@
   align-items: center;
   max-width: 96%;
 
-  &:hover {
-    max-width: unset;
+  .chat-channel-row:hover & {
     overflow: hidden;
+    max-width: unset;
   }
 
   .category-chat-private .d-icon {

--- a/assets/stylesheets/common/chat-channel-title.scss
+++ b/assets/stylesheets/common/chat-channel-title.scss
@@ -1,6 +1,12 @@
 .chat-channel-title {
   display: flex;
   align-items: center;
+  max-width: 96%;
+
+  &:hover {
+    max-width: unset;
+    overflow: hidden;
+  }
 
   .category-chat-private .d-icon {
     background-color: var(--secondary);


### PR DESCRIPTION
<!-- Checklist for UI / stylesheet changes, delete if not applicable -->

- [x] chat-scoped -- core unaffected

### View mode

- [x] docked (windowed/drawer)

### Browsers

- [ ] safari
- [ ] chrome
- [ ] firefox

### Device

- [x] desktop – wide screen
- [x] mobile – `?mobile_view=1`
