### PR TITLE
FIX: Channel index mobile issues

### DIFF
--- a/assets/stylesheets/common/chat-browse.scss
+++ b/assets/stylesheets/common/chat-browse.scss
@@ -26,10 +26,6 @@
     @include breakpoint(tablet) {
       margin-top: 1rem;
     }
-
-    @include breakpoint(mobile-large) {
-      margin-right: 1rem; //fix for different scroll behaviour on mobile where overflow-y:scroll acts like auto
-    }
   }
 
   &__cards {
@@ -60,10 +56,6 @@
       nav {
         width: 100%;
       }
-    }
-
-    @include breakpoint(mobile-large) {
-      margin-right: 1rem; //fix for different scroll behaviour on mobile where overflow-y:scroll acts like auto
     }
   }
 

--- a/assets/stylesheets/common/chat-browse.scss
+++ b/assets/stylesheets/common/chat-browse.scss
@@ -4,15 +4,15 @@
   overflow-y: scroll;
   @include chat-scrollbar(var(--secondary));
 
+  @include breakpoint(mobile-large) {
+    padding-right: 1rem; //fix for different scroll behaviour on mobile where overflow-y:scroll acts like auto
+  }
+
   &__header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin: 0 0 0 1rem;
-
-    @include breakpoint(mobile-large) {
-      margin-right: 1rem; //fix for different scroll behaviour on mobile where overflow-y:scroll acts like auto
-    }
+    margin: 1rem 0 1rem 1rem;
   }
 
   &__title {

--- a/assets/stylesheets/common/chat-browse.scss
+++ b/assets/stylesheets/common/chat-browse.scss
@@ -8,11 +8,15 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    margin: 0 0 0 1rem;
+
+    @include breakpoint(mobile-large) {
+      margin-right: 1rem; //fix for different scroll behaviour on mobile where overflow-y:scroll acts like auto
+    }
   }
 
   &__title {
     box-sizing: border-box;
-    margin: 1rem;
   }
 
   &__content_wrapper {
@@ -21,6 +25,10 @@
 
     @include breakpoint(tablet) {
       margin-top: 1rem;
+    }
+
+    @include breakpoint(mobile-large) {
+      margin-right: 1rem; //fix for different scroll behaviour on mobile where overflow-y:scroll acts like auto
     }
   }
 
@@ -52,6 +60,10 @@
       nav {
         width: 100%;
       }
+    }
+
+    @include breakpoint(mobile-large) {
+      margin-right: 1rem; //fix for different scroll behaviour on mobile where overflow-y:scroll acts like auto
     }
   }
 

--- a/assets/stylesheets/common/chat-browse.scss
+++ b/assets/stylesheets/common/chat-browse.scss
@@ -98,6 +98,7 @@
 
   .chat-channel-card {
     .chat-channel-card__leave-btn {
+      padding: 0;
       &:hover,
       &:focus {
         background: none;

--- a/assets/stylesheets/common/dc-filter-input.scss
+++ b/assets/stylesheets/common/dc-filter-input.scss
@@ -11,6 +11,7 @@
 
   .dc-filter-input,
   .dc-filter-input:focus {
+    width: 100%;
     margin: 0;
     border: none;
     outline: none;


### PR DESCRIPTION
<!-- Checklist for UI / stylesheet changes, delete if not applicable -->

- [x] chat-scoped -- core unaffected

### View mode

- [ ] docked (windowed/drawer)

### Browsers

- [ ] safari
- [ ] chrome
- [ ] firefox

### Device

- [ ] desktop – wide screen
- [x] mobile – `?mobile_view=1`

Before: stuck to sides + placeholder gets cutoff
<img width="414" alt="image" src="https://user-images.githubusercontent.com/101828855/198577772-a48fca2c-e659-4072-99e7-f5d6891925dc.png">

After:
<img width="414" alt="image" src="https://user-images.githubusercontent.com/101828855/198578137-c9771489-2363-4b5d-8437-b371d9628c06.png">


