### PR TITLE
FIX: clicking more in autocompletion should open picker

### DIFF
--- a/assets/javascripts/discourse/components/chat-composer.js
+++ b/assets/javascripts/discourse/components/chat-composer.js
@@ -316,8 +316,24 @@ export default Component.extend(TextareaTextManipulation, {
   },
 
   @bind
-  didSelectEmoji(emoji) {
-    this.addText(this.getSelected(), `:${emoji}:`);
+  didSelectEmoji(code) {
+    let selected = this.getSelected();
+    const captures = selected.pre.match(/\B:(\w*)$/);
+
+    if (isEmpty(captures)) {
+      if (selected.pre.match(/\S$/)) {
+        this.addText(selected, ` :${code}:`);
+      } else {
+        this.addText(selected, `:${code}:`);
+      }
+    } else {
+      let numOfRemovedChars = captures[1].length;
+      this._insertAt(
+        selected.start - numOfRemovedChars,
+        selected.end,
+        `${code}:`
+      );
+    }
   },
 
   @action
@@ -411,7 +427,10 @@ export default Component.extend(TextareaTextManipulation, {
           return `${v.code}:`;
         } else {
           $textarea.autocomplete({ cancel: true });
-          this.set("emojiPickerIsActive", true);
+          this.chatEmojiPickerManager.startFromComposer(
+            this.didSelectEmoji,
+            v.term
+          );
           return "";
         }
       },

--- a/assets/javascripts/discourse/services/chat-emoji-picker-manager.js
+++ b/assets/javascripts/discourse/services/chat-emoji-picker-manager.js
@@ -111,13 +111,13 @@ export default class ChatEmojiPickerManager extends Service {
     }
   }
 
-  startFromComposer(callback) {
+  startFromComposer(callback, term = "") {
     this.context = "chat-composer";
     this.element = document.querySelector(".chat-composer-emoji-picker-anchor");
-    this.open(callback);
+    this.open(callback, term);
   }
 
-  open(callback) {
+  open(callback, term = "") {
     if (this.opened) {
       this.closeExisting();
     }
@@ -126,6 +126,10 @@ export default class ChatEmojiPickerManager extends Service {
 
     this.callback = callback;
     this.opened = true;
+
+    schedule("afterRender", () => {
+      document.querySelector(".dc-filter-input").value = term;
+    })
   }
 
   _loadEmojisData() {


### PR DESCRIPTION
Note this commit also makes sure to:
- fill the emoji picker with the current value
- correctly replace the existing query when selecting an emoji
