### PR TITLE
FIX: avoids blank screen on ios on sticky scroll

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -629,6 +629,11 @@ export default Component.extend({
     this.set("stickyScroll", true);
 
     if (this._scrollerEl) {
+      // iOS hack to avoid blank div when requesting section during momentum
+      if (this.capabilities.isIOS) {
+        this._scrollerEl.style.overflow = "hidden";
+      }
+
       // Trigger a tiny scrollTop change so Safari scrollbar is placed at bottom.
       // Setting to just 0 doesn't work (it's at 0 by default, so there is no change)
       // Very hacky, but no way to get around this Safari bug
@@ -637,6 +642,11 @@ export default Component.extend({
       window.requestAnimationFrame(() => {
         if (this._scrollerEl) {
           this._scrollerEl.scrollTop = 0;
+
+          // iOS hack to avoid blank div when requesting section during momentum
+          if (this.capabilities.isIOS) {
+            this._scrollerEl.style.overflow = "scroll";
+          }
         }
       });
     }

--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -629,7 +629,7 @@ export default Component.extend({
     this.set("stickyScroll", true);
 
     if (this._scrollerEl) {
-      // iOS hack to avoid blank div when requesting section during momentum
+      // iOS hack to avoid blank div when sticking scroll to bottom during momentum
       if (this.capabilities.isIOS) {
         this._scrollerEl.style.overflow = "hidden";
       }
@@ -643,7 +643,7 @@ export default Component.extend({
         if (this._scrollerEl) {
           this._scrollerEl.scrollTop = 0;
 
-          // iOS hack to avoid blank div when requesting section during momentum
+          // iOS hack to avoid blank div when sticking scroll to bottom during momentum
           if (this.capabilities.isIOS) {
             this._scrollerEl.style.overflow = "scroll";
           }


### PR DESCRIPTION
When scrolling the chat live pane on iOS, if the sticky scroll button is clicked during the scroll momentum , that would most likely result in a blank screen. This hack attempts to ensure it doesn’t happen.
