### PR TITLE
FIX: Remove hijack on webhook and improve documentation

### DIFF
--- a/app/controllers/incoming_chat_webhooks_controller.rb
+++ b/app/controllers/incoming_chat_webhooks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DiscourseChat::IncomingChatWebhooksController < ApplicationController
-  WEBHOOK_MAX_MESSAGE_LENGTH = 1000
+  WEBHOOK_MAX_MESSAGE_LENGTH = 2000
   WEBHOOK_MESSAGES_PER_MINUTE_LIMIT = 10
 
   skip_before_action :verify_authenticity_token, :redirect_to_login_if_required
@@ -11,7 +11,7 @@ class DiscourseChat::IncomingChatWebhooksController < ApplicationController
   def create_message
     debug_payload
 
-    hijack { process_webhook_payload(text: params[:text], key: params[:key]) }
+    process_webhook_payload(text: params[:text], key: params[:key])
   end
 
   # See https://api.slack.com/reference/messaging/payload for the
@@ -40,7 +40,7 @@ class DiscourseChat::IncomingChatWebhooksController < ApplicationController
       text = DiscourseChat::SlackCompatibility.process_legacy_attachments(attachments)
     end
 
-    hijack { process_webhook_payload(text: text, key: params[:key]) }
+    process_webhook_payload(text: text, key: params[:key])
   rescue JSON::ParserError
     raise Discourse::InvalidParameters
   end

--- a/assets/javascripts/discourse/templates/admin-plugins-chat.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-chat.hbs
@@ -143,6 +143,8 @@
     }}
   {{/if}}
 
+  <p>{{html-safe (i18n "chat.incoming_webhooks.instructions")}}</p>
+
   <div class="incoming-chat-webhooks">
     {{#if model.incoming_chat_webhooks}}
       {{#each sortedWebhooks as |webhook|}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -332,6 +332,7 @@ en:
         url_instructions: "This URL contains a secret value - keep it safe."
         username: "Username"
         username_instructions: "Username of bot that posts to channel. Defaults to 'system' when left blank."
+        instructions: "Incoming webhooks can be used by external systems to post messages into a designated chat channel as a bot user via the <code>/hooks/:key</code> endpoint. The payload consists of a single <code>text</code> parameter, which is limited to 2000 characters.<br><br>We also support limited Slack-formatted <code>text</code> parameters, extracting links and mentions based on the format at <a href=\"https://api.slack.com/reference/surfaces/formatting\">https://api.slack.com/reference/surfaces/formatting</a>, but the <code>/hooks/:key/slack</code> endpoint must be used for this."
 
       selection:
         cancel: "Cancel"

--- a/spec/requests/incoming_chat_webhooks_controller_spec.rb
+++ b/spec/requests/incoming_chat_webhooks_controller_spec.rb
@@ -19,8 +19,13 @@ RSpec.describe DiscourseChat::IncomingChatWebhooksController do
       expect(response.status).to eq(400)
     end
 
-    it "errors when the body is over 1000 characters" do
-      post "/chat/hooks/#{webhook.key}.json", params: { text: "$" * 1001 }
+    it "errors when the body is over WEBHOOK_MAX_MESSAGE_LENGTH characters" do
+      post "/chat/hooks/#{webhook.key}.json",
+           params: {
+             text:
+               "$" *
+                 (DiscourseChat::IncomingChatWebhooksController::WEBHOOK_MAX_MESSAGE_LENGTH + 1),
+           }
       expect(response.status).to eq(400)
     end
 


### PR DESCRIPTION
This commit removes the `hijack` on the chat webhooks controller since it is of dubious necessity and because `hijack` is suppressing the correct resposne codes.

Also add some documentation around how the incoming webhooks work, their params, and their limits.

Bump the incoming text param length limit to 2000, 1000 is quite low.