### PR TITLE
DEV: Update scrolling test to work with css loaded

### DIFF
--- a/test/javascripts/acceptance/chat-live-pane-test.js
+++ b/test/javascripts/acceptance/chat-live-pane-test.js
@@ -151,7 +151,8 @@ acceptance(
       await visit("/chat/channel/1/cat");
 
       assert.notOk(exists(`.chat-message-container[data-id='${51}']`));
-      const scrollerEl = document.querySelector("#ember-testing-container");
+      const scrollerEl = document.querySelector(".chat-messages-scroll");
+      scrollerEl.scrollTop = -500; // Scroll up a bit
       const initialPosition = scrollerEl.scrollTop;
       await triggerEvent(".chat-messages-scroll", "scroll", {
         forceShowScrollToBottom: true,


### PR DESCRIPTION
When CSS is loaded, `.chat-messages-scroll` is correctly used as the scrolling element for chat messages. Its default position is the bottom, so we need to scroll up manually at the start of the test.

Preparation for https://github.com/discourse/discourse/pull/18668
