### PR TITLE
FIX: Move reaction emoji name from class to data attribute

### DIFF
--- a/assets/javascripts/discourse/templates/components/chat-message-reaction.hbs
+++ b/assets/javascripts/discourse/templates/components/chat-message-reaction.hbs
@@ -7,10 +7,10 @@
     class={{concat-class
       this.class
       "chat-message-reaction"
-      this.reaction.emoji
       (if this.reaction.reacted "reacted")
       (if this.reaction.count "show")
     }}
+    data-emoji-name={{this.reaction.emoji}}
     title={{this.emojiString}}
   >
     <img

--- a/test/javascripts/acceptance/chat-live-pane-test.js
+++ b/test/javascripts/acceptance/chat-live-pane-test.js
@@ -130,9 +130,7 @@ acceptance(
         chat_message_id: 1,
       });
 
-      assert.ok(
-        exists(`.chat-message-reaction.reacted[data-emoji-name="cat"]`)
-      );
+      assert.ok(exists(`.chat-message-reaction[data-emoji-name="cat"]`));
     });
 
     test("Sending a new message when there are still unloaded ones will fetch them", async function (assert) {

--- a/test/javascripts/acceptance/chat-live-pane-test.js
+++ b/test/javascripts/acceptance/chat-live-pane-test.js
@@ -130,7 +130,9 @@ acceptance(
         chat_message_id: 1,
       });
 
-      assert.ok(exists(".chat-message-reaction.cat"));
+      assert.ok(
+        exists(`.chat-message-reaction.reacted[data-emoji-name="cat"]`)
+      );
     });
 
     test("Sending a new message when there are still unloaded ones will fetch them", async function (assert) {

--- a/test/javascripts/acceptance/chat-message-test.js
+++ b/test/javascripts/acceptance/chat-message-test.js
@@ -34,7 +34,7 @@ acceptance("Discourse Chat - Chat Message", function (needs) {
 
     await visit("/chat/channel/4/public-category");
     await click(
-      `.chat-message-container[data-id="176"] .chat-message-reaction.heart`
+      `.chat-message-container[data-id="176"] .chat-message-reaction[data-emoji-name="heart"]`
     );
 
     assert.deepEqual(
@@ -44,7 +44,7 @@ acceptance("Discourse Chat - Chat Message", function (needs) {
     );
 
     await click(
-      `.chat-message-container[data-id="176"] .chat-message-reaction.heart`
+      `.chat-message-container[data-id="176"] .chat-message-reaction[data-emoji-name="heart"]`
     );
 
     assert.deepEqual(
@@ -73,7 +73,7 @@ acceptance("Discourse Chat - Chat Message", function (needs) {
     );
 
     await click(
-      `.chat-message-container[data-id="176"] .chat-message-reaction.grinning`
+      `.chat-message-container[data-id="176"] .chat-message-reaction[data-emoji-name="grinning"]`
     );
 
     assert.deepEqual(

--- a/test/javascripts/acceptance/chat-test.js
+++ b/test/javascripts/acceptance/chat-test.js
@@ -768,7 +768,7 @@ Widget.triangulate(arg: "test")
 
     // React with a heart and make sure the count increments and class is added
     const heartReaction = lastMessage.querySelector(
-      ".chat-message-reaction.heart"
+      `.chat-message-reaction[data-emoji-name="heart"]`
     );
     assert.equal(heartReaction.innerText.trim(), "1");
     await click(heartReaction);
@@ -797,7 +797,7 @@ Widget.triangulate(arg: "test")
       chat_message_id: 176,
     });
     const sneezingFaceReaction = lastMessage.querySelector(
-      ".chat-message-reaction.sneezing_face"
+      `.chat-message-reaction[data-emoji-name="sneezing_face"]`
     );
     assert.ok(sneezingFaceReaction);
     assert.equal(sneezingFaceReaction.innerText.trim(), "1");
@@ -836,7 +836,7 @@ Widget.triangulate(arg: "test")
     await click(`.emoji[alt="grinning"]`);
 
     const reaction = lastMessage.querySelector(
-      ".chat-message-reaction.grinning.reacted"
+      `.chat-message-reaction.reacted[data-emoji-name="grinning"]`
     );
 
     await publishToMessageBus("/chat/11", {
@@ -849,7 +849,9 @@ Widget.triangulate(arg: "test")
     await click(reaction);
 
     assert.notOk(
-      lastMessage.querySelector(".chat-message-reaction.grinning.reacted")
+      lastMessage.querySelector(
+        `.chat-message-reaction.reacted[data-emoji-name="grinning"]`
+      )
     );
   });
 

--- a/test/javascripts/components/chat-message-reaction-test.js
+++ b/test/javascripts/components/chat-message-reaction-test.js
@@ -29,7 +29,7 @@ module("Discourse Chat | Component | chat-message-reaction", function (hooks) {
     template: hbs`{{chat-message-reaction reaction=(hash emoji="heart")}}`,
 
     async test(assert) {
-      assert.ok(exists(".chat-message-reaction.heart"));
+      assert.ok(exists(`.chat-message-reaction[data-emoji-name="heart"]`));
     },
   });
 


### PR DESCRIPTION
Using it as a class can cause unexpected clashes with 'real' CSS classes. Using a data attribute is safer, and can still be targetted by CSS if desired.
