### PR TITLE
DEV: Split channel search in ChatChannelFetcher into own method

### DIFF
--- a/lib/chat_channel_fetcher.rb
+++ b/lib/chat_channel_fetcher.rb
@@ -62,7 +62,7 @@ module DiscourseChat::ChatChannelFetcher
     SQL
   end
 
-  def self.secured_public_channels(guardian, memberships, options = { following: true })
+  def self.secured_public_channel_search(guardian, options = {})
     channels =
       ChatChannel
         .includes(:chat_channel_archive)
@@ -107,7 +107,11 @@ module DiscourseChat::ChatChannelFetcher
     )
     options[:offset] = [options[:offset].to_i, 0].max
 
-    channels = channels.limit(options[:limit]).offset(options[:offset])
+    channels.limit(options[:limit]).offset(options[:offset])
+  end
+
+  def self.secured_public_channels(guardian, memberships, options = { following: true })
+    channels = secured_public_channel_search(guardian, options)
     decorate_memberships_with_tracking_data(guardian, channels, memberships)
     channels = channels.to_a
     preload_custom_fields_for(channels)


### PR DESCRIPTION
This decouples the `secured_public_channels` method which also decorates the user memberships from the actual channel searching, filtering, ordering, and limiting based on the user's permissions, so we can just get the channels the user has access to see without needing to know their memberships.