### PR TITLE
FIX: Staff should always be able to chat

### DIFF
--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -105,7 +105,11 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
 
     users = User.joins(:user_option).where.not(id: current_user.id)
     if !DiscourseChat.allowed_group_ids.include?(Group::AUTO_GROUPS[:everyone])
-      users = users.joins(:groups).where(groups: { id: DiscourseChat.allowed_group_ids })
+      users =
+        users
+          .joins(:groups)
+          .where(groups: { id: DiscourseChat.allowed_group_ids })
+          .or(users.joins(:groups).where("users.admin = true OR users.moderator = true"))
     end
 
     users = users.where(user_option: { chat_enabled: true })

--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -109,7 +109,7 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
         users
           .joins(:groups)
           .where(groups: { id: DiscourseChat.allowed_group_ids })
-          .or(users.joins(:groups).staff
+          .or(users.joins(:groups).staff)
     end
 
     users = users.where(user_option: { chat_enabled: true })

--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -109,7 +109,7 @@ class DiscourseChat::ChatChannelsController < DiscourseChat::ChatBaseController
         users
           .joins(:groups)
           .where(groups: { id: DiscourseChat.allowed_group_ids })
-          .or(users.joins(:groups).where("users.admin = true OR users.moderator = true"))
+          .or(users.joins(:groups).staff
     end
 
     users = users.where(user_option: { chat_enabled: true })

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,7 +1,7 @@
 en:
   site_settings:
     chat_enabled: "Enable the discourse-chat plugin."
-    chat_allowed_groups: "Users in these groups can chat."
+    chat_allowed_groups: "Users in these groups can chat. Note that staff can always access chat."
     chat_channel_retention_days: "Chat messages in regular channels will be retained for this many days. Set to '0' to retain messages forever."
     chat_dm_retention_days: "Chat messages in personal chat channels will be retained for this many days. Set to '0' to retain messages forever."
     chat_auto_silence_duration: "Number of minutes that users will be silenced for when they exceed the chat message creation rate limit. Set to '0' to disable auto-silencing."

--- a/lib/guardian_extensions.rb
+++ b/lib/guardian_extensions.rb
@@ -13,10 +13,7 @@ module DiscourseChat::GuardianExtensions
   def can_chat?(user)
     return false unless user
 
-    allowed_group_ids = DiscourseChat.allowed_group_ids
-    return true if allowed_group_ids.include?(Group::AUTO_GROUPS[:everyone])
-
-    (allowed_group_ids & user.group_ids).any?
+    user.staff? || user.in_any_groups?(DiscourseChat.allowed_group_ids)
   end
 
   def can_create_chat_message?

--- a/plugin.rb
+++ b/plugin.rb
@@ -89,7 +89,7 @@ after_initialize do
     end
 
     def self.allowed_group_ids
-      SiteSetting.chat_allowed_groups.to_s.split("|").map(&:to_i)
+      SiteSetting.chat_allowed_groups_map
     end
 
     def self.onebox_template

--- a/spec/lib/guardian_extensions_spec.rb
+++ b/spec/lib/guardian_extensions_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe DiscourseChat::GuardianExtensions do
     expect(guardian.can_chat?(user)).to eq(false)
   end
 
+  it "staff can always chat regardless of chat_allowed_grups" do
+    SiteSetting.chat_allowed_groups = ""
+    expect(guardian.can_chat?(staff)).to eq(true)
+  end
+
   describe "chat channel" do
     it "only staff can create channels" do
       expect(guardian.can_create_chat_channel?).to eq(false)


### PR DESCRIPTION
The `chat_allowed_groups` setting is changing in this commit to reflect other group settings, which always allow staff to do the related action regardless of whether the staff user is in one of the designated groups or not.