### PR TITLE
FIX: firefox uses relatedTarget for toElement/fromElement

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -1339,14 +1339,18 @@ export default Component.extend({
     if (event) {
       if (
         event.type === "mouseleave" &&
-        event.toElement?.closest(".chat-message-actions-desktop-anchor")
+        (event.toElement || event.relatedTarget)?.closest(
+          ".chat-message-actions-desktop-anchor"
+        )
       ) {
         return;
       }
 
       if (
         event.type === "mouseenter" &&
-        event.fromElement?.closest(".chat-message-actions-desktop-anchor")
+        (event.fromElement || event.relatedTarget)?.closest(
+          ".chat-message-actions-desktop-anchor"
+        )
       ) {
         this.set("hoveredMessageId", message?.id);
         return;


### PR DESCRIPTION
Before this fix, firefox couldn't compute the enter/leave logic and the msg actions menu would disappear when hovering it.
