### PR TITLE
FIX: direct_message_enabled_groups refinements

### DIFF
--- a/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -419,6 +419,10 @@ export default {
             }
 
             get actions() {
+              if (!this.userCanDirectMessage) {
+                return [];
+              }
+
               return [
                 {
                   id: "startDm",

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -15,7 +15,7 @@ en:
     chat_allow_uploads: "Allow uploads in public chat channels and direct message channels."
     chat_archive_destination_topic_status: "The status that the destination topic should be once a channel archive is completed. This only applies when the destination topic is a new topic, not an existing one."
     default_emoji_reactions: "Default emoji reactions for chat messages. Add up to 5 emojis for quick reaction."
-    direct_message_enabled_groups: "Allow users within these groups to create direct messages and reply to direct messages. Trust level groups include all trust levels above that number, for example choosing trust_level_1 also allows trust_level_2, 3, 4 users to send direct messages. Note that staff can always send direct messages no matter what."
+    direct_message_enabled_groups: "Allow users within these groups to create user-to-user Personal Chats. Note: staff can always create Personal Chats, and users will be able to reply to Personal Chats initiated by users who have permission to create them."
     chat_message_flag_allowed_groups: "Users in these groups are allowed to flag chat messages."
     errors:
       chat_default_channel: "The default chat channel must be a public channel."

--- a/lib/guardian_extensions.rb
+++ b/lib/guardian_extensions.rb
@@ -51,11 +51,7 @@ module DiscourseChat::GuardianExtensions
 
   def can_create_channel_message?(chat_channel)
     valid_statuses = is_staff? ? %w[open closed] : ["open"]
-    if chat_channel.direct_message_channel?
-      can_create_direct_message? && valid_statuses.include?(chat_channel.status)
-    else
-      valid_statuses.include?(chat_channel.status)
-    end
+    valid_statuses.include?(chat_channel.status)
   end
 
   # This is intentionally identical to can_create_channel_message, we

--- a/spec/lib/guardian_extensions_spec.rb
+++ b/spec/lib/guardian_extensions_spec.rb
@@ -328,10 +328,10 @@ RSpec.describe DiscourseChat::GuardianExtensions do
       context "for direct message channels" do
         before { Group.refresh_automatic_groups! }
 
-        it "returns false if the user is not in direct_message_enabled_groups" do
+        it "it still allows the user to message even if they are not in direct_message_enabled_groups because they are not creating the channel" do
           SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:trust_level_4]
           dm_channel.update!(status: :open)
-          expect(guardian.can_create_channel_message?(dm_channel)).to eq(false)
+          expect(guardian.can_create_channel_message?(dm_channel)).to eq(true)
         end
       end
     end

--- a/test/javascripts/acceptance/core-sidebar-test.js
+++ b/test/javascripts/acceptance/core-sidebar-test.js
@@ -649,6 +649,11 @@ acceptance(
         exists(".sidebar-section-chat-dms"),
         "it does show the section for a regular user"
       );
+
+      assert.notOk(
+        exists(".sidebar-section-chat-dms .sidebar-section-header-button"),
+        "user cannot see the create DM channel button"
+      );
     });
   }
 );


### PR DESCRIPTION
Users who are not inside any direct_message_enabled_groups should not be able to create DM channels, however if they are messaged by a user who does have this permission they should be able to send messages back in the channel without issue. Update setting description to reflect this.

Also do not show the create direct message channel button in the sidebar for users who do not have permission to do so, where the sidebar is showing for them since another user has opened a DM channel with them.