### PR TITLE
FIX: Don't fail when trying to display DM flags in the review queue.

### DIFF
--- a/app/serializers/chat_message_serializer.rb
+++ b/app/serializers/chat_message_serializer.rb
@@ -130,11 +130,10 @@ class ChatMessageSerializer < ApplicationSerializer
     return [] if !scope.can_flag_chat_message?(object)
     return [] if reviewable_id.present? && user_flag_status == ReviewableScore.statuses[:pending]
 
+    channel = @options.dig(:chat_channel) || object.chat_channel
+
     PostActionType.flag_types.map do |sym, id|
-      if @options[:chat_channel].direct_message_channel? &&
-           %i[notify_moderators notify_user].include?(sym)
-        next
-      end
+      next if channel.direct_message_channel? && %i[notify_moderators notify_user].include?(sym)
 
       if sym == :notify_user &&
            (

--- a/app/serializers/reviewable_chat_message_serializer.rb
+++ b/app/serializers/reviewable_chat_message_serializer.rb
@@ -3,16 +3,17 @@
 require_dependency "reviewable_serializer"
 
 class ReviewableChatMessageSerializer < ReviewableSerializer
-  has_one :chat_message, serializer: ChatMessageSerializer, root: false, embed: :objects
-  has_one :chat_channel, serializer: ChatChannelSerializer, root: false, embed: :objects
-
+  target_attributes :cooked
   payload_attributes :transcript_topic_id, :message_cooked
+  attributes :target_id
+
+  has_one :chat_channel, serializer: ChatChannelSerializer, root: false, embed: :objects
 
   def chat_channel
     object.chat_message.chat_channel
   end
 
-  def chat_message
-    object.chat_message
+  def target_id
+    object.target&.id
   end
 end

--- a/assets/javascripts/discourse/templates/components/reviewable-chat-message.hbs
+++ b/assets/javascripts/discourse/templates/components/reviewable-chat-message.hbs
@@ -3,23 +3,23 @@
     "chat.channel"
     reviewable.chat_channel.id
     reviewable.chat_channel.title
-    (query-params messageId=reviewable.chat_message.id)
+    (query-params messageId=reviewable.target_id)
   }}
     {{chat-channel-title channel=reviewable.chat_channel}}
   {{/link-to}}
 </div>
 
 <div class="post-contents-wrapper">
-  {{reviewable-created-by user=reviewable.chat_message.user tagName=""}}
+  {{reviewable-created-by user=reviewable.target_created_by tagName=""}}
   <div class="post-contents">
     {{reviewable-post-header
       reviewable=reviewable
-      createdBy=reviewable.chat_message.user
+      createdBy=reviewable.target_created_by
       tagName=""
     }}
 
     <div class="post-body">
-      {{html-safe (or reviewable.payload.message_cooked reviewable.chat_message.cooked)}}
+      {{html-safe (or reviewable.payload.message_cooked reviewable.cooked)}}
     </div>
 
     {{#if this.reviewable.payload.transcript_topic_id}}

--- a/spec/serializer/chat_message_serializer_spec.rb
+++ b/spec/serializer/chat_message_serializer_spec.rb
@@ -198,6 +198,12 @@ describe ChatMessageSerializer do
 
         expect(serialized[:available_flags]).to include(:spam)
       end
+
+      it "fallbacks to the object association when the chat_channel option is nil" do
+        serialized = described_class.new(dm_message, options.except(:chat_channel)).as_json
+
+        expect(serialized[:available_flags]).not_to include(:notify_moderators)
+      end
     end
   end
 end


### PR DESCRIPTION
The serializer tried to serialize the whole message, but this needed the channel passed in the options hash to work. I wrote the code this way to avoid fetching each message chat channel when serializing in the context of the `ChatView`.

This change simplifies the reviewable chat message serializer and fallbacks to the object's `chat_channel` when `@options[:chat_channel]` is `nil`.
