### PR TITLE
DEV: Fix JS tests to use default site settings pt. 2

### DIFF
--- a/test/javascripts/acceptance/core-sidebar-test.js
+++ b/test/javascripts/acceptance/core-sidebar-test.js
@@ -482,6 +482,7 @@ acceptance("Discourse Chat - Plugin Sidebar", function (needs) {
 
   needs.settings({
     chat_enabled: true,
+    enable_sidebar: false,
   });
 
   needs.pretender((server, helper) => {


### PR DESCRIPTION
In preparation for core PR https://github.com/discourse/discourse/pull/18413 which changes JS to load default yml site settings.
