### PR TITLE
DEV: Use new setupHashtagAutocomplete + registerHashtagSearchParam APIs

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -10,18 +10,17 @@ import TextareaTextManipulation from "discourse/mixins/textarea-text-manipulatio
 import userSearch from "discourse/lib/user-search";
 import { action } from "@ember/object";
 import { cancel, next, schedule, throttle } from "@ember/runloop";
-import { categoryHashtagTriggerRule } from "discourse/lib/category-hashtags";
 import { cloneJSON } from "discourse-common/lib/object";
 import { findRawTemplate } from "discourse-common/lib/raw-templates";
 import { emojiSearch, isSkinTonableEmoji } from "pretty-text/emoji";
 import { emojiUrlFor } from "discourse/lib/text";
 import { inject as service } from "@ember/service";
 import { readOnly, reads } from "@ember/object/computed";
-import { search as searchCategoryTag } from "discourse/lib/category-tag-search";
 import { SKIP } from "discourse/lib/autocomplete";
 import { Promise } from "rsvp";
 import { translations } from "pretty-text/emoji/data";
 import { channelStatusName } from "discourse/plugins/discourse-chat/discourse/models/chat-channel";
+import { setupHashtagAutocomplete } from "discourse/lib/hashtag-autocomplete";
 import {
   chatComposerButtons,
   chatComposerButtonsDependentKeys,
@@ -343,29 +342,15 @@ export default Component.extend(TextareaTextManipulation, {
   },
 
   _applyCategoryHashtagAutocomplete($textarea) {
-    const siteSettings = this.siteSettings;
-
-    $textarea.autocomplete({
-      template: findRawTemplate("category-tag-autocomplete"),
-      key: "#",
-      treatAsTextarea: true,
-      afterComplete: (value) => {
+    setupHashtagAutocomplete(
+      "chat-composer",
+      $textarea,
+      this.siteSettings,
+      (value) => {
         this.set("value", value);
         return this._focusTextArea();
-      },
-      transformComplete: (obj) => {
-        return obj.text;
-      },
-      dataSource: (term) => {
-        if (term.match(/\s/)) {
-          return null;
-        }
-        return searchCategoryTag(term, siteSettings);
-      },
-      triggerRule: (textarea, opts) => {
-        return categoryHashtagTriggerRule(textarea, opts);
-      },
-    });
+      }
+    );
   },
 
   _applyEmojiAutocomplete($textarea) {

--- a/assets/javascripts/discourse/initializers/chat-setup.js
+++ b/assets/javascripts/discourse/initializers/chat-setup.js
@@ -42,6 +42,11 @@ export default {
         });
       }
 
+      if (this.siteSettings.enable_experimental_hashtag_autocomplete) {
+        api.registerHashtagSearchParam("category", "chat-composer", 100);
+        api.registerHashtagSearchParam("tag", "chat-composer", 50);
+      }
+
       // we want to decorate the chat quote dates regardless
       // of whether the current user has chat enabled
       api.decorateCookedElement(

--- a/test/javascripts/acceptance/composer-hashtag-autocomplete-test.js
+++ b/test/javascripts/acceptance/composer-hashtag-autocomplete-test.js
@@ -1,0 +1,68 @@
+import { setCaretPosition } from "discourse/lib/utilities";
+import {
+  acceptance,
+  exists,
+  query,
+  queryAll,
+} from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import { chatChannelPretender } from "../helpers/chat-pretenders";
+import { fillIn, settled, triggerKeyEvent, visit } from "@ember/test-helpers";
+
+acceptance(
+  "Discourse Chat - Composer hashtag autocompletion",
+  function (needs) {
+    needs.user({
+      admin: false,
+      moderator: false,
+      username: "eviltrout",
+      id: 100,
+      can_chat: true,
+      has_chat_enabled: true,
+    });
+    needs.pretender((server, helper) => {
+      chatChannelPretender(server, helper);
+      server.get("/chat/:id/messages.json", () =>
+        helper.response({ chat_messages: [], meta: {} })
+      );
+      server.post("/chat/drafts", () => helper.response(500, {}));
+      server.get("/hashtags/search.json", () => {
+        return helper.response({
+          results: [
+            { type: "category", text: "Design", slug: "design", ref: "design" },
+            { type: "tag", text: "dev", slug: "dev", ref: "dev" },
+            { type: "tag", text: "design", slug: "design", ref: "design::tag" },
+          ],
+        });
+      });
+    });
+    needs.settings({
+      chat_enabled: true,
+      enable_experimental_hashtag_autocomplete: true,
+    });
+
+    test("using # in the chat composer shows category and tag autocomplete options", async function (assert) {
+      await visit("/chat/channel/11/-");
+      const composerInput = query(".chat-composer-input");
+      await fillIn(".chat-composer-input", "abc #");
+      await triggerKeyEvent(".chat-composer-input", "keydown", "#");
+      await fillIn(".chat-composer-input", "abc #");
+      await setCaretPosition(composerInput, 5);
+      await triggerKeyEvent(".chat-composer-input", "keyup", "#");
+      await triggerKeyEvent(".chat-composer-input", "keydown", "D");
+      await fillIn(".chat-composer-input", "abc #d");
+      await setCaretPosition(composerInput, 6);
+      await triggerKeyEvent(".chat-composer-input", "keyup", "D");
+      await settled();
+      assert.ok(
+        exists(".hashtag-autocomplete"),
+        "hashtag autocomplete menu appears"
+      );
+      assert.strictEqual(
+        queryAll(".hashtag-autocomplete__option").length,
+        3,
+        "all options should be shown"
+      );
+    });
+  }
+);


### PR DESCRIPTION
Include context in the setupHashtagAutocomplete call, and use registerHashtagSearchParam to set up category + tag search for the chat composer. We cannot add channel search yet because we need to be able to look up channels by slugs first and also choose/render selected channels. More core work still to come.

c.f. https://github.com/discourse/discourse/pull/18592

**Do not merge until the core PR has merged!**