### PR TITLE
FEATURE: Inline video player for video uploads

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer-upload.js
+++ b/assets/javascripts/discourse/components/chat-composer-upload.js
@@ -1,6 +1,6 @@
 import Component from "@ember/component";
 import discourseComputed from "discourse-common/utils/decorators";
-import { IMAGES_EXTENSIONS_REGEX } from "discourse/lib/uploads";
+import { isImage } from "discourse/lib/uploads";
 
 export default Component.extend({
   IMAGE_TYPE: "image",
@@ -11,9 +11,9 @@ export default Component.extend({
   upload: null,
   onCancel: null,
 
-  @discourseComputed("upload.extension")
-  type(extension) {
-    if (IMAGES_EXTENSIONS_REGEX.test(extension)) {
+  @discourseComputed("upload.original_filename")
+  type(filename) {
+    if (isImage(filename)) {
       return this.IMAGE_TYPE;
     }
   },

--- a/assets/javascripts/discourse/components/chat-composer-upload.js
+++ b/assets/javascripts/discourse/components/chat-composer-upload.js
@@ -11,9 +11,9 @@ export default Component.extend({
   upload: null,
   onCancel: null,
 
-  @discourseComputed("upload.original_filename")
-  type(filename) {
-    if (isImage(filename)) {
+  @discourseComputed("upload.{original_filename,fileName}")
+  type(upload) {
+    if (isImage(upload.original_filename || upload.fileName)) {
       return this.IMAGE_TYPE;
     }
   },

--- a/assets/javascripts/discourse/components/chat-upload.js
+++ b/assets/javascripts/discourse/components/chat-upload.js
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 
 import { inject as service } from "@ember/service";
-import { IMAGES_EXTENSIONS_REGEX } from "discourse/lib/uploads";
+import { isImage, isVideo } from "discourse/lib/uploads";
 import { action } from "@ember/object";
 import { tracked } from "@glimmer/tracking";
 import { htmlSafe } from "@ember/template";
@@ -12,11 +12,19 @@ export default class extends Component {
   @tracked loaded = false;
 
   IMAGE_TYPE = "image";
+  VIDEO_TYPE = "video";
+  ATTACHMENT_TYPE = "video";
 
   get type() {
-    if (IMAGES_EXTENSIONS_REGEX.test(this.args.upload.extension)) {
+    if (isImage(this.args.upload.original_filename)) {
       return this.IMAGE_TYPE;
     }
+
+    if (isVideo(this.args.upload.original_filename)) {
+      return this.VIDEO_TYPE;
+    }
+
+    return this.ATTACHMENT_TYPE;
   }
 
   get size() {

--- a/assets/javascripts/discourse/components/chat-upload.js
+++ b/assets/javascripts/discourse/components/chat-upload.js
@@ -13,7 +13,7 @@ export default class extends Component {
 
   IMAGE_TYPE = "image";
   VIDEO_TYPE = "video";
-  ATTACHMENT_TYPE = "video";
+  ATTACHMENT_TYPE = "attachment";
 
   get type() {
     if (isImage(this.args.upload.original_filename)) {

--- a/assets/javascripts/discourse/templates/components/chat-upload.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-upload.hbs
@@ -9,6 +9,11 @@
     loading="lazy"
     {{on "load" this.imageLoaded}}
   >
+{{else if (eq this.type this.VIDEO_TYPE)}}
+  <video class="chat-video-upload" preload="metadata" controls>
+    <source src={{@upload.url}}>
+    <a href={{@upload.url}}>{{@upload.url}}</a>
+  </video>
 {{else}}
   <a
     class="chat-other-upload"

--- a/assets/javascripts/discourse/templates/components/chat-upload.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-upload.hbs
@@ -12,7 +12,6 @@
 {{else if (eq this.type this.VIDEO_TYPE)}}
   <video class="chat-video-upload" preload="metadata" controls>
     <source src={{@upload.url}}>
-    <a href={{@upload.url}}>{{@upload.url}}</a>
   </video>
 {{else}}
   <a

--- a/assets/stylesheets/common/chat-message-collapser.scss
+++ b/assets/stylesheets/common/chat-message-collapser.scss
@@ -1,3 +1,5 @@
+$max_video_height: 150px;
+
 .chat-message-collapser {
   .chat-message-collapser-header {
     display: flex;
@@ -10,9 +12,15 @@
 
   .chat-img-upload,
   .chat-other-upload,
+  .chat-video-upload,
   .chat-message-collapser-header + div p img {
     margin-top: 0.25em;
     margin-bottom: 0.5em;
+  }
+
+  .chat-video-upload {
+    height: $max_video_height;
+    width: calc(#{$max_video_height} / 9 * 16);
   }
 
   .chat-message-collapser-link-small {

--- a/test/javascripts/components/chat-message-collapser-test.js
+++ b/test/javascripts/components/chat-message-collapser-test.js
@@ -232,7 +232,7 @@ module(
 
       beforeEach() {
         this.set("cooked", imageTextCooked);
-        this.set("uploads", [{ extension: "png" }]);
+        this.set("uploads", [{ original_filename: "tomtom.png" }]);
       },
 
       async test(assert) {

--- a/test/javascripts/components/chat-upload-test.js
+++ b/test/javascripts/components/chat-upload-test.js
@@ -23,6 +23,22 @@ const IMAGE_FIXTURE = {
   dominant_color: "788370", // rgb(120, 131, 112)
 };
 
+const VIDEO_FIXTURE = {
+  id: 290,
+  url: null, // Nulled out to avoid actually setting the img src - avoids an HTTP request
+  original_filename: "video.mp4",
+  filesize: 172214,
+  width: 1024,
+  height: 768,
+  thumbnail_width: 666,
+  thumbnail_height: 500,
+  extension: "mp4",
+  short_url: "upload://mnCnqY5tunCFw2qMgtPnu1mu1C9.mp4",
+  short_path: "/uploads/short-url/mnCnqY5tunCFw2qMgtPnu1mu1C9.mp4",
+  retain_hours: null,
+  human_filesize: "168 KB",
+};
+
 const TXT_FIXTURE = {
   id: 290,
   url: "https://example.com/file.txt",
@@ -63,6 +79,25 @@ module("Discourse Chat | Component | chat-upload", function (hooks) {
         image.style.backgroundColor,
         "",
         "removes the background color once the image has loaded"
+      );
+    },
+  });
+
+  componentTest("with a video", {
+    template: hbs`{{chat-upload upload=upload}}`,
+
+    beforeEach() {
+      this.set("upload", VIDEO_FIXTURE);
+    },
+
+    async test(assert) {
+      assert.true(exists("video.chat-video-upload"), "displays as an video");
+      const video = query("video.chat-video-upload");
+      assert.ok(video.hasAttribute("controls"), "has video controls");
+      assert.strictEqual(
+        video.getAttribute("preload"),
+        "metadata",
+        "video has correct preload settings"
       );
     },
   });


### PR DESCRIPTION
This commit makes it so user-uploaded videos in chat are shown inside a video player rather than as a
downloadable attachment. Same width and height rules as youtube videos defined in 811595b8b13bec45abaf18133379e85d5c670ca3 apply.

![image](https://user-images.githubusercontent.com/920448/194226022-a23cf11d-d495-49e0-ad09-23590f06ae18.png)
