### PR TITLE
PEFF: hide msgactions on scroll

### DIFF
--- a/assets/javascripts/discourse/components/chat-live-pane.js
+++ b/assets/javascripts/discourse/components/chat-live-pane.js
@@ -662,6 +662,14 @@ export default Component.extend({
     if (this._selfDeleted) {
       return;
     }
+
+    const chatLivePane = document.querySelector(".chat-live-pane");
+    cancel(this._scrollClassTimer);
+    chatLivePane.classList.add("is-scrolling");
+    this._scrollClassTimer = discourseLater(() => {
+      chatLivePane.classList.remove("is-scrolling");
+    }, 150);
+
     resetIdle();
 
     const atTop =

--- a/assets/javascripts/discourse/components/chat-message-actions-desktop.js
+++ b/assets/javascripts/discourse/components/chat-message-actions-desktop.js
@@ -25,8 +25,11 @@ export default Component.extend({
         ),
         {
           placement: "right-start",
-          hide: { enabled: true },
           modifiers: [
+            {
+              name: "eventListeners",
+              options: { scroll: false },
+            },
             {
               name: "offset",
               options: {

--- a/assets/stylesheets/desktop/desktop.scss
+++ b/assets/stylesheets/desktop/desktop.scss
@@ -62,6 +62,12 @@
   }
 }
 
+.chat-live-pane.is-scrolling {
+  .chat-msgactions-hover {
+    visibility: hidden;
+  }
+}
+
 // Full Page Styling in Core
 .has-full-page-chat:not(.discourse-sidebar) {
   --max-chat-width: 1200px;


### PR DESCRIPTION
It prevents various issues like flickering and also perf issues as popper was constantly trying to reposition it. It's very add to test as discourseLater will be to 0 in tests and a result the class is already removed.
