### PR TITLE
FIX: default is now only used for custom emojis

### DIFF
--- a/app/controllers/emojis_controller.rb
+++ b/app/controllers/emojis_controller.rb
@@ -2,7 +2,7 @@
 
 class DiscourseChat::EmojisController < DiscourseChat::ChatBaseController
   def index
-    emojis = Emoji.all.group_by(&:group).except("default")
+    emojis = Emoji.all.group_by(&:group)
     render json: MultiJson.dump(emojis)
   end
 end


### PR DESCRIPTION
Following https://github.com/discourse/discourse/commit/a705e4815fac1cc74073848a8dfa3c7b441ead22 we don't need to exclude the default group anymore as it will now only contain custom emojis.
