### PR TITLE
FEATURE: Enable flagging for DMs

### DIFF
--- a/app/serializers/chat_message_serializer.rb
+++ b/app/serializers/chat_message_serializer.rb
@@ -128,9 +128,14 @@ class ChatMessageSerializer < ApplicationSerializer
 
   def available_flags
     return [] if !scope.can_flag_chat_message?(object)
-    return [] if reviewable_id.present?
+    return [] if reviewable_id.present? && user_flag_status == ReviewableScore.statuses[:pending]
 
     PostActionType.flag_types.map do |sym, id|
+      if @options[:chat_channel].direct_message_channel? &&
+           %i[notify_moderators notify_user].include?(sym)
+        next
+      end
+
       if sym == :notify_user &&
            (
              scope.current_user == user || user.bot? ||

--- a/app/serializers/chat_view_serializer.rb
+++ b/app/serializers/chat_view_serializer.rb
@@ -9,6 +9,7 @@ class ChatViewSerializer < ApplicationSerializer
       each_serializer: ChatMessageSerializer,
       reviewable_ids: object.reviewable_ids,
       user_flag_statuses: object.user_flag_statuses,
+      chat_channel: object.chat_channel,
       scope: scope,
     )
   end

--- a/app/serializers/reviewable_chat_message_serializer.rb
+++ b/app/serializers/reviewable_chat_message_serializer.rb
@@ -6,6 +6,8 @@ class ReviewableChatMessageSerializer < ReviewableSerializer
   has_one :chat_message, serializer: ChatMessageSerializer, root: false, embed: :objects
   has_one :chat_channel, serializer: ChatChannelSerializer, root: false, embed: :objects
 
+  payload_attributes :transcript_topic_id, :message_cooked
+
   def chat_channel
     object.chat_message.chat_channel
   end

--- a/assets/javascripts/discourse/templates/components/reviewable-chat-message.hbs
+++ b/assets/javascripts/discourse/templates/components/reviewable-chat-message.hbs
@@ -19,8 +19,16 @@
     }}
 
     <div class="post-body">
-      {{html-safe reviewable.chat_message.cooked}}
+      {{html-safe (or reviewable.payload.message_cooked reviewable.chat_message.cooked)}}
     </div>
+
+    {{#if this.reviewable.payload.transcript_topic_id}}
+      <div class="transcript">
+        <LinkTo @route="topic" @models={{array "-" this.reviewable.payload.transcript_topic_id}} class="btn btn-small">
+          {{i18n "review.transcript.view"}}
+        </LinkTo>
+      </div>
+    {{/if}}
 
     {{yield}}
   </div>

--- a/assets/stylesheets/common/reviewable-chat-message.scss
+++ b/assets/stylesheets/common/reviewable-chat-message.scss
@@ -1,0 +1,5 @@
+.reviewable-chat-message {
+  .transcript {
+    margin: 0 0 1em 0;
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -419,6 +419,8 @@ en:
               label: Sender
               description: Defaults to system
     review:
+      transcript:
+        view: "View previous messages transcript"
       types:
         reviewable_chat_message:
           title: "Flagged Chat Message"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -88,6 +88,9 @@ en:
           title: "Disagree"
         ignore:
           title: "Ignore"
+      direct_messages:
+        transcript_title: "Transcript of previous messages in %{channel_name}"
+        transcript_body: "To give you more context, we included a transcript of the previous messages in this conversation (up to ten):\n\n%{transcript}"
     channel:
       statuses:
         read_only: "Read Only"

--- a/lib/guardian_extensions.rb
+++ b/lib/guardian_extensions.rb
@@ -104,7 +104,8 @@ module DiscourseChat::GuardianExtensions
 
   def can_flag_in_chat_channel?(chat_channel)
     return false if !can_modify_channel_message?(chat_channel)
-    !chat_channel.direct_message_channel? && can_see_chat_channel?(chat_channel)
+
+    can_see_chat_channel?(chat_channel)
   end
 
   def can_flag_chat_message?(chat_message)

--- a/plugin.rb
+++ b/plugin.rb
@@ -57,6 +57,7 @@ register_asset "stylesheets/common/chat-message-separator.scss"
 register_asset "stylesheets/common/chat-onebox.scss"
 register_asset "stylesheets/common/chat-skeleton.scss"
 register_asset "stylesheets/colors.scss", :color_definitions
+register_asset "stylesheets/common/reviewable-chat-message.scss"
 
 register_svg_icon "comments"
 register_svg_icon "comment-slash"

--- a/spec/requests/chat_controller_spec.rb
+++ b/spec/requests/chat_controller_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe DiscourseChat::ChatController do
       expect(response.parsed_body["meta"]["can_flag"]).to be true
     end
 
-    it "returns `can_flag=false` for DM channels" do
+    it "returns `can_flag=true` for DM channels" do
       get "/chat/#{dm_chat_channel.id}/messages.json", params: { page_size: page_size }
-      expect(response.parsed_body["meta"]["can_flag"]).to be false
+      expect(response.parsed_body["meta"]["can_flag"]).to be true
     end
 
     it "returns `can_moderate=true` based on whether the user can moderate the chatable" do
@@ -1215,15 +1215,6 @@ RSpec.describe DiscourseChat::ChatController do
       put "/chat/flag.json",
           params: {
             chat_message_id: admin_chat_message.id,
-            flag_type_id: ReviewableScore.types[:off_topic],
-          }
-      expect(response.status).to eq(403)
-    end
-
-    it "doesn't allow flagging direct messages" do
-      put "/chat/flag.json",
-          params: {
-            chat_message_id: admin_dm_message.id,
             flag_type_id: ReviewableScore.types[:off_topic],
           }
       expect(response.status).to eq(403)


### PR DESCRIPTION
For flagged DMs, we'll include a transcript of the previous messages (up to ten), which we store in a companion topic.

Additionally, we store the cooked content of the message in the reviewable to prevent users from editing it before staff reviews it.

<img width="867" alt="Screen Shot 2022-10-07 at 17 49 51" src="https://user-images.githubusercontent.com/5025816/194650349-b20e503e-033f-4752-b90e-3f8925af795a.png">
<img width="836" alt="Screen Shot 2022-10-07 at 17 50 00" src="https://user-images.githubusercontent.com/5025816/194650360-f1c53306-dc1a-4d2e-82db-6d4d32c58ce2.png">
