### PR TITLE
FIX: Use sidebar contentCSSClass for muted channels

### DIFF
--- a/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -108,6 +108,12 @@ export default {
                 ? "urgent"
                 : "unread";
             }
+
+            get contentCSSClass() {
+              return this.channel.current_user_membership.muted
+                ? "--muted"
+                : "";
+            }
           };
 
           const SidebarChatChannelsSection = class extends BaseCustomSidebarSection {
@@ -299,6 +305,12 @@ export default {
                 return "active";
               }
               return "";
+            }
+
+            get contentCSSClass() {
+              return this.channel.current_user_membership.muted
+                ? "--muted"
+                : "";
             }
 
             get suffixType() {

--- a/assets/stylesheets/sidebar-extensions.scss
+++ b/assets/stylesheets/sidebar-extensions.scss
@@ -160,5 +160,8 @@
     .user-status {
       margin-left: 0.3em;
     }
+    &.--muted {
+      opacity: 0.65;
+    }
   }
 }


### PR DESCRIPTION
In https://github.com/discourse/discourse/pull/18555 we are adding a sidebar function, contentCSSClass, for section links, and this commit uses it to make the muted channels low opacity again, since this is not currently working with the new sidebar.