### PR TITLE
FIX: prevents selected toned emoji to append t1

### DIFF
--- a/assets/javascripts/discourse/components/chat-emoji-picker.js
+++ b/assets/javascripts/discourse/components/chat-emoji-picker.js
@@ -280,8 +280,9 @@ export default class ChatEmojiPicker extends Component {
       const originalTarget = event.target;
       let emoji = event.target.dataset.emoji;
       const tonable = event.target.dataset.tonable;
-      if (tonable) {
-        emoji = `${emoji}:t${this.chatEmojiReactionStore.diversity}`;
+      const diversity = this.chatEmojiReactionStore.diversity;
+      if (tonable && diversity > 1) {
+        emoji = `${emoji}:t${diversity}`;
       }
 
       this.chatEmojiPickerManager.didSelectEmoji(emoji);

--- a/test/javascripts/components/chat-emoji-picker-test.js
+++ b/test/javascripts/components/chat-emoji-picker-test.js
@@ -33,6 +33,13 @@ function emojisResponse() {
         group: "people_&_body",
         search_aliases: [],
       },
+      {
+        name: "man_rowing_boat",
+        tonable: true,
+        url: "/images/emoji/twitter/man_rowing_boat.png?v=12",
+        group: "people_&_body",
+        search_aliases: [],
+      },
     ],
     objects: [
       {
@@ -49,6 +56,10 @@ function emojisResponse() {
 module("Discourse Chat | Component | chat-emoji-picker", function (hooks) {
   setupRenderingTest(hooks);
 
+  hooks.afterEach(function () {
+    this.emojiReactionStore.diversity = 1;
+  });
+
   hooks.beforeEach(function () {
     pretender.get("/chat/emojis.json", () => {
       return [200, {}, emojisResponse()];
@@ -58,6 +69,15 @@ module("Discourse Chat | Component | chat-emoji-picker", function (hooks) {
       "service:chat-emoji-picker-manager"
     );
     this.chatEmojiPickerManager.startFromComposer(() => {});
+    this.chatEmojiPickerManager.addVisibleSections([
+      "smileys_&_emotion",
+      "people_&_body",
+      "objects",
+    ]);
+
+    this.emojiReactionStore = this.container.lookup(
+      "service:chat-emoji-reaction-store"
+    );
   });
 
   test("When displaying navigation", async function (assert) {
@@ -144,6 +164,23 @@ module("Discourse Chat | Component | chat-emoji-picker", function (hooks) {
     await click('img.emoji[alt="grinning"]');
 
     assert.strictEqual(selection, "grinning");
+  });
+
+  test("When selecting a toned an emoji", async function (assert) {
+    let selection;
+    this.chatEmojiPickerManager.didSelectEmoji = (emoji) => {
+      selection = emoji;
+    };
+    await render(hbs`<ChatEmojiPicker />`);
+    this.emojiReactionStore.diversity = 1;
+    await click('img.emoji[alt="man_rowing_boat"]');
+
+    assert.strictEqual(selection, "man_rowing_boat");
+
+    this.emojiReactionStore.diversity = 2;
+    await click('img.emoji[alt="man_rowing_boat"]');
+
+    assert.strictEqual(selection, "man_rowing_boat:t2");
   });
 
   test("When opening the picker", async function (assert) {


### PR DESCRIPTION
Fitzpatrick scale should only be appended when scale is > 1. This will fix a bug generating invalid reactions URL when the scale was at 1.
