### PR TITLE
FIX: prevents exception when transcripting multiple messages

### DIFF
--- a/assets/javascripts/discourse/initializers/chat-decorators.js
+++ b/assets/javascripts/discourse/initializers/chat-decorators.js
@@ -93,9 +93,14 @@ export default {
           ".chat-transcript-datetime a"
         );
 
-        // same as highlight, no need to do this for every single message every time
-        // any message changes
+        // we only show date for first message
+        if (!dateTimeLinkEl) {
+          return;
+        }
+
         if (dateTimeLinkEl.innerText !== "") {
+          // same as highlight, no need to do this for every single message every time
+          // any message changes
           return;
         }
 


### PR DESCRIPTION
Only the first message would get the date element and following `dateTimeLinkEl` would be undefined, resulting in an error when trying to assign `innerText`.
