### PR TITLE
FIX: prevents shimmer effect to apply to sidebar

### DIFF
--- a/assets/stylesheets/common/chat-skeleton.scss
+++ b/assets/stylesheets/common/chat-skeleton.scss
@@ -110,6 +110,7 @@ $radius: 10px;
   }
 
   &.-animation {
+    position: relative;
     overflow: hidden;
 
     &::after {


### PR DESCRIPTION
It was particularly visible when switching channels